### PR TITLE
Fix for issue #149, TileMap.getObjectGroupByName(name)

### DIFF
--- a/src/level/TMXTiledMap.js
+++ b/src/level/TMXTiledMap.js
@@ -113,7 +113,18 @@
 		 * @private	
 		 */
 		getObjectGroupByName : function(name) {
-			return this.objectGroups[name];
+			var objectGroup = null;
+
+            		// normalize name
+            		name = name.trim().toLowerCase();
+            		for ( var i = this.objectGroups.length; i--;) {
+                		if (this.objectGroups[i].name.toLowerCase().contains(name)) {
+                    			objectGroup = this.objectGroups[i];
+                    			break;
+                		}
+            		};
+
+			return objectGroup;
 		},
 
 		/**


### PR DESCRIPTION
Instead of trying to index the objectGroups array directly, it now loops through searching for an objectGroup with an matching name. 

(seems like the commit has gone a little wild. Probably a whitespace issue or something. Strange, cause I used the online editor here on github. Anyway - the only real change is in the getObjectGroupByName( ) method.)
