### PR TITLE
Update Makefile to work on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@
 # 
 #######################################################################
 
+# Fix MAKE for Windows Problem
+ifdef SystemRoot
+  SHELL=C:/Windows/System32/cmd.exe
+endif
+
 # GOOGLE CLOSURE COMPILER
 GCC_VERSION = 20130227
 GCC_PATH = tools/closure-compiler/


### PR DESCRIPTION
Makefile doesn't work on Windows when using GNU make command line utility.
The error is a known bug qnd here is the workaround.
