### PR TITLE
Fix a bug in `background_color` map property.

### DIFF
--- a/src/level/TMXLayer.js
+++ b/src/level/TMXLayer.js
@@ -20,7 +20,7 @@
 		// constructor
 		init: function(name, color, z) {
 			this.name = name;
-			this.color = me.utils.HexToRGB(color);
+			this.color = color;
 			// for displaying order
 			this.z = z;
 			


### PR DESCRIPTION
- It looks like there is some broken color conversion happening. Canvas already supports #hex notation colors. Canvas supports all CSS color values.
