### PR TITLE
Debug panel scaling

### DIFF
--- a/plugins/debug/debugPanel.js
+++ b/plugins/debug/debugPanel.js
@@ -98,7 +98,7 @@
             this.help_str      = "(s)how/(h)ide";
             this.help_str_len = this.font.measureText(me.video.getSystemContext(), this.help_str).width;
             this.fps_str_len = this.font.measureText(me.video.getSystemContext(), "00/00 fps").width;
-            this.memoryPositionX = this.font.measureText(me.video.getSystemContext(), "Draw   : ").width * 3 + 310;
+            this.memoryPositionX = this.font.measureText(me.video.getSystemContext(), "Draw   : ").width * 2.2 + 310 * this.mod;
 
             // enable the FPS counter
             me.debug.displayFPS = true;
@@ -316,19 +316,19 @@
                 this.samples[len] = (usedHeap / totalHeap)  * 25;
 
                 // draw the graph
-                for (var x = len;x--;) {
+                for (var x = len; x >= 0; x--) {
                     var where = endX - (len - x);
                     context.beginPath();
                     context.strokeStyle = "lightblue";
-                    context.moveTo(where, 30);
-                    context.lineTo(where, 30 - (this.samples[x] || 0));
+                    context.moveTo(where, 30 * this.mod);
+                    context.lineTo(where, (30 - (this.samples[x] || 0)) * this.mod);
                     context.stroke();
                 }
                 // display the current value
-                this.font.draw(context, "Heap : " + usedHeap + '/' + totalHeap + ' MB', this.memoryPositionX * this.mod, 5 * this.mod);
+                this.font.draw(context, "Heap : " + usedHeap + '/' + totalHeap + ' MB', this.memoryPositionX, 5 * this.mod);
             } else {
                 // Heap Memory information not available
-                this.font.draw(context, "Heap : ??/?? MB", this.memoryPositionX * this.mod, 5 * this.mod);
+                this.font.draw(context, "Heap : ??/?? MB", this.memoryPositionX, 5 * this.mod);
             }
         },
 


### PR DESCRIPTION
Alright so i fixed the infinite loop i believe for #414. I also added a bit of a hack in to position things better depending on viewport size. It wont cater to all screen sizes that well, but it's readable at least.

Weird thing is, in the 1.1.0-dev version, the used heap would be a fairly large number, and you would see the memory graph fill up, that's no longer the case. However, doing a profile in chrome with the changes i made and without shows little difference in memory usage. So I'm not sure what's going on there. @parasyte you know this stuff far better than I do :)
