### PR TITLE
Renamed singleton variables from obj to api

### DIFF
--- a/src/audio/audio.js
+++ b/src/audio/audio.js
@@ -19,7 +19,7 @@
          */
 
         // hold public stuff in our singleton
-        var obj = {};
+        var api = {};
 
         // audio channel list
         var audioTracks = {};
@@ -85,7 +85,7 @@
          * // on Opera the loader will however load audio.ogg files
          * me.audio.init("mp3,ogg");
          */
-        obj.init = function (audioFormat) {
+        api.init = function (audioFormat) {
             if (!me.initialized) {
                 throw "melonJS: me.audio.init() called before engine initialization.";
             }
@@ -105,7 +105,7 @@
          * @public
          * @function
          */
-        obj.enable = function () {
+        api.enable = function () {
             this.unmuteAll();
         };
 
@@ -117,7 +117,7 @@
          * @public
          * @function
          */
-        obj.disable = function () {
+        api.disable = function () {
             this.muteAll();
         };
 
@@ -129,7 +129,7 @@
          * - src     : source path<br>
          * @ignore
          */
-        obj.load = function (sound, onload_cb, onerror_cb) {
+        api.load = function (sound, onload_cb, onerror_cb) {
             var urls = [];
             for (var i = 0; i < this.audioFormats.length; i++) {
                 urls.push(sound.src + sound.name + "." + this.audioFormats[i] + me.loader.nocache);
@@ -184,7 +184,7 @@
          * // play the "gameover_sfx" audio clip with a lower volume level
          * me.audio.play("gameover_sfx", false, null, 0.5);
          */
-        obj.play = function (sound_id, loop, callback, volume) {
+        api.play = function (sound_id, loop, callback, volume) {
             var sound = audioTracks[sound_id.toLowerCase()];
             if (sound && typeof sound !== "undefined") {
                 sound.loop(loop || false);
@@ -213,7 +213,7 @@
          * @example
          * me.audio.stop("cling");
          */
-        obj.stop = function (sound_id) {
+        api.stop = function (sound_id) {
             var sound = audioTracks[sound_id.toLowerCase()];
             if (sound && typeof sound !== "undefined") {
                 sound.stop();
@@ -232,7 +232,7 @@
          * @example
          * me.audio.pause("cling");
          */
-        obj.pause = function (sound_id) {
+        api.pause = function (sound_id) {
             var sound = audioTracks[sound_id.toLowerCase()];
             if (sound && typeof sound !== "undefined") {
                 sound.pause();
@@ -253,7 +253,7 @@
          * @example
          * me.audio.playTrack("awesome_music");
          */
-        obj.playTrack = function (sound_id, volume) {
+        api.playTrack = function (sound_id, volume) {
             current_track = me.audio.play(sound_id, true, null, volume);
             current_track_id = sound_id.toLowerCase();
         };
@@ -272,7 +272,7 @@
          * // stop the current music
          * me.audio.stopTrack();
          */
-        obj.stopTrack = function () {
+        api.stopTrack = function () {
             if (current_track) {
                 current_track.pause();
                 current_track_id = null;
@@ -288,7 +288,7 @@
          * @function
          * @param {Number} volume Float specifying volume (0.0 - 1.0 values accepted).
          */
-        obj.setVolume = function (volume) {
+        api.setVolume = function (volume) {
             Howler.volume(volume);
         };
 
@@ -300,7 +300,7 @@
          * @function
          * @returns {Number} current volume value in Float [0.0 - 1.0] .
          */
-        obj.getVolume = function () {
+        api.getVolume = function () {
             return Howler.volume();
         };
 
@@ -312,7 +312,7 @@
          * @function
          * @param {String} sound_id audio clip id
          */
-        obj.mute = function (sound_id, mute) {
+        api.mute = function (sound_id, mute) {
             // if not defined : true
             mute = (typeof(mute) === "undefined" ? true : !!mute);
             var sound = audioTracks[sound_id.toLowerCase()];
@@ -329,8 +329,8 @@
          * @function
          * @param {String} sound_id audio clip id
          */
-        obj.unmute = function (sound_id) {
-            obj.mute(sound_id, false);
+        api.unmute = function (sound_id) {
+            api.mute(sound_id, false);
         };
 
         /**
@@ -340,7 +340,7 @@
          * @public
          * @function
          */
-        obj.muteAll = function () {
+        api.muteAll = function () {
             Howler.mute();
         };
 
@@ -351,7 +351,7 @@
          * @public
          * @function
          */
-        obj.unmuteAll = function () {
+        api.unmuteAll = function () {
             Howler.unmute();
         };
 
@@ -363,7 +363,7 @@
          * @function
          * @return {String} audio track id
          */
-        obj.getCurrentTrack = function () {
+        api.getCurrentTrack = function () {
             return current_track_id;
         };
 
@@ -377,7 +377,7 @@
          * @example
          * me.audio.pauseTrack();
          */
-        obj.pauseTrack = function () {
+        api.pauseTrack = function () {
             if (current_track) {
                 current_track.pause();
             }
@@ -399,7 +399,7 @@
          * // resume the music
          * me.audio.resumeTrack();
          */
-        obj.resumeTrack = function () {
+        api.resumeTrack = function () {
             if (current_track) {
                 current_track.play();
             }
@@ -417,17 +417,17 @@
          * @example
          * me.audio.unload("awesome_music");
          */
-        obj.unload = function (sound_id) {
+        api.unload = function (sound_id) {
             sound_id = sound_id.toLowerCase();
             if (!(sound_id in audioTracks)) {
                 return false;
             }
 
             if (current_track_id === sound_id) {
-                obj.stopTrack();
+                api.stopTrack();
             }
             else {
-                obj.stop(sound_id);
+                api.stop(sound_id);
             }
             // destroy the Howl object
             audioTracks[sound_id].unload();
@@ -446,15 +446,15 @@
          * @example
          * me.audio.unloadAll();
          */
-        obj.unloadAll = function () {
+        api.unloadAll = function () {
             for (var sound_id in audioTracks) {
                 if (audioTracks.hasOwnProperty(sound_id)) {
-                    obj.unload(sound_id);
+                    api.unload(sound_id);
                 }
             }
         };
 
         // return our object
-        return obj;
+        return api;
     })();
 })();

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -11,7 +11,7 @@
      */
     me.input = (function () {
         // hold public stuff in our singleton
-        var obj = {};
+        var api = {};
 
         /*
          * PRIVATE STUFF
@@ -21,7 +21,7 @@
          * prevent event propagation
          * @ignore
          */
-        obj._preventDefault = function (e) {
+        api._preventDefault = function (e) {
             // stop event propagation
             if (e.stopPropagation) {
                 e.stopPropagation();
@@ -53,9 +53,9 @@
          * @name preventDefault
          * @memberOf me.input
          */
-        obj.preventDefault = true;
+        api.preventDefault = true;
 
         // return our object
-        return obj;
+        return api;
     })();
 })();

--- a/src/level/LevelDirector.js
+++ b/src/level/LevelDirector.js
@@ -14,7 +14,7 @@
      */
     me.levelDirector = (function () {
         // hold public stuff in our singletong
-        var obj = {};
+        var api = {};
 
         /*
          * PRIVATE STUFF
@@ -157,13 +157,13 @@
          * reset the level director
          * @ignore
          */
-        obj.reset = function () {};
+        api.reset = function () {};
 
         /**
          * add a level
          * @ignore
          */
-        obj.addLevel = function () {
+        api.addLevel = function () {
             throw "melonJS: no level loader defined";
         };
 
@@ -172,7 +172,7 @@
          * add a TMX level
          * @ignore
          */
-        obj.addTMXLevel = function (levelId, callback) {
+        api.addTMXLevel = function (levelId, callback) {
             // just load the level with the XML stuff
             if (levels[levelId] == null) {
                 //console.log("loading "+ levelId);
@@ -216,7 +216,7 @@
          * // load a level
          * me.levelDirector.loadLevel("a4_level1");
          */
-        obj.loadLevel = function (levelId) {
+        api.loadLevel = function (levelId) {
             // make sure it's a string
             levelId = levelId.toString().toLowerCase();
             // throw an exception if not existing
@@ -243,8 +243,8 @@
                 me.utils.resetGUID(levelId);
 
                 // clean the current (previous) level
-                if (levels[obj.getCurrentLevelId()]) {
-                    levels[obj.getCurrentLevelId()].destroy();
+                if (levels[api.getCurrentLevelId()]) {
+                    levels[api.getCurrentLevelId()].destroy();
                 }
 
                 // read the map data
@@ -276,7 +276,7 @@
          * @function
          * @return {String}
          */
-        obj.getCurrentLevelId = function () {
+        api.getCurrentLevelId = function () {
             return levelIdx[currentLevelIdx];
         };
 
@@ -287,10 +287,10 @@
          * @public
          * @function
          */
-        obj.reloadLevel = function () {
+        api.reloadLevel = function () {
             // reset the level to initial state
             //levels[currentLevel].reset();
-            return obj.loadLevel(obj.getCurrentLevelId());
+            return api.loadLevel(api.getCurrentLevelId());
         };
 
         /**
@@ -300,10 +300,10 @@
          * @public
          * @function
          */
-        obj.nextLevel = function () {
+        api.nextLevel = function () {
             //go to the next level
             if (currentLevelIdx + 1 < levelIdx.length) {
-                return obj.loadLevel(levelIdx[currentLevelIdx + 1]);
+                return api.loadLevel(levelIdx[currentLevelIdx + 1]);
             }
             else {
                 return false;
@@ -317,10 +317,10 @@
          * @public
          * @function
          */
-        obj.previousLevel = function () {
+        api.previousLevel = function () {
             // go to previous level
             if (currentLevelIdx - 1 >= 0) {
-                return obj.loadLevel(levelIdx[currentLevelIdx - 1]);
+                return api.loadLevel(levelIdx[currentLevelIdx - 1]);
             }
             else {
                 return false;
@@ -334,11 +334,11 @@
          * @public
          * @function
          */
-        obj.levelCount = function () {
+        api.levelCount = function () {
             return levelIdx.length;
         };
 
         // return our object
-        return obj;
+        return api;
     })();
 })();

--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -13,7 +13,7 @@
      */
     me.loader = (function () {
         // hold public stuff in our singleton
-        var obj = {};
+        var api = {};
 
         // contains all the images loaded
         var imgList = {};
@@ -35,12 +35,12 @@
         function checkLoadStatus() {
             if (loadCount === resourceCount) {
                 // wait 1/2s and execute callback (cheap workaround to ensure everything is loaded)
-                if (obj.onload) {
+                if (api.onload) {
                     // make sure we clear the timer
                     clearTimeout(timerId);
                     // trigger the onload callback
                     setTimeout(function () {
-                        obj.onload();
+                        api.onload();
                         me.event.publish(me.event.LOADER_COMPLETE);
                     }, 300);
                 }
@@ -69,7 +69,7 @@
             imgList[img.name] = new Image();
             imgList[img.name].onload = onload;
             imgList[img.name].onerror = onerror;
-            imgList[img.name].src = img.src + obj.nocache;
+            imgList[img.name].src = img.src + api.nocache;
         }
 
         /**
@@ -111,7 +111,7 @@
                 }
             }
 
-            xmlhttp.open("GET", tmxData.src + obj.nocache, true);
+            xmlhttp.open("GET", tmxData.src + api.nocache, true);
 
 
             // set the callbacks
@@ -176,7 +176,7 @@
                 xmlhttp.overrideMimeType("application/json");
             }
 
-            xmlhttp.open("GET", data.src + obj.nocache, true);
+            xmlhttp.open("GET", data.src + api.nocache, true);
 
             // set the callbacks
             xmlhttp.ontimeout = onerror;
@@ -207,7 +207,7 @@
             var httpReq = new XMLHttpRequest();
 
             // load our file
-            httpReq.open("GET", data.src + obj.nocache, true);
+            httpReq.open("GET", data.src + api.nocache, true);
             httpReq.responseType = "arraybuffer";
             httpReq.onerror = onerror;
             httpReq.onload = function () {
@@ -230,7 +230,7 @@
          * to enable/disable caching
          * @ignore
          */
-        obj.nocache = "";
+        api.nocache = "";
 
         /*
          * PUBLIC STUFF
@@ -247,7 +247,7 @@
          * // set a callback when everything is loaded
          * me.loader.onload = this.loaded.bind(this);
          */
-        obj.onload = undefined;
+        api.onload = undefined;
 
         /**
          * onProgress callback<br>
@@ -262,21 +262,21 @@
          * // set a callback for progress notification
          * me.loader.onProgress = this.updateProgress.bind(this);
          */
-        obj.onProgress = undefined;
+        api.onProgress = undefined;
 
         /**
          *  just increment the number of already loaded resources
          * @ignore
          */
-        obj.onResourceLoaded = function (res) {
+        api.onResourceLoaded = function (res) {
             // increment the loading counter
             loadCount++;
 
             // callback ?
-            var progress = obj.getLoadProgress();
-            if (obj.onProgress) {
+            var progress = api.getLoadProgress();
+            if (api.onProgress) {
                 // pass the load progress in percent, as parameter
-                obj.onProgress(progress, res);
+                api.onProgress(progress, res);
             }
             me.event.publish(me.event.LOADER_PROGRESS, [progress, res]);
         };
@@ -285,7 +285,7 @@
          * on error callback for image loading
          * @ignore
          */
-        obj.onLoadingError = function (res) {
+        api.onLoadingError = function (res) {
             throw "melonJS: Failed loading resource " + res.src;
         };
 
@@ -293,8 +293,8 @@
          * enable the nocache mechanism
          * @ignore
          */
-        obj.setNocache = function (enable) {
-            obj.nocache = enable ? "?" + parseInt(Math.random() * 10000000, 10) : "";
+        api.setNocache = function (enable) {
+            api.nocache = enable ? "?" + parseInt(Math.random() * 10000000, 10) : "";
         };
 
 
@@ -344,13 +344,13 @@
          * // set all resources to be loaded
          * me.loader.preload(g_resources);
          */
-        obj.preload = function (res) {
+        api.preload = function (res) {
             // parse the resources
             for (var i = 0; i < res.length; i++) {
-                resourceCount += obj.load(
+                resourceCount += api.load(
                     res[i],
-                    obj.onResourceLoaded.bind(obj, res[i]),
-                    obj.onLoadingError.bind(obj, res[i])
+                    api.onResourceLoaded.bind(api, res[i]),
+                    api.onLoadingError.bind(api, res[i])
                 );
             }
             // check load status
@@ -391,7 +391,7 @@
          *     me.audio.play("bgmusic");
          * });
          */
-        obj.load = function (res, onload, onerror) {
+        api.load = function (res, onload, onerror) {
             // fore lowercase for the resource name
             res.name = res.name.toLowerCase();
             // check ressource type
@@ -435,7 +435,7 @@
          * @return {Boolean} true if unloaded
          * @example me.loader.unload({name: "avatar",  type:"image",  src: "data/avatar.png"});
          */
-        obj.unload = function (res) {
+        api.unload = function (res) {
             res.name = res.name.toLowerCase();
             switch (res.type) {
                 case "binary":
@@ -491,13 +491,13 @@
          * @function
          * @example me.loader.unloadAll();
          */
-        obj.unloadAll = function () {
+        api.unloadAll = function () {
             var name;
 
             // unload all binary resources
             for (name in binList) {
                 if (binList.hasOwnProperty(name)) {
-                    obj.unload({
+                    api.unload({
                         "name" : name,
                         "type" : "binary"
                     });
@@ -507,7 +507,7 @@
             // unload all image resources
             for (name in imgList) {
                 if (imgList.hasOwnProperty(name)) {
-                    obj.unload({
+                    api.unload({
                         "name" : name,
                         "type" : "image"
                     });
@@ -517,7 +517,7 @@
             // unload all tmx resources
             for (name in tmxList) {
                 if (tmxList.hasOwnProperty(name)) {
-                    obj.unload({
+                    api.unload({
                         "name" : name,
                         "type" : "tmx"
                     });
@@ -527,7 +527,7 @@
             // unload all in json resources
             for (name in jsonList) {
                 if (jsonList.hasOwnProperty(name)) {
-                    obj.unload({
+                    api.unload({
                         "name" : name,
                         "type" : "json"
                     });
@@ -547,7 +547,7 @@
          * @param {String} tmx name of the tmx/tsx element ("map1");
          * @return {TMx}
          */
-        obj.getTMX = function (elt) {
+        api.getTMX = function (elt) {
             // avoid case issue
             elt = elt.toLowerCase();
             if (elt in tmxList) {
@@ -568,7 +568,7 @@
          * @param {String} name of the binary object ("ymTrack");
          * @return {Object}
          */
-        obj.getBinary = function (elt) {
+        api.getBinary = function (elt) {
             // avoid case issue
             elt = elt.toLowerCase();
             if (elt in binList) {
@@ -590,7 +590,7 @@
          * @param {String} Image name of the Image element ("tileset-platformer");
          * @return {Image}
          */
-        obj.getImage = function (elt) {
+        api.getImage = function (elt) {
             // avoid case issue
             elt = elt.toLowerCase();
             if (elt in imgList) {
@@ -613,7 +613,7 @@
          * @param {String} Name for the json file to load
          * @return {Object}
          */
-        obj.getJSON = function (elt) {
+        api.getJSON = function (elt) {
             elt = elt.toLowerCase();
             if (elt in jsonList) {
                 return jsonList[elt];
@@ -632,11 +632,11 @@
          * @deprecated use callback instead
          * @return {Number}
          */
-        obj.getLoadProgress = function () {
+        api.getLoadProgress = function () {
             return loadCount / resourceCount;
         };
 
         // return our object
-        return obj;
+        return api;
     })();
 })();

--- a/src/state/state.js
+++ b/src/state/state.js
@@ -108,7 +108,7 @@
 
     me.state = (function () {
         // hold public stuff in our singleton
-        var obj = {};
+        var api = {};
 
         /*-------------------------------------------
             PRIVATE STUFF
@@ -250,7 +250,7 @@
          * @name LOADING
          * @memberOf me.state
          */
-        obj.LOADING = 0;
+        api.LOADING = 0;
 
         /**
          * default state value for Menu Screen
@@ -259,7 +259,7 @@
          * @memberOf me.state
          */
 
-        obj.MENU = 1;
+        api.MENU = 1;
         /**
          * default state value for "Ready" Screen
          * @constant
@@ -267,7 +267,7 @@
          * @memberOf me.state
          */
 
-        obj.READY = 2;
+        api.READY = 2;
         /**
          * default state value for Play Screen
          * @constant
@@ -275,7 +275,7 @@
          * @memberOf me.state
          */
 
-        obj.PLAY = 3;
+        api.PLAY = 3;
         /**
          * default state value for Game Over Screen
          * @constant
@@ -283,7 +283,7 @@
          * @memberOf me.state
          */
 
-        obj.GAMEOVER = 4;
+        api.GAMEOVER = 4;
         /**
          * default state value for Game End Screen
          * @constant
@@ -291,7 +291,7 @@
          * @memberOf me.state
          */
 
-        obj.GAME_END = 5;
+        api.GAME_END = 5;
         /**
          * default state value for High Score Screen
          * @constant
@@ -299,7 +299,7 @@
          * @memberOf me.state
          */
 
-        obj.SCORE = 6;
+        api.SCORE = 6;
         /**
          * default state value for Credits Screen
          * @constant
@@ -307,14 +307,14 @@
          * @memberOf me.state
          */
 
-        obj.CREDITS = 7;
+        api.CREDITS = 7;
         /**
          * default state value for Settings Screen
          * @constant
          * @name SETTINGS
          * @memberOf me.state
          */
-        obj.SETTINGS = 8;
+        api.SETTINGS = 8;
 
         /**
          * default state value for user defined constants<br>
@@ -327,7 +327,7 @@
          * var STATE_ERROR = me.state.USER + 2;
          * var STATE_CUTSCENE = me.state.USER + 3;
          */
-        obj.USER = 100;
+        api.USER = 100;
 
         /**
          * onPause callback
@@ -335,7 +335,7 @@
          * @name onPause
          * @memberOf me.state
          */
-        obj.onPause = null;
+        api.onPause = null;
 
         /**
          * onResume callback
@@ -343,7 +343,7 @@
          * @name onResume
          * @memberOf me.state
          */
-        obj.onResume = null;
+        api.onResume = null;
 
         /**
          * onStop callback
@@ -351,7 +351,7 @@
          * @name onStop
          * @memberOf me.state
          */
-        obj.onStop = null;
+        api.onStop = null;
 
         /**
          * onRestart callback
@@ -359,14 +359,14 @@
          * @name onRestart
          * @memberOf me.state
          */
-        obj.onRestart = null;
+        api.onRestart = null;
 
         /**
          * @ignore
          */
-        obj.init = function () {
+        api.init = function () {
             // set the embedded loading screen
-            obj.set(obj.LOADING, new me.DefaultLoadingScreen());
+            api.set(api.LOADING, new me.DefaultLoadingScreen());
         };
 
         /**
@@ -377,9 +377,9 @@
          * @function
          * @param {Boolean} pauseTrack pause current track on screen stop.
          */
-        obj.stop = function (music) {
+        api.stop = function (music) {
             // only stop when we are not loading stuff
-            if ((_state !== obj.LOADING) && obj.isRunning()) {
+            if ((_state !== api.LOADING) && api.isRunning()) {
                 // stop the main loop
                 _stopRunLoop();
                 // current music stop
@@ -393,8 +393,8 @@
                 // publish the stop notification
                 me.event.publish(me.event.STATE_STOP);
                 // any callback defined ?
-                if (typeof(obj.onStop) === "function") {
-                    obj.onStop();
+                if (typeof(api.onStop) === "function") {
+                    api.onStop();
                 }
             }
         };
@@ -407,9 +407,9 @@
          * @function
          * @param {Boolean} pauseTrack pause current track on screen pause
          */
-        obj.pause = function (music) {
+        api.pause = function (music) {
             // only pause when we are not loading stuff
-            if ((_state !== obj.LOADING) && !obj.isPaused()) {
+            if ((_state !== api.LOADING) && !api.isPaused()) {
                 // stop the main loop
                 _pauseRunLoop();
                 // current music stop
@@ -423,8 +423,8 @@
                 // publish the pause event
                 me.event.publish(me.event.STATE_PAUSE);
                 // any callback defined ?
-                if (typeof(obj.onPause) === "function") {
-                    obj.onPause();
+                if (typeof(api.onPause) === "function") {
+                    api.onPause();
                 }
             }
         };
@@ -437,8 +437,8 @@
          * @function
          * @param {Boolean} resumeTrack resume current track on screen resume
          */
-        obj.restart = function (music) {
-            if (!obj.isRunning()) {
+        api.restart = function (music) {
+            if (!api.isRunning()) {
                 // restart the main loop
                 _startRunLoop();
                 // current music stop
@@ -455,8 +455,8 @@
                 // publish the restart notification
                 me.event.publish(me.event.STATE_RESTART, [ _pauseTime ]);
                 // any callback defined ?
-                if (typeof(obj.onRestart) === "function") {
-                    obj.onRestart();
+                if (typeof(api.onRestart) === "function") {
+                    api.onRestart();
                 }
             }
         };
@@ -469,8 +469,8 @@
          * @function
          * @param {Boolean} resumeTrack resume current track on screen resume
          */
-        obj.resume = function (music) {
-            if (obj.isPaused()) {
+        api.resume = function (music) {
+            if (api.isPaused()) {
                 // resume the main loop
                 _resumeRunLoop();
                 // current music stop
@@ -484,8 +484,8 @@
                 // publish the resume event
                 me.event.publish(me.event.STATE_RESUME, [ _pauseTime ]);
                 // any callback defined ?
-                if (typeof(obj.onResume) === "function") {
-                    obj.onResume();
+                if (typeof(api.onResume) === "function") {
+                    api.onResume();
                 }
             }
         };
@@ -498,7 +498,7 @@
          * @function
          * @return {Boolean} true if a "process is running"
          */
-        obj.isRunning = function () {
+        api.isRunning = function () {
             return _animFrameId !== -1;
         };
 
@@ -510,7 +510,7 @@
          * @function
          * @return {Boolean} true if the game is paused
          */
-        obj.isPaused = function () {
+        api.isPaused = function () {
             return _isPaused;
         };
 
@@ -523,7 +523,7 @@
          * @param {Number} state @see me.state#Constant
          * @param {me.ScreenObject}
          */
-        obj.set = function (state, so) {
+        api.set = function (state, so) {
             _screenObject[state] = {};
             _screenObject[state].screen = so;
             _screenObject[state].transition = true;
@@ -538,7 +538,7 @@
          * @function
          * @return {me.ScreenObject}
          */
-        obj.current = function () {
+        api.current = function () {
             return _screenObject[_state].screen;
         };
 
@@ -552,7 +552,7 @@
          * @param {String} color a CSS color value
          * @param {Number} [duration=1000] expressed in milliseconds
          */
-        obj.transition = function (effect, color, duration) {
+        api.transition = function (effect, color, duration) {
             if (effect === "fade") {
                 _fade.color = color;
                 _fade.duration = duration;
@@ -566,7 +566,7 @@
          * @public
          * @function
          */
-        obj.setTransition = function (state, enable) {
+        api.setTransition = function (state, enable) {
             _screenObject[state].transition = enable;
         };
 
@@ -583,7 +583,7 @@
          * // "level_1" and the number 3
          * me.state.change(me.state.PLAY, "level_1", 3);
          */
-        obj.change = function (state) {
+        api.change = function (state) {
             // Protect against undefined ScreenObject
             if (typeof(_screenObject[state]) === "undefined") {
                 throw "melonJS : Undefined ScreenObject for state '" + state + "'";
@@ -625,11 +625,11 @@
          * @function
          * @param {Number} state @see me.state#Constant
          */
-        obj.isCurrent = function (state) {
+        api.isCurrent = function (state) {
             return _state === state;
         };
 
         // return our object
-        return obj;
+        return api;
     })();
 })();

--- a/src/system/device.js
+++ b/src/system/device.js
@@ -12,7 +12,7 @@
      */
     me.device = (function () {
         // defines object for holding public information/functionality.
-        var obj = {};
+        var api = {};
         // private properties
         var accelInitialized = false;
         var deviceOrientationInitialized = false;
@@ -22,7 +22,7 @@
          * check the device capapbilities
          * @ignore
          */
-        obj._check = function () {
+        api._check = function () {
 
             // detect device type/platform
             me.device._detectDevice();
@@ -67,10 +67,10 @@
             navigator.vibrate = me.agent.prefixed("vibrate", navigator);
 
             try {
-                obj.localStorage = !!window.localStorage;
+                api.localStorage = !!window.localStorage;
             } catch (e) {
                 // the above generates an exception when cookies are blocked
-                obj.localStorage = false;
+                api.localStorage = false;
             }
 
             // detect audio capabilities
@@ -139,7 +139,7 @@
          * detect the device type
          * @ignore
          */
-        obj._detectDevice = function () {
+        api._detectDevice = function () {
             // detect platform
             me.device.isMobile = me.device.ua.match(/Android|iPhone|iPad|iPod|BlackBerry|Windows Phone|Mobi/i) || false;
             // iOS Device ?
@@ -155,7 +155,7 @@
          * check the audio capapbilities
          * @ignore
          */
-        obj._detectAudio = function () {
+        api._detectAudio = function () {
             // check for browser codec support
             me.device.sound = !Howler.noAudio;
 
@@ -186,7 +186,7 @@
          * @name ua
          * @memberOf me.device
          */
-        obj.ua = navigator.userAgent;
+        api.ua = navigator.userAgent;
 
         /**
          * list of supported audio codecs
@@ -195,7 +195,7 @@
          * @name audioCodecs
          * @memberOf me.device
          */
-        obj.audioCodecs = {};
+        api.audioCodecs = {};
 
         /**
          * Browser Audio capabilities
@@ -204,7 +204,7 @@
          * @name sound
          * @memberOf me.device
          */
-        obj.sound = false;
+        api.sound = false;
 
         /**
          * Browser Local Storage capabilities <br>
@@ -214,7 +214,7 @@
          * @name localStorage
          * @memberOf me.device
          */
-        obj.localStorage = false;
+        api.localStorage = false;
 
         /**
          * Browser accelerometer capabilities
@@ -223,7 +223,7 @@
          * @name hasAccelerometer
          * @memberOf me.device
          */
-        obj.hasAccelerometer = false;
+        api.hasAccelerometer = false;
 
         /**
          * Browser device orientation
@@ -232,7 +232,7 @@
          * @name hasDeviceOrientation
          * @memberOf me.device
          */
-        obj.hasDeviceOrientation = false;
+        api.hasDeviceOrientation = false;
 
         /**
          * Browser full screen support
@@ -241,7 +241,7 @@
          * @name hasFullscreenSupport
          * @memberOf me.device
          */
-        obj.hasFullscreenSupport = false;
+        api.hasFullscreenSupport = false;
 
          /**
          * Browser pointerlock api support
@@ -250,7 +250,7 @@
          * @name hasPointerLockSupport
          * @memberOf me.device
          */
-        obj.hasPointerLockSupport = false;
+        api.hasPointerLockSupport = false;
 
         /**
          * Browser Base64 decoding capability
@@ -259,7 +259,7 @@
          * @name nativeBase64
          * @memberOf me.device
          */
-        obj.nativeBase64 = (typeof(window.atob) === "function");
+        api.nativeBase64 = (typeof(window.atob) === "function");
 
         /**
          * Touch capabilities
@@ -268,7 +268,7 @@
          * @name touch
          * @memberOf me.device
          */
-        obj.touch = false;
+        api.touch = false;
 
         /**
          * equals to true if a mobile device <br>
@@ -278,7 +278,7 @@
          * @name isMobile
          * @memberOf me.device
          */
-        obj.isMobile = false;
+        api.isMobile = false;
 
         /**
          * equals to true if the device is an iOS platform <br>
@@ -287,7 +287,7 @@
          * @name iOS
          * @memberOf me.device
          */
-        obj.iOS = false;
+        api.iOS = false;
 
         /**
          * equals to true if the device is an Android platform <br>
@@ -296,7 +296,7 @@
          * @name android
          * @memberOf me.device
          */
-        obj.android = false;
+        api.android = false;
 
         /**
          * equals to true if the device is an Android 2.x platform <br>
@@ -305,7 +305,7 @@
          * @name android2
          * @memberOf me.device
          */
-        obj.android2 = false;
+        api.android2 = false;
 
          /**
          * equals to true if the device is an Windows Phone platform <br>
@@ -314,7 +314,7 @@
          * @name wp
          * @memberOf me.device
          */
-        obj.wp = false;
+        api.wp = false;
 
         /**
          * The device current orientation status. <br>
@@ -327,7 +327,7 @@
          * @name orientation
          * @memberOf me.device
          */
-        obj.orientation = 0;
+        api.orientation = 0;
 
         /**
          * contains the g-force acceleration along the x-axis.
@@ -337,7 +337,7 @@
          * @name accelerationX
          * @memberOf me.device
          */
-        obj.accelerationX = 0;
+        api.accelerationX = 0;
 
         /**
          * contains the g-force acceleration along the y-axis.
@@ -347,7 +347,7 @@
          * @name accelerationY
          * @memberOf me.device
          */
-        obj.accelerationY = 0;
+        api.accelerationY = 0;
 
         /**
          * contains the g-force acceleration along the z-axis.
@@ -357,7 +357,7 @@
          * @name accelerationZ
          * @memberOf me.device
          */
-        obj.accelerationZ = 0;
+        api.accelerationZ = 0;
 
         /**
          * Device orientation Gamma property. Gives angle on tilting a portrait held phone left or right
@@ -367,7 +367,7 @@
          * @name gamma
          * @memberOf me.device
          */
-        obj.gamma = 0;
+        api.gamma = 0;
 
         /**
          * Device orientation Beta property. Gives angle on tilting a portrait held phone forward or backward
@@ -377,7 +377,7 @@
          * @name beta
          * @memberOf me.device
          */
-        obj.beta = 0;
+        api.beta = 0;
 
         /**
          * Device orientation Alpha property. Gives angle based on the rotation of the phone around its z axis.
@@ -388,7 +388,7 @@
          * @name alpha
          * @memberOf me.device
          */
-        obj.alpha = 0;
+        api.alpha = 0;
 
         /**
          * Triggers a fullscreen request. Requires fullscreen support from the browser/device.
@@ -410,7 +410,7 @@
          *    }
          * });
          */
-        obj.requestFullscreen = function (element) {
+        api.requestFullscreen = function (element) {
             if (this.hasFullscreenSupport) {
                 element = element || me.video.getWrapper();
                 element.requestFullscreen = me.agent.prefixed("requestFullscreen", element) ||
@@ -426,7 +426,7 @@
          * @memberOf me.device
          * @function
          */
-        obj.exitFullscreen = function () {
+        api.exitFullscreen = function () {
             if (this.hasFullscreenSupport) {
                 document.exitFullscreen();
             }
@@ -438,7 +438,7 @@
          * @memberOf me.device
          * @function
          */
-        obj.getPixelRatio = function () {
+        api.getPixelRatio = function () {
 
             if (devicePixelRatio === null) {
                 var _context = me.video.getScreenContext();
@@ -457,7 +457,7 @@
          * @param {String} [type="local"]
          * @return me.save object
          */
-        obj.getStorage = function (type) {
+        api.getStorage = function (type) {
 
             type = type || "local";
 
@@ -480,22 +480,22 @@
         function onDeviceMotion(e) {
             if (e.reading) {
                 // For Windows 8 devices
-                obj.accelerationX = e.reading.accelerationX;
-                obj.accelerationY = e.reading.accelerationY;
-                obj.accelerationZ = e.reading.accelerationZ;
+                api.accelerationX = e.reading.accelerationX;
+                api.accelerationY = e.reading.accelerationY;
+                api.accelerationZ = e.reading.accelerationZ;
             }
             else {
                 // Accelerometer information
-                obj.accelerationX = e.accelerationIncludingGravity.x;
-                obj.accelerationY = e.accelerationIncludingGravity.y;
-                obj.accelerationZ = e.accelerationIncludingGravity.z;
+                api.accelerationX = e.accelerationIncludingGravity.x;
+                api.accelerationY = e.accelerationIncludingGravity.y;
+                api.accelerationZ = e.accelerationIncludingGravity.z;
             }
         }
 
         function onDeviceRotate(e) {
-            obj.gamma = e.gamma;
-            obj.beta = e.beta;
-            obj.alpha = e.alpha;
+            api.gamma = e.gamma;
+            api.beta = e.beta;
+            api.alpha = e.alpha;
         }
 
         /**
@@ -514,7 +514,7 @@
          * document.addEventListener("mozpointerlockerror", pointerlockerror, false);
          * document.addEventListener("webkitpointerlockerror", pointerlockerror, false);
          */
-        obj.turnOnPointerLock = function () {
+        api.turnOnPointerLock = function () {
             if (this.hasPointerLockSupport) {
                 var element = me.video.getWrapper();
                 if (me.device.ua.match(/Firefox/i)) {
@@ -547,7 +547,7 @@
          * @memberOf me.device
          * @function
          */
-        obj.turnOffPointerLock = function () {
+        api.turnOffPointerLock = function () {
             if (this.hasPointerLockSupport) {
                 document.exitPointerLock();
             }
@@ -561,7 +561,7 @@
          * @function
          * @return {Boolean} false if not supported by the device
          */
-        obj.watchAccelerometer = function () {
+        api.watchAccelerometer = function () {
             if (me.device.hasAccelerometer) {
                 if (!accelInitialized) {
                     if (typeof Windows === "undefined") {
@@ -594,7 +594,7 @@
          * @public
          * @function
          */
-        obj.unwatchAccelerometer = function () {
+        api.unwatchAccelerometer = function () {
             if (accelInitialized) {
                 if (typeof Windows === "undefined") {
                     // add a listener for the mouse
@@ -617,7 +617,7 @@
          * @function
          * @return {Boolean} false if not supported by the device
          */
-        obj.watchDeviceOrientation = function () {
+        api.watchDeviceOrientation = function () {
             if (me.device.hasDeviceOrientation && !deviceOrientationInitialized) {
                 window.addEventListener("deviceorientation", onDeviceRotate, false);
                 deviceOrientationInitialized = true;
@@ -632,7 +632,7 @@
          * @public
          * @function
          */
-        obj.unwatchDeviceOrientation = function () {
+        api.unwatchDeviceOrientation = function () {
             if (deviceOrientationInitialized) {
                 window.removeEventListener("deviceorientation", onDeviceRotate, false);
                 deviceOrientationInitialized = false;
@@ -659,14 +659,14 @@
          * // cancel any existing vibrations
          * navigator.vibrate(0);
          */
-        obj.vibrate = function (pattern) {
+        api.vibrate = function (pattern) {
             if (navigator.vibrate) {
                 navigator.vibrate(pattern);
             }
         };
 
 
-        return obj;
+        return api;
     })();
 
     /**

--- a/src/vendors/minpubsub.src.js
+++ b/src/vendors/minpubsub.src.js
@@ -14,7 +14,7 @@
      */
     me.event = (function () {
         // hold public stuff inside the singleton
-        var obj = {};
+        var api = {};
 
         /**
          * the channel/subscription hash
@@ -34,7 +34,7 @@
          * @type String
          * @name me.event#STATE_PAUSE
          */
-        obj.STATE_PAUSE = "me.state.onPause";
+        api.STATE_PAUSE = "me.state.onPause";
 
         /**
          * Channel Constant for when the game is resumed <br>
@@ -44,7 +44,7 @@
          * @type String
          * @name me.event#STATE_RESUME
          */
-        obj.STATE_RESUME = "me.state.onResume";
+        api.STATE_RESUME = "me.state.onResume";
 
         /**
          * Channel Constant when the game is stopped <br>
@@ -54,7 +54,7 @@
          * @type String
          * @name me.event#STATE_STOP
          */
-        obj.STATE_STOP = "me.state.onStop";
+        api.STATE_STOP = "me.state.onStop";
 
         /**
          * Channel Constant for when the game is restarted <br>
@@ -64,7 +64,7 @@
          * @type String
          * @name me.event#STATE_RESTART
          */
-        obj.STATE_RESTART = "me.state.onRestart";
+        api.STATE_RESTART = "me.state.onRestart";
 
         /**
          * Channel Constant for when the game manager is initialized <br>
@@ -74,7 +74,7 @@
          * @type String
          * @name me.event#GAME_INIT
          */
-        obj.GAME_INIT = "me.game.onInit";
+        api.GAME_INIT = "me.game.onInit";
 
         /**
          * Channel Constant for when a level is loaded <br>
@@ -84,7 +84,7 @@
          * @type String
          * @name me.event#LEVEL_LOADED
          */
-        obj.LEVEL_LOADED = "me.game.onLevelLoaded";
+        api.LEVEL_LOADED = "me.game.onLevelLoaded";
 
         /**
          * Channel Constant for when everything has loaded <br>
@@ -94,7 +94,7 @@
          * @type String
          * @name me.event#LOADER_COMPLETE
          */
-        obj.LOADER_COMPLETE = "me.loader.onload";
+        api.LOADER_COMPLETE = "me.loader.onload";
 
         /**
          * Channel Constant for displaying a load progress indicator <br>
@@ -104,7 +104,7 @@
          * @type String
          * @name me.event#LOADER_PROGRESS
          */
-        obj.LOADER_PROGRESS = "me.loader.onProgress";
+        api.LOADER_PROGRESS = "me.loader.onProgress";
 
         /**
          * Channel Constant for pressing a binded key <br>
@@ -133,7 +133,7 @@
          *   }
          * });
          */
-        obj.KEYDOWN = "me.input.keydown";
+        api.KEYDOWN = "me.input.keydown";
 
         /**
          * Channel Constant for releasing a binded key <br>
@@ -155,7 +155,7 @@
          *   }
          * });
          */
-        obj.KEYUP = "me.input.keyup";
+        api.KEYUP = "me.input.keyup";
 
         /**
          * Channel Constant for mousemove or dragmove events on the game viewport <br>
@@ -165,7 +165,7 @@
          * @type String
          * @name me.event#MOUSEMOVE
          */
-        obj.MOUSEMOVE = "me.game.pointermove";
+        api.MOUSEMOVE = "me.game.pointermove";
 
         /**
          * Channel Constant for dragstart events on a Draggable entity <br>
@@ -177,7 +177,7 @@
          * @type String
          * @name me.event#DRAGSTART
          */
-        obj.DRAGSTART = "me.game.dragstart";
+        api.DRAGSTART = "me.game.dragstart";
 
         /**
          * Channel Constant for dragend events on a Draggable entity <br>
@@ -189,7 +189,7 @@
          * @type String
          * @name me.event#DRAGEND
          */
-        obj.DRAGEND = "me.game.dragend";
+        api.DRAGEND = "me.game.dragend";
 
         /**
          * Channel Constant for when the (browser) window is resized <br>
@@ -199,7 +199,7 @@
          * @type String
          * @name me.event#WINDOW_ONRESIZE
          */
-        obj.WINDOW_ONRESIZE = "window.onresize";
+        api.WINDOW_ONRESIZE = "window.onresize";
 
         /**
          * Channel Constant for when the device is rotated <br>
@@ -209,7 +209,7 @@
          * @type String
          * @name me.event#WINDOW_ONORIENTATION_CHANGE
          */
-        obj.WINDOW_ONORIENTATION_CHANGE = "window.orientationchange";
+        api.WINDOW_ONORIENTATION_CHANGE = "window.orientationchange";
 
         /**
          * Channel Constant for when the (browser) window is scrolled <br>
@@ -219,7 +219,7 @@
          * @type String
          * @name me.event#WINDOW_ONSCROLL
          */
-        obj.WINDOW_ONSCROLL = "window.onscroll";
+        api.WINDOW_ONSCROLL = "window.onscroll";
 
         /**
          * Channel Constant for when the viewport position is updated <br>
@@ -229,7 +229,7 @@
          * @type String
          * @name me.event#VIEWPORT_ONCHANGE
          */
-        obj.VIEWPORT_ONCHANGE = "viewport.onchange";
+        api.VIEWPORT_ONCHANGE = "viewport.onchange";
 
         /**
          * Publish some data on a channel
@@ -246,7 +246,7 @@
          * me.event.publish("/some/channel", ["a","b","c"]);
          *
          */
-        obj.publish = function (channel, args) {
+        api.publish = function (channel, args) {
             var subs = cache[channel],
                 len = subs ? subs.length : 0;
 
@@ -271,7 +271,7 @@
          * me.event.subscribe("/some/channel", function (a, b, c){ doSomething(); });
          */
 
-        obj.subscribe = function (channel, callback) {
+        api.subscribe = function (channel, callback) {
             if (!cache[channel]) {
                 cache[channel] = [];
             }
@@ -297,7 +297,7 @@
          * me.event.subscribe("/some/channel", callback);
          * me.event.unsubscribe("/some/channel", callback);
          */
-        obj.unsubscribe = function (handle, callback) {
+        api.unsubscribe = function (handle, callback) {
             var subs = cache[callback ? handle : handle[0]],
                 len = subs ? subs.length : 0;
 
@@ -311,6 +311,6 @@
         };
 
         // return our object
-        return obj;
+        return api;
     })();
 })();


### PR DESCRIPTION
Renamed 'obj' singletons to 'api' for consistency and readability, with the exception of me.TMXUtils.parse, as it conflicts with the me.TMXUtils function api variable, which would get confusing

P.S. sorry about the bad commit message, I'm still learning how to properly document my commits. Shouldn't happen again.
