### PR TITLE
Removed unused variable

### DIFF
--- a/src/renderable/container.js
+++ b/src/renderable/container.js
@@ -107,6 +107,12 @@
 
             this.autoSort = true;
             this.transform.identity();
+            
+            /**
+             * Used by the debug panel plugin
+             * @ignore
+             */
+            this.drawCount = 0;
         },
 
 
@@ -732,6 +738,8 @@
         draw : function (context, rect) {
             var viewport = me.game.viewport;
             var isFloating = false;
+            
+            this.drawCount = 0;
 
             context.save();
 
@@ -766,6 +774,8 @@
                     if (isFloating === true) {
                         context.restore();
                     }
+                    
+                    this.drawCount++;
                 }
             }
 


### PR DESCRIPTION
Adding prototype variables at runtime causes JS engines like V8 to setup a new hidden type, which is inefficient
