### PR TITLE
Fix a problem when spacing and margin and not define

### DIFF
--- a/src/entity/sprite.js
+++ b/src/entity/sprite.js
@@ -131,8 +131,8 @@
 						spriteheight || image.height);
 						
 			// Spacing and margin in spritesheet
-			this.spacing = spacing;
-			this.margin = margin;
+			this.spacing = spacing || 0;
+			this.margin = margin || 0;
 
 			// cache image reference
 			this.image = image;


### PR DESCRIPTION
Since the last version, my sprite animation didn't work because I didn't specify the margin and spacing value. Instead of having "0" it has "undefined" and that blow up all my code and animation didn't work.

I just fixed the problem by adding a "0" value when undefined is set and now my player animation is working again.
