### PR TITLE
Fix access to inherited properties

### DIFF
--- a/src/level/TMXUtils.js
+++ b/src/level/TMXUtils.js
@@ -60,19 +60,21 @@
 			var properties = data[me.TMX_TAG_PROPERTIES];
 			if (properties) {
 				for(var name in properties){
-					var value = properties[name];
-					
-					// if value not defined or boolean
-					if (!value || value.isBoolean()) {
-						value = value ? (value == "true") : true;
-					}
-					// check if numeric
-					else if (value.isNumeric()) {
-						value = Number(value);
-					}
-					// add the new prop to the object prop list
-					obj[name] = value;
-				}
+                    if (properties.hasOwnProperty(name)) {
+                        var value = properties[name];
+
+                        // if value not defined or boolean
+                        if (!value || value.isBoolean()) {
+                            value = value ? (value == "true") : true;
+                        }
+                        // check if numeric
+                        else if (value.isNumeric()) {
+                            value = Number(value);
+                        }
+                        // add the new prop to the object prop list
+                        obj[name] = value;
+                    }
+                }
 			}
 		};
 		


### PR DESCRIPTION
When loading a JSON level melonJS crashes with the following error:

```
 Uncaught TypeError: Object function () {
   var newObj = (this instanceof Array) ? [] : {};
   for (i in this) {
     if (i == 'clone') continue;
     if (this[i] && typeof this[i] == "object") {
       newObj[i] = this[i].clone();
     } else newObj[i] = this[i]
   } return newObj;
 } has no method 'isBoolean' melonJS.js:9848
 me.TMXUtils.api.applyTMXPropertiesFromJSON melonJS.js:9848
 me.TMXMapReader.extend.readJSONMap melonJS.js:12230
 me.TMXMapReader.Object.extend.readMap melonJS.js:11819
 me.levelDirector.obj.loadLevel melonJS.js:12483
 me.ScreenObject.extend.onResetEvent playscreen.js:10
 me.ScreenObject.me.Renderable.extend.reset melonJS.js:5073
 _switchState melonJS.js:5344
 Function.defer melonJS.js:554 
```

Solved the bug by cheking if property is inherited.
