### PR TITLE
Changes to me.Font.set()

### DIFF
--- a/src/font/font.js
+++ b/src/font/font.js
@@ -65,9 +65,12 @@
 		/**
 		 * Change the font settings
 		 * @param {String} font
-		 * @param {int} size
+		 * @param {int} size/{String} size + suffix (px, em, pt)
 		 * @param {String} color
 		 * @param {String} [align="top"]
+		 * @example
+		 * font.set("Arial", 20, "white");
+		 * font.set("Arial", "1.5em", "white");
 		 */
 		set : function(font, size, color, align) {
 			// font name and type


### PR DESCRIPTION
Adjusted the set function to allow an integer or string for the font. String requires the font suffix of px/em/pt. 

The font name also allows fallback fonts, via comma separated like in CSS

```
"Arial"
"Helvetica,Arial,sans-serif"
```
