### PR TITLE
Fix me.Font `align` argument.

### DIFF
--- a/src/font/font.js
+++ b/src/font/font.js
@@ -95,7 +95,7 @@
 			// draw the text
 			context.font = this.font;
 			context.fillStyle = this.color;
-			context.textBaseLine = this.align;
+			context.textBaseline = this.align;
 			var dim = context.measureText(text);
 			dim.height = this.height;
 
@@ -113,7 +113,7 @@
 			// draw the text
 			context.font = this.font;
 			context.fillStyle = this.color;
-			context.textBaseLine = this.align;
+			context.textBaseline = this.align;
 			context.fillText(text, ~~x, ~~y);
 		}
 	});

--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -22,8 +22,8 @@
 		init : function() {
 			this.parent(true);
 			// melonJS logo
-			this.logo1 = new me.Font('century gothic', 32, 'white');
-			this.logo2 = new me.Font('century gothic', 32, '#89b002');
+			this.logo1 = new me.Font('century gothic', 32, 'white', 'bottom');
+			this.logo2 = new me.Font('century gothic', 32, '#89b002', 'bottom');
 			this.logo2.bold();
 
 			// flag to know if we need to refresh the display
@@ -79,12 +79,10 @@
 			// draw the melonJS logo
 			this.logo1.draw(context, 'melon',
 					((context.canvas.width - logo_width) / 2),
-					(context.canvas.height + 60) / 2);
+					(context.canvas.height / 2));
 			this.logo2.draw(context, 'JS',
 					((context.canvas.width - logo_width) / 2) + logo1_width,
-					(context.canvas.height + 60) / 2);
-			// add the height of the logo
-			y += 40;
+					(context.canvas.height / 2));
 
 			// display a progressive loading bar
 			var width = Math.floor(this.loadPercent * context.canvas.width);


### PR DESCRIPTION
- The context.textBaseline attribute is case-sensitive.
- Also update me.DefaultLoadingScreen to use the baseline.
