### PR TITLE
Update to bitmap font to honor newlines

### DIFF
--- a/src/font/font.js
+++ b/src/font/font.js
@@ -241,8 +241,13 @@
 		 * @param {int} y
 		 */
 		draw : function(context, text, x, y) {
+            
+            // Keep starting x pos
+			startx = x;
 			// make sure it's a String object
-			text = new String(text);
+            text = new String(text);
+            // process non JavaScript newlines
+            text = text.replace(/\\n/g, "\n")
 
 			// adjust pos based on alignment
 			switch(this.textAlign) {
@@ -260,13 +265,20 @@
 				// calculate the char index
 				var idx = text.charCodeAt(i) - this.firstChar;
 				// draw it
-				context.drawImage(this.font,
+				if (idx == (10- this.firstChar)) {
+				    y += this.sSize.y + ~~(this.size.y / 2) ;
+                    x = startx;
+                }
+                else
+                {
+                context.drawImage(this.font,
 						this.size.x * (idx % this.charCount), 
 						this.size.y * ~~(idx / this.charCount), 
 						this.size.x, this.size.y, 
 						~~x, ~~y, 
 						this.sSize.x, this.sSize.y);
 				x += this.sSize.x;
+                }
 			}
 
 		}


### PR DESCRIPTION
I'm building some GUI objects and I needed line wrapping, I didn't think extending was the way to go for this 

If the string passed to the bitmap font engine has a \n it will start a new line art 125% of the font height. Combine this with a wordwrap function and you have nice paragraph text

Shouldn't affect anyone currently using bitmapFont, but MeasureText() will need to be rewritten to return the correct size in the future.
