### PR TITLE
set binary load to async, and removed the usage of dataType

### DIFF
--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -195,7 +195,7 @@
 			var httpReq = new XMLHttpRequest();
 
 			// load our file
-			httpReq.open("GET", data.src + obj.nocache, false);
+			httpReq.open("GET", data.src + obj.nocache, true);
 			httpReq.responseType = "arraybuffer";
 			httpReq.onerror = onerror;
 			httpReq.onload = function(event){
@@ -203,11 +203,10 @@
 				if (arrayBuffer) {
 					var byteArray = new Uint8Array(arrayBuffer);
 					var buffer = [];
-					binList[data.name] = new dataType();
 					for (var i = 0; i < byteArray.byteLength; i++) { 
 						buffer[i] = String.fromCharCode(byteArray[i]);
 					}
-					binList[data.name].data = buffer.join("");
+					binList[data.name] = buffer.join("");
 					// callback
 					onload();
 				}


### PR DESCRIPTION
Discussed previously in the mailing list the issue here. Jason noted the request was oddly set to synchronous, so I changed that, allowing the response type to be changed.  I also removed the usage of datatype since that could not be resolved. Works with the current test implementation of melonjs-spine repo. 

Please review, and let's discuss if this works. My main concern is the change to dataType, as I wonder what that resolved to before.
