### PR TITLE
Fix strange behavior case in me.input with Shift key

### DIFF
--- a/src/input/input.js
+++ b/src/input/input.js
@@ -25,15 +25,15 @@
 		  ---------------------------------------------*/
 
 		// list of binded keys
-		var KeyBinding = [];
+		var KeyBinding = {};
 
 		// corresponding actions
-		var keyStatus = [];
+		var keyStatus = {};
 
 		// lock enable flag for keys
-		var keyLock = [];
+		var keyLock = {};
 		// actual lock status of each key
-		var keyLocked = [];
+		var keyLocked = {};
 
 		// some usefull flags
 		var keyboardInitialized = false;
@@ -486,6 +486,7 @@
 
 			KeyBinding[keycode] = action;
 
+			keyStatus[action] = false;
 			keyLock[action] = lock ? lock : false;
 			keyLocked[action] = false;
 		};


### PR DESCRIPTION
- The example code below would return a reference to Array.prototype.shift()
  until Shift is pressed and released for the first time. The shift function
  evaluates true, making the statement execute as a false-positive.

me.input.bindKey(me.input.KEY.SHIFT, "shift");
if (!me.input.keyStatus("shift")) ...
- Also it was not possible to bind a key named "length".
