### PR TITLE
added CoinEntity's image reference and spritewidth properties to it's init function

### DIFF
--- a/web/tutorial/index.html
+++ b/web/tutorial/index.html
@@ -686,9 +686,13 @@ var g_resources = [
  a Coin entity
 ------------------------ */
 var CoinEntity = me.CollectableEntity.extend({
-    // extending the init function is not mandatory
+    // extending the init function is not mandatory by the way
     // unless you need to add some extra initialization
     init: function(x, y, settings) {
+        // define this here instead of tiled
+        settings.image = "spinning_coin_gold";
+        settings.spritewidth = 32;
+
         // call the parent constructor
         this.parent(x, y, settings);
     },


### PR DESCRIPTION
Hi!

First of all, thanks for the great game engine! I'm trying out the tutorial now and I came across a bug. The spritewidth and image reference of CoinEntity were missing in CoinEntity's init. That caused a JavaScript error and the game didn't work. I fixed it hereby.

Keep up the good work!

frank
