### PR TITLE
Modified me.loader.onProgress's arguments

### DIFF
--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -258,7 +258,7 @@
 		 * @ignore
 		 */
 
-		obj.onResourceLoaded = function(e) {
+		obj.onResourceLoaded = function(res) {
 
 			// increment the loading counter
 			loadCount++;
@@ -267,9 +267,9 @@
 			var progress = obj.getLoadProgress();
 			if (obj.onProgress) {
 				// pass the load progress in percent, as parameter
-				obj.onProgress(progress);
+				obj.onProgress(progress, res);
 			}
-			me.event.publish(me.event.LOADER_PROGRESS, [progress]);
+			me.event.publish(me.event.LOADER_PROGRESS, [progress, res]);
 		};
 		
 		/**
@@ -332,7 +332,7 @@
 		obj.preload = function(res) {
 			// parse the resources
 			for ( var i = 0; i < res.length; i++) {
-				resourceCount += obj.load(res[i], obj.onResourceLoaded.bind(obj), obj.onLoadingError.bind(obj, res[i]));
+				resourceCount += obj.load(res[i], obj.onResourceLoaded.bind(obj, res[i]), obj.onLoadingError.bind(obj, res[i]));
 			}
 			// check load status
 			checkLoadStatus();


### PR DESCRIPTION
me.loader.onProgress is now informed of which resource was loaded, just like me.loader.onError knows which one failed to be loaded.

I'm still not sure if there is any contribution convention (commit message, codestyle), so please feel free to criticize.

Also, I'm unsure wether I should also add this change in the broadcast event LOADER_PROGRESS.

This could potentially be useful for custom loading screens (which is what I have done with this change, as I am making a game that loads various areas named differently)
