### PR TITLE
Fix race condition with "me.game.repaint"

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -923,6 +923,9 @@ window.me = window.me || {};
 		// to know when we have to refresh the display
 		var isDirty = true;
 
+		// Whether a forced repaint is required
+		var pendingRepaint = false;
+
 		/*---------------------------------------------
 
 			PUBLIC STUFF
@@ -1466,7 +1469,12 @@ window.me = window.me || {};
 		 */
 
 		api.repaint = function() {
+			// Repaint immediately
 			isDirty = true;
+
+			// Repaint once more after next update (objects may have been
+			// changed in ways which require an update before repainting)
+			pendingRepaint = true;
 		};
 
 
@@ -1485,6 +1493,12 @@ window.me = window.me || {};
 			
 			// update the camera/viewport
 			isDirty = api.viewport.update(isDirty) || isDirty;
+
+			// force repaint while ensuring objects have been updated first
+			if (pendingRepaint) {
+				pendingRepaint = false;
+				isDirty = true;
+			}
 
 			return isDirty;
 			


### PR DESCRIPTION
This patch fixes an issue where “me.game.repaint” would not have the
desired effect, that is repainting changes made to objects.

“repaint” sets an internal “isDirty” variable, which is used and unset
by “me.game.draw”. Once per frame, as controlled by “me.sys.fps”,
“me.ScreenObject.onUpdateFrame” calls “me.game.update” which may also
set “isDirty”. “onUpdateFrame” then calls “draw” every time, which will
update the canvas and also unset the variable.

Now if “repaint” is called at the wrong time, e.g. in an event handler,
“isDirty” is set and then unset by “draw” again before it's ever used
for actually updating the screen (a race condition of sorts).
Consequently, updates made to objects, e.g. visibility, won't be shown
until something else causes the screen to be updated.

With this patch an additional variable notes a requested repaint and is
only cleared once the world and viewport have been updated. This ensures
that calling “repaint” works anytime.
