### PR TITLE
Fix render position of flipped TMX tiles.

### DIFF
--- a/src/level/TMXTileset.js
+++ b/src/level/TMXTileset.js
@@ -306,12 +306,14 @@
 		drawTile : function(context, dx, dy, tmxTile) {
 			// check if any transformation is required
 			if (tmxTile.flipped) {
+				var map_pos = me.game.currentLevel.pos;
+				var viewport_pos = me.game.viewport.pos;
 				var m11 = 1; // Horizontal scaling factor
 				var m12 = 0; // Vertical shearing factor
 				var m21 = 0; // Horizontal shearing factor
 				var m22 = 1; // Vertical scaling factor
-				var mx	= dx; 
-				var my	= dy;
+				var mx	= dx + map_pos.x - viewport_pos.x;
+				var my	= dy + map_pos.y - viewport_pos.y;
 				// set initial value to zero since we use a transform matrix
 				dx = dy = 0;
 				


### PR DESCRIPTION
This patch does two things:
1. Offsets the transformation matrix by the current level position, fixing flipped tiles on maps that are smaller than the screen resolution.
2. Offsets the transformation matrix again by the viewport position, fixing flipped tiles on maps that are larger than the screen resolution and scrolled.
