### PR TITLE
Add me.debug.renderCollisionMap setting.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -58,6 +58,7 @@ var me = me || {};
 		 * @memberOf me.debug 
 		 */
 		displayFPS : false,
+
 		/**
 		 * render object Rectangle & Collision Box<br>
 		 * default value : false
@@ -65,6 +66,14 @@ var me = me || {};
 		 * @memberOf me.debug 
 		 */
 		renderHitBox : false,
+
+		/**
+		 * render Collision Map layer<br>
+		 * default value : false
+		 * @type {Boolean}
+		 * @memberOf me.debug
+		 */
+		renderCollisionMap : false,
 
 		/**
 		 * render dirty region/rectangle<br>

--- a/src/level/TMXLayer.js
+++ b/src/level/TMXLayer.js
@@ -495,7 +495,7 @@
 
 			// detect if the layer is a collision map
 			this.isCollisionMap = (this.name.toLowerCase().contains(me.LevelConstants.COLLISION_MAP));
-			if (this.isCollisionMap) {
+			if (this.isCollisionMap && !me.debug.renderCollisionMap) {
 				// force the layer as invisible
 				this.visible = false;
 			}


### PR DESCRIPTION
This setting will disable the automatic "invisible" flag when a collision map is created. Used as a debug aid with me.debug.renderHitBox
