### PR TITLE
GUI_Object tap and hold

### DIFF
--- a/src/renderable/GUI.js
+++ b/src/renderable/GUI.js
@@ -107,7 +107,7 @@
             if (this.updated) {
                 // clear the flag
                 if(!this.released){
-					this.updated = false;					
+                    this.updated = false;					
                 }
                 return true;
             }
@@ -123,7 +123,7 @@
                 this.updated = true;
                 if(this.isHoldable){
                     if(this.holdTimeout!==null){
-						me.timer.clearTimeout(this.holdTimeout);
+                        me.timer.clearTimeout(this.holdTimeout);
                     }
                     this.holdTimeout = me.timer.setTimeout(this.hold.bind(this),this.holdThreshold,false);
                     this.released = false;					


### PR DESCRIPTION
Add tap and hold for GUI_Object. After item is clicked, timer starts to
run. If after timer ended, item is still clicked it means we are
holding it. Object registers “pointer up” event to check is item
released.
