### PR TITLE
Add animation pause to me.AnimationSheet; closes issue #60

### DIFF
--- a/src/entity/entity.js
+++ b/src/entity/entity.js
@@ -518,6 +518,15 @@
 				fpscount : 0,
 
 				/**
+				 * pause and resume animation<br>
+				 * default value : false;
+				 * @public
+				 * @type Boolean
+				 * @name me.AnimationSheet#animationpause
+				 */
+				animationpause : false,
+
+				/**
 				 * animation cycling speed<br>
 				 * default value : me.sys.fps / 10;
 				 * @public
@@ -646,7 +655,7 @@
 					// call the parent function
 					this.parent();
 					// update animation if necessary
-					if (this.visible && (this.fpscount++ > this.animationspeed)) {
+					if (this.visible && !this.animationpause && (this.fpscount++ > this.animationspeed)) {
 						this.setAnimationFrame(++this.current.idx);
 						this.fpscount = 0;
 						


### PR DESCRIPTION
Hi Olivier, this is a patch for issue #60. It adds a boolean flag to pause the animation. I'm using it for the blinking eyes class in my game with excellent results. Here it is, as a use case example: https://bitbucket.org/parasyte/lpcgame/src/e3dbfc527f9b/js/objects.js#cl-261
