### PR TITLE
allow loading tmx data from javascript objects instead of only from xhr

### DIFF
--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -82,6 +82,28 @@
 		 * @ignore
 		 */
 		function preloadTMX(tmxData, onload, onerror) {
+
+			function addToTMXList(data,format) {
+				// set the TMX content
+				tmxList[tmxData.name] = {
+					data: data,
+					isTMX: (tmxData.type === "tmx"),
+					format : format
+				};
+			}
+
+			// add the tmx to the levelDirector
+			if (tmxData.type === "tmx") {
+				me.levelDirector.addTMXLevel(tmxData.name);
+			}
+			
+			//if the data is in the tmxData object, don't get it via a XMLHTTPRequest
+			if (tmxData.data) {
+				addToTMXList(tmxData.data,tmxData.format);
+				onload();
+				return;
+			}
+			
 			var xmlhttp = new XMLHttpRequest();
 			// check the data format ('tmx', 'json')
 			var format = me.utils.getFileExtension(tmxData.src).toLowerCase();
@@ -96,10 +118,6 @@
 			
 			xmlhttp.open("GET", tmxData.src + obj.nocache, true);
 
-			// add the tmx to the levelDirector
-			if (tmxData.type === "tmx") {
-				me.levelDirector.addTMXLevel(tmxData.name);
-			}
 
 			// set the callbacks
 			xmlhttp.ontimeout = onerror;
@@ -133,12 +151,8 @@
 								throw "melonJS: TMX file format " + format + "not supported !";
 						}
 												
-						// get the TMX content
-						tmxList[tmxData.name] = {
-							data: result,
-							isTMX: (tmxData.type === "tmx"),
-							format : format
-						};
+						//set the TMX content
+						addToTMXList(result,format);
 						
 						// fire the callback
 						onload();
@@ -294,7 +308,13 @@
 		 * each resource item must contain the following fields :<br>
 		 * - name    : internal name of the resource<br>
 		 * - type    : "binary", "image", "tmx", "tsx", "audio"<br>
+		 * each resource except type "tmx" must contain the following field :<br>
 		 * - src     : path and file name of the resource<br>
+		 * (!) for tmx :<br>
+		 * - src     : path and file name of the resource<br>
+		 * or<br>
+		 * - data    : the json or xml object representation of the tmx file<br>
+		 * - format  : "xml" or "json"<br>
 		 * (!) for audio :<br>
 		 * - src     : path (only) where resources are located<br>
 		 * - channel : optional number of channels to be created<br>
@@ -316,7 +336,9 @@
 		 *   // TMX level (XML & JSON)
 		 *   {name: "map1", type: "tmx", src: "data/map/map1.json"},
 		 *   {name: "map2", type: "tmx", src: "data/map/map2.tmx"},
-		 *   // audio ressources
+		 *   {name: "map3", type: "tmx", format: "json", data: {"height":15,"layers":[...],"tilewidth":32,"version":1,"width":20}},
+		 *   {name: "map4", type: "tmx", format: "xml", data: {xml representation of tmx}},
+		 *   // audio resources
 		 *   {name: "bgmusic", type: "audio",  src: "data/audio/",  channel: 1,  stream: true},
 		 *   {name: "cling",   type: "audio",  src: "data/audio/",  channel: 2},
 		 *   // binary file
@@ -342,8 +364,14 @@
 		 * Load a single resource (to be used if you need to load additional resource during the game)<br>
 		 * Given parmeter must contain the following fields :<br>
 		 * - name    : internal name of the resource<br>
-		 * - type    : "audio", binary", "image", "json", "tmx", "tsx"
+		 * - type    : "audio", binary", "image", "json", "tmx", "tsx"<br>
+		 * each resource except type "tmx" must contain the following field :<br>
 		 * - src     : path and file name of the resource<br>
+		 * (!) for tmx :<br>
+		 * - src     : path and file name of the resource<br>
+		 * or<br>
+		 * - data    : the json or xml object representation of the tmx file<br>
+		 * - format  : "xml" or "json"<br>
 		 * (!) for audio :<br>
 		 * - src     : path (only) where resources are located<br>
 		 * - channel : optional number of channels to be created<br>


### PR DESCRIPTION
I wanted to get the tmx file without needing the XMLHttpRequest. Let me know if I need to do anything else to get it merged (or if there was a better way to go about it...).
