### PR TITLE
Publish on keydown and keyup events

### DIFF
--- a/src/input/input.js
+++ b/src/input/input.js
@@ -118,6 +118,9 @@
 					keyStatus[action] = true;
 					// lock the key if requested
 					keyLocked[action] = keyLock[action];
+
+					// publish a message for keydown event
+					me.event.publish(me.event.KEYDOWN, [ action ]);
 				}
 				// prevent event propagation
 				preventDefault(e);
@@ -139,6 +142,10 @@
 
 				keyStatus[action] = false;
 				keyLocked[action] = false;
+
+				// publish message for keyup event
+				me.event.publish(me.event.KEYUP, [ action ]);
+
 				// prevent the event propagation
 				preventDefault(e);
 				return false;

--- a/src/vendors/minpubsub.src.js
+++ b/src/vendors/minpubsub.src.js
@@ -83,8 +83,26 @@
 		 * @name me.event#LOADER_PROGRESS
 		 */
 		obj.LOADER_PROGRESS = "me.loader.onProgress";
-		
-		
+
+		/**
+		 * Channel Constant for pressing a binded key <br>
+		 * Data passed : {String} user-defined action <br>
+		 * @public
+		 * @type {String}
+		 * @name me.event#KEYDOWN
+		 */
+		obj.KEYDOWN = "me.input.keydown";
+
+		/**
+		 * Channel Constant for releasing a binded key <br>
+		 * Data passed : {Number} user-defined action <br>
+		 * @public
+		 * @type {String}
+		 * @name me.event#KEYUP
+		 */
+		obj.KEYUP = "me.input.keyup";
+
+
 		/**
 		 * Publish some data on a channel
 		 * @name me.event#publish


### PR DESCRIPTION
For background, this feature will help with asynchronously handling key events. Especially in the case where the user wants to resume a paused game with a key: https://groups.google.com/forum/?fromgroups=#!topic/melonjs/7LnZpwdtWFM

The "current" solution available is creating an interval that will periodically poll the key to determine when it's time to resume gameplay. This patch allows us to be kind to battery life:

``` JavaScript
if (me.input.isKeyPressed("pause")) {
    me.state.pause();

    var resume_event = me.event.subscribe(me.event.KEYDOWN, function check_resume(action) {
        if (me.input.isKeyPressed("pause")) {
            me.event.unsubscribe(resume_event);
            me.state.resume();
        }
    });
}
```

General use patterns for these callbacks is:
- Use `me.input.isKeyPressed(...)` inside the callback if the key was binded with the `lock` parameter set to `true`.
- Else use `if (action == ...)`

Maybe this should be documented somehow?
