### PR TITLE
Viewport bounds not set with isometric map

### DIFF
--- a/src/level/TMXLayer.js
+++ b/src/level/TMXLayer.js
@@ -393,8 +393,13 @@
             this.setOpacity(visible ? parseFloat(layer[me.TMX_TAG_OPACITY]) : 0);
 
             // layer "real" size
-            this.width = this.cols * this.tilewidth;
-            this.height = this.rows * this.tileheight;
+            if (this.orientation === "isometric") {
+                this.width = (this.cols + this.rows) * (this.tilewidth / 2);
+                this.height = (this.cols + this.rows) * (this.tileheight / 2);
+            } else {
+                this.width = this.cols * this.tilewidth;
+                this.height = this.rows * this.tileheight;
+            }
             // check if we have any user-defined properties
             me.TMXUtils.applyTMXProperties(this, layer);
 

--- a/src/level/TMXMapReader.js
+++ b/src/level/TMXMapReader.js
@@ -166,8 +166,13 @@
             map.rows = parseInt(data[me.TMX_TAG_HEIGHT], 10);
             map.tilewidth = parseInt(data[me.TMX_TAG_TILEWIDTH], 10);
             map.tileheight = parseInt(data[me.TMX_TAG_TILEHEIGHT], 10);
-            map.width = map.cols * map.tilewidth;
-            map.height = map.rows * map.tileheight;
+            if (map.orientation === "isometric") {
+                map.width = (map.cols + map.rows) * (map.tilewidth / 2);
+                map.height = (map.cols + map.rows) * (map.tileheight / 2);
+            } else {
+                map.width = map.cols * map.tilewidth;
+                map.height = map.rows * map.tileheight;
+            }
             map.backgroundcolor = data[me.TMX_BACKGROUND_COLOR];
             map.z = zOrder++;
 


### PR DESCRIPTION
Init map sets viewport bounds according to orthogonal map which is not
right for isometric map.
