### PR TITLE
Explicitly attach me to the window object

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -13,7 +13,7 @@
  * You generally should not add new properties to this namespace as it may be overwritten in future versions.
  * @namespace
  */
-var me = me || {};
+window.me = window.me || {};
 
 (function($) {
 	// Use the correct document accordingly to window argument


### PR DESCRIPTION
In some settings (e.g. Meteor), a top-level var statement does not automatically become a global variable. I think it would be better to be explicit about this.
