### PR TITLE
#258

### DIFF
--- a/src/input/pointer.js
+++ b/src/input/pointer.js
@@ -144,12 +144,6 @@
     var viewportOffset = new me.Vector2d();
 
     /**
-     * Array of object containing changed touch information (iOS event model)
-     * @ignore
-     */
-    var changedTouches = [];
-
-    /**
      * cache value for the offset of the canvas position within the page
      * @ignore
      */
@@ -174,7 +168,7 @@
     function enablePointerEvent() {
         if (!pointerInitialized) {
             // initialize mouse pos (0,0)
-            changedTouches.push({ x: 0, y: 0 });
+            // changedTouches.push({ x: 0, y: 0 });
             obj.mouse.pos = new me.Vector2d(0, 0);
             // get relative canvas position in the page
             obj._offset = me.video.getPos();
@@ -241,7 +235,7 @@
      * propagate events to registered objects
      * @ignore
      */
-    function dispatchEvent(e) {
+    function dispatchEvent(e, changedTouches) {
         var handled = false;
         var handlers = evtHandlers[e.type];
 
@@ -314,8 +308,8 @@
     function updateCoordFromEvent(event) {
         var local;
 
-        // reset the touch array cache
-        changedTouches.length = 0;
+        // touch array cache
+        var changedTouches = [];
 
         // PointerEvent or standard Mouse event
         if (!event.touches) {
@@ -334,13 +328,14 @@
         }
         // if event.isPrimary is defined and false, return
         if (event.isPrimary === false) {
-            return;
+            return changedTouches;
         }
         // Else use the first entry to simulate mouse event
         obj.mouse.pos.set(
             changedTouches[0].x,
             changedTouches[0].y
         );
+		return changedTouches;
     }
 
 
@@ -364,8 +359,9 @@
                 // Webkit also support wheelDeltaX
                 e.wheelDeltaX && (_event.deltaX = - 1 / 40 * e.wheelDeltaX);
             }
+			var changedTouches = updateCoordFromEvent(_event);
             // dispatch mouse event to registered object
-            if (dispatchEvent(_event)) {
+            if (dispatchEvent(_event, changedTouches)) {
                 // prevent default action
                 return obj._preventDefault(e);
             }
@@ -380,9 +376,9 @@
      */
     function onMoveEvent(e) {
         // update position
-        updateCoordFromEvent(e);
+        var changedTouches = updateCoordFromEvent(e);
         // dispatch mouse event to registered object
-        if (dispatchEvent(e)) {
+        if (dispatchEvent(e, changedTouches)) {
             // prevent default action
             return obj._preventDefault(e);
         }
@@ -395,10 +391,10 @@
      */
     function onPointerEvent(e) {
         // update the pointer position
-        updateCoordFromEvent(e);
+        var changedTouches = updateCoordFromEvent(e);
 
         // dispatch event to registered objects
-        if (dispatchEvent(e)) {
+        if (dispatchEvent(e, changedTouches)) {
             // prevent default action
             return obj._preventDefault(e);
         }

--- a/src/input/pointer.js
+++ b/src/input/pointer.js
@@ -136,8 +136,8 @@
     var POINTER_DOWN    = 2;
     var POINTER_UP      = 3;
     var POINTER_CANCEL  = 4;
-	var POINTER_ENTER	= 5;
-	var POINTER_LEAVE	= 6;
+    var POINTER_ENTER   = 5;
+    var POINTER_LEAVE   = 6;
 
     /**
      * cache value for the offset of the canvas position within the page
@@ -239,139 +239,139 @@
      */
     function dispatchEvent(e, changedTouches) {
         var handled = false;
-		
+        
         for (var guid in evtHandlers) {
-			if (evtHandlers.hasOwnProperty(guid)) {
-				var handlers = evtHandlers[guid];
-				// get the current screen to world offset
-				me.game.viewport.localToWorld(0, 0, viewportOffset);
-				for (var t = 0, tl = changedTouches.length; t < tl; t++) {
-					// Do not fire older events
-					if (typeof(e.timeStamp) !== "undefined") {
-						if (e.timeStamp < lastTimeStamp) {
-							continue;
-						}
-						lastTimeStamp = e.timeStamp;
-					}
+            if (evtHandlers.hasOwnProperty(guid)) {
+                var handlers = evtHandlers[guid];
+                // get the current screen to world offset
+                me.game.viewport.localToWorld(0, 0, viewportOffset);
+                for (var t = 0, tl = changedTouches.length; t < tl; t++) {
+                    // Do not fire older events
+                    if (typeof(e.timeStamp) !== "undefined") {
+                        if (e.timeStamp < lastTimeStamp) {
+                            continue;
+                        }
+                        lastTimeStamp = e.timeStamp;
+                    }
 
-					// if PointerEvent is not supported
-					if (!me.device.pointerEnabled) {
-						// -> define pointerId to simulate the PointerEvent standard
-						e.pointerId = changedTouches[t].id;
-					}
+                    // if PointerEvent is not supported
+                    if (!me.device.pointerEnabled) {
+                        // -> define pointerId to simulate the PointerEvent standard
+                        e.pointerId = changedTouches[t].id;
+                    }
 
-					/* Initialize the two coordinate space properties. */
-					e.gameScreenX = changedTouches[t].x;
-					e.gameScreenY = changedTouches[t].y;
-					e.gameWorldX = e.gameScreenX + viewportOffset.x;
-					e.gameWorldY = e.gameScreenY + viewportOffset.y;
-					if (handlers.rect.floating === true) {
-						e.gameX = e.gameScreenX;
-						e.gameY = e.gameScreenY;
-					} else {
-						e.gameX = e.gameWorldX;
-						e.gameY = e.gameWorldY;
-					}
-					var eventInBounds = handlers.rect.getBounds().containsPoint(e.gameX, e.gameY);
-					
-					switch (activeEventList.indexOf(e.type)) {
-						case POINTER_MOVE:
-							var i, callback;
-							if (handlers.pointerId === e.pointerId) {
-								if (eventInBounds) {
-									// pointer defined & inside of bounds: trigger the POINTER_MOVE callback
-									if (handlers.callbacks[e.type]) {
-										for (i = handlers.callbacks[e.type].length - 1; (callback = handlers.callbacks[e.type][i]); i--) {
-											if (callback(e) === false) {
-												// stop propagating the event if return false
-												handled = true;
-												break;
-											}
-										}
-									}
-								} else {
-									// moved out of bounds: trigger the POINTER_LEAVE callbacks instead
-									if (handlers.callbacks[activeEventList[POINTER_LEAVE]]) {
-										for (i = handlers.callbacks[activeEventList[POINTER_LEAVE]].length - 1; (callback = handlers.callbacks[activeEventList[POINTER_LEAVE]][i]); i--) {
-											// delete the pointerId
-											handlers.pointerId = null;
-											if (callback(e) === false) {
-												// stop propagating the event if return false
-												handled = true;
-												break;
-											}
-										}
-									}
-								}
-							} else if (handlers.pointerId === null && eventInBounds) {
-								// no pointer & moved inside of bounds: trigger the POINTER_ENTER callbacks instead
-								if (handlers.callbacks[activeEventList[POINTER_ENTER]]) {
-									for (i = handlers.callbacks[activeEventList[POINTER_ENTER]].length - 1; (callback = handlers.callbacks[activeEventList[POINTER_ENTER]][i]); i--) {
-										// save the pointerId
-										handlers.pointerId = e.pointerId;
-										if (callback(e) === false) {
-											// stop propagating the event if return false
-											handled = true;
-											break;
-										}
-									}
-								}
-							}
-							break;
-						case POINTER_DOWN:
-							// event inside of bounds: trigger the POINTER_DOWN callback
-							if (eventInBounds) {
-								// save the pointerId
-								handlers.pointerId = e.pointerId;
-								// trigger the corresponding callback
-								if (handlers.callbacks[e.type]) {
-									for (i = handlers.callbacks[e.type].length - 1; (callback = handlers.callbacks[e.type][i]); i--) {
-										if (callback(e) === false) {
-											// stop propagating the event if return false
-											handled = true;
-											break;
-										}
-									}
-								}
-							}
-							break;
-						case POINTER_UP:
-							// pointer defined & inside of bounds: trigger the POINTER_UP callback
-							if (handlers.pointerId === e.pointerId && eventInBounds) {
-								// delete the pointerId
-								handlers.pointerId = null;
-								// trigger the corresponding callback
-								if (handlers.callbacks[e.type]) {
-									for (i = handlers.callbacks[e.type].length - 1; (callback = handlers.callbacks[e.type][i]); i--) {
-										if (callback(e) === false) {
-											// stop propagating the event if return false
-											handled = true;
-											break;
-										}
-									}
-								}
-							}
-							break;
-						case POINTER_CANCEL:
-							// pointer defined: trigger the POINTER_CANCEL callback
-							if (handlers.pointerId === e.pointerId) {
-								// delete the pointerId
-								handlers.pointerId = null;
-								// trigger the corresponding callback
-								if (handlers.callbacks[e.type]) {
-									for (i = handlers.callbacks[e.type].length - 1; (callback = handlers.callbacks[e.type][i]); i--) {
-										if (callback(e) === false) {
-											// stop propagating the event if return false
-											handled = true;
-											break;
-										}
-									}
-								}
-							}
-							break;
-					}
-				}
-			}
+                    /* Initialize the two coordinate space properties. */
+                    e.gameScreenX = changedTouches[t].x;
+                    e.gameScreenY = changedTouches[t].y;
+                    e.gameWorldX = e.gameScreenX + viewportOffset.x;
+                    e.gameWorldY = e.gameScreenY + viewportOffset.y;
+                    if (handlers.rect.floating === true) {
+                        e.gameX = e.gameScreenX;
+                        e.gameY = e.gameScreenY;
+                    } else {
+                        e.gameX = e.gameWorldX;
+                        e.gameY = e.gameWorldY;
+                    }
+                    var eventInBounds = handlers.rect.getBounds().containsPoint(e.gameX, e.gameY);
+                    
+                    switch (activeEventList.indexOf(e.type)) {
+                        case POINTER_MOVE:
+                            var i, callback;
+                            if (handlers.pointerId === e.pointerId) {
+                                if (eventInBounds) {
+                                    // pointer defined & inside of bounds: trigger the POINTER_MOVE callback
+                                    if (handlers.callbacks[e.type]) {
+                                        for (i = handlers.callbacks[e.type].length - 1; (callback = handlers.callbacks[e.type][i]); i--) {
+                                            if (callback(e) === false) {
+                                                // stop propagating the event if return false
+                                                handled = true;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    // moved out of bounds: trigger the POINTER_LEAVE callbacks instead
+                                    if (handlers.callbacks[activeEventList[POINTER_LEAVE]]) {
+                                        for (i = handlers.callbacks[activeEventList[POINTER_LEAVE]].length - 1; (callback = handlers.callbacks[activeEventList[POINTER_LEAVE]][i]); i--) {
+                                            // delete the pointerId
+                                            handlers.pointerId = null;
+                                            if (callback(e) === false) {
+                                                // stop propagating the event if return false
+                                                handled = true;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            } else if (handlers.pointerId === null && eventInBounds) {
+                                // no pointer & moved inside of bounds: trigger the POINTER_ENTER callbacks instead
+                                if (handlers.callbacks[activeEventList[POINTER_ENTER]]) {
+                                    for (i = handlers.callbacks[activeEventList[POINTER_ENTER]].length - 1; (callback = handlers.callbacks[activeEventList[POINTER_ENTER]][i]); i--) {
+                                        // save the pointerId
+                                        handlers.pointerId = e.pointerId;
+                                        if (callback(e) === false) {
+                                            // stop propagating the event if return false
+                                            handled = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+                        case POINTER_DOWN:
+                            // event inside of bounds: trigger the POINTER_DOWN callback
+                            if (eventInBounds) {
+                                // save the pointerId
+                                handlers.pointerId = e.pointerId;
+                                // trigger the corresponding callback
+                                if (handlers.callbacks[e.type]) {
+                                    for (i = handlers.callbacks[e.type].length - 1; (callback = handlers.callbacks[e.type][i]); i--) {
+                                        if (callback(e) === false) {
+                                            // stop propagating the event if return false
+                                            handled = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+                        case POINTER_UP:
+                            // pointer defined & inside of bounds: trigger the POINTER_UP callback
+                            if (handlers.pointerId === e.pointerId && eventInBounds) {
+                                // delete the pointerId
+                                handlers.pointerId = null;
+                                // trigger the corresponding callback
+                                if (handlers.callbacks[e.type]) {
+                                    for (i = handlers.callbacks[e.type].length - 1; (callback = handlers.callbacks[e.type][i]); i--) {
+                                        if (callback(e) === false) {
+                                            // stop propagating the event if return false
+                                            handled = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+                        case POINTER_CANCEL:
+                            // pointer defined: trigger the POINTER_CANCEL callback
+                            if (handlers.pointerId === e.pointerId) {
+                                // delete the pointerId
+                                handlers.pointerId = null;
+                                // trigger the corresponding callback
+                                if (handlers.callbacks[e.type]) {
+                                    for (i = handlers.callbacks[e.type].length - 1; (callback = handlers.callbacks[e.type][i]); i--) {
+                                        if (callback(e) === false) {
+                                            // stop propagating the event if return false
+                                            handled = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+                    }
+                }
+            }
         }
         return handled;
     }
@@ -410,7 +410,7 @@
             changedTouches[0].x,
             changedTouches[0].y
         );
-		return changedTouches;
+        return changedTouches;
     }
 
 
@@ -434,7 +434,7 @@
                 // Webkit also support wheelDeltaX
                 e.wheelDeltaX && (_event.deltaX = - 1 / 40 * e.wheelDeltaX);
             }
-			var changedTouches = updateCoordFromEvent(_event);
+            var changedTouches = updateCoordFromEvent(_event);
             // dispatch mouse event to registered object
             if (dispatchEvent(_event, changedTouches)) {
                 // prevent default action
@@ -643,26 +643,26 @@
         if (pointerEventList !== activeEventList) {
             eventType = activeEventList[pointerEventList.indexOf(eventType)];
         }
-		
-		// allocated a GUID value if not present
-		if (!rect.GUID) {
-			rect.GUID = me.utils.createGUID();
-		}
-		
+        
+        // allocated a GUID value if not present
+        if (!rect.GUID) {
+            rect.GUID = me.utils.createGUID();
+        }
+        
         // register the event
         if (!evtHandlers[rect.GUID]) {
             evtHandlers[rect.GUID] = {
-				rect : rect,
-				callbacks : {},
-				pointerId : null,
-			};
+                rect : rect,
+                callbacks : {},
+                pointerId : null,
+            };
         }
-		
-		// allocate array if not defined
-		if (!evtHandlers[rect.GUID].callbacks[eventType]) {
-			evtHandlers[rect.GUID].callbacks[eventType] = [];
-		}
-		
+        
+        // allocate array if not defined
+        if (!evtHandlers[rect.GUID].callbacks[eventType]) {
+            evtHandlers[rect.GUID].callbacks[eventType] = [];
+        }
+        
         // initialize the handler
         evtHandlers[rect.GUID].callbacks[eventType].push(callback);
         return;
@@ -692,10 +692,10 @@
             eventType = activeEventList[pointerEventList.indexOf(eventType)];
         }
 
-		// unregister all callbacks of "eventType" for object "rect"
-		while (evtHandlers[rect.GUID].callbacks[eventType].length > 0) {
-			evtHandlers[rect.GUID].callbacks[eventType].pop();
-		}
+        // unregister all callbacks of "eventType" for object "rect"
+        while (evtHandlers[rect.GUID].callbacks[eventType].length > 0) {
+            evtHandlers[rect.GUID].callbacks[eventType].pop();
+        }
     };
 
     /**

--- a/src/input/pointer.js
+++ b/src/input/pointer.js
@@ -146,6 +146,12 @@
     var viewportOffset = new me.Vector2d();
 
     /**
+     * Array of object containing changed touch information (iOS event model)
+     * @ignore
+     */
+    var changedTouches = [];
+
+    /**
      * cache value for the offset of the canvas position within the page
      * @ignore
      */
@@ -170,7 +176,7 @@
     function enablePointerEvent() {
         if (!pointerInitialized) {
             // initialize mouse pos (0,0)
-            // changedTouches.push({ x: 0, y: 0 });
+            changedTouches.push({ x: 0, y: 0 });
             obj.mouse.pos = new me.Vector2d(0, 0);
             // get relative canvas position in the page
             obj._offset = me.video.getPos();
@@ -237,7 +243,7 @@
      * propagate events to registered objects
      * @ignore
      */
-    function dispatchEvent(e, changedTouches) {
+    function dispatchEvent(e) {
         var handled = false;
         
         for (var guid in evtHandlers) {
@@ -383,8 +389,8 @@
     function updateCoordFromEvent(event) {
         var local;
 
-        // touch array cache
-        var changedTouches = [];
+        // reset the touch array cache
+        changedTouches.length = 0;
 
         // PointerEvent or standard Mouse event
         if (!event.touches) {
@@ -403,14 +409,13 @@
         }
         // if event.isPrimary is defined and false, return
         if (event.isPrimary === false) {
-            return changedTouches;
+            return;
         }
         // Else use the first entry to simulate mouse event
         obj.mouse.pos.set(
             changedTouches[0].x,
             changedTouches[0].y
         );
-        return changedTouches;
     }
 
 
@@ -434,9 +439,8 @@
                 // Webkit also support wheelDeltaX
                 e.wheelDeltaX && (_event.deltaX = - 1 / 40 * e.wheelDeltaX);
             }
-            var changedTouches = updateCoordFromEvent(_event);
             // dispatch mouse event to registered object
-            if (dispatchEvent(_event, changedTouches)) {
+            if (dispatchEvent(_event)) {
                 // prevent default action
                 return obj._preventDefault(e);
             }
@@ -451,9 +455,9 @@
      */
     function onMoveEvent(e) {
         // update position
-        var changedTouches = updateCoordFromEvent(e);
+        updateCoordFromEvent(e);
         // dispatch mouse event to registered object
-        if (dispatchEvent(e, changedTouches)) {
+        if (dispatchEvent(e)) {
             // prevent default action
             return obj._preventDefault(e);
         }
@@ -466,10 +470,10 @@
      */
     function onPointerEvent(e) {
         // update the pointer position
-        var changedTouches = updateCoordFromEvent(e);
+        updateCoordFromEvent(e);
 
         // dispatch event to registered objects
-        if (dispatchEvent(e, changedTouches)) {
+        if (dispatchEvent(e)) {
             // prevent default action
             return obj._preventDefault(e);
         }

--- a/src/input/pointer.js
+++ b/src/input/pointer.js
@@ -93,8 +93,8 @@
         "pointerdown",
         "pointerup",
         "pointercancel",
-        undefined,
-        undefined
+        "pointerenter",
+        "pointerleave"
     ];
 
     // previous MS prefixed pointer event type
@@ -104,8 +104,8 @@
         "MSPointerDown",
         "MSPointerUp",
         "MSPointerCancel",
-        undefined,
-        undefined
+        "MSPointerEnter",
+        "MSPointerLeave"
     ];
 
     // legacy mouse event type
@@ -115,8 +115,8 @@
         "mousedown",
         "mouseup",
         undefined,
-        undefined,
-        undefined
+        "mouseenter",
+        "mouseleave"
     ];
 
     // iOS style touch event type
@@ -126,8 +126,8 @@
         "touchstart",
         "touchend",
         "touchcancel",
-        undefined,
-        undefined
+        "touchenter",
+        "touchleave"
     ];
 
     // internal constants
@@ -136,6 +136,8 @@
     var POINTER_DOWN    = 2;
     var POINTER_UP      = 3;
     var POINTER_CANCEL  = 4;
+	var POINTER_ENTER	= 5;
+	var POINTER_LEAVE	= 6;
 
     /**
      * cache value for the offset of the canvas position within the page

--- a/src/renderable/GUI.js
+++ b/src/renderable/GUI.js
@@ -96,6 +96,9 @@
             // register on mouse event
             me.input.registerPointerEvent("pointerdown", this, this.clicked.bind(this));
             me.input.registerPointerEvent("pointerup", this, this.release.bind(this));
+			me.input.registerPointerEvent("pointerenter", this, this.clicked.bind(this));
+			me.input.registerPointerEvent("pointerleave", this, this.release.bind(this));
+			me.input.registerPointerEvent("pointercancel", this, this.release.bind(this));
         },
 
         /**
@@ -118,20 +121,31 @@
          * @ignore
          */
         clicked : function (event) {
-            if (this.isClickable) {
-                this.updated = true;
-                if (this.isHoldable) {
-                    if (this.holdTimeout !== null) {
-                        me.timer.clearTimeout(this.holdTimeout);
-                    }
-                    this.holdTimeout = me.timer.setTimeout(this.hold.bind(this), this.holdThreshold, false);
-                    this.released = false;
-                }
-                return this.onClick(event);
-            }
+			// Check if left mouse button is pressed OR if device has touch
+			if ((event.which === 1 || me.device.touch) && this.isClickable) {
+				this.updated = true;
+				if (this.isHoldable) {
+					if (this.holdTimeout !== null) {
+						me.timer.clearTimeout(this.holdTimeout);
+					}
+					this.holdTimeout = me.timer.setTimeout(this.hold.bind(this), this.holdThreshold, false);
+					this.released = false;
+				}
+				return this.onClick(event);
+			}
         },
 
         /**
+         * function callback for the pointerup event
+         * @ignore
+         */
+        release : function (event) {
+            this.released = true;
+            me.timer.clearTimeout(this.holdTimeout);
+            return this.onRelease(event);
+        },
+		
+		/**
          * function called when the object is clicked <br>
          * to be extended <br>
          * return false if we need to stop propagating the event
@@ -143,16 +157,6 @@
          */
         onClick : function () {
             return false;
-        },
-
-        /**
-         * function callback for the pointerup event
-         * @ignore
-         */
-        release : function (event) {
-            this.released = true;
-            me.timer.clearTimeout(this.holdTimeout);
-            return this.onRelease(event);
         },
 
         /**
@@ -203,6 +207,9 @@
         onDestroyEvent : function () {
             me.input.releasePointerEvent("pointerdown", this);
             me.input.releasePointerEvent("pointerup", this);
+			me.input.releasePointerEvent("pointerenter", this);
+			me.input.releasePointerEvent("pointerleave", this);
+			me.input.releasePointerEvent("pointercancel", this);
             me.timer.clearTimeout(this.holdTimeout);
         }
     });

--- a/src/renderable/GUI.js
+++ b/src/renderable/GUI.js
@@ -96,9 +96,9 @@
             // register on mouse event
             me.input.registerPointerEvent("pointerdown", this, this.clicked.bind(this));
             me.input.registerPointerEvent("pointerup", this, this.release.bind(this));
-			me.input.registerPointerEvent("pointerenter", this, this.clicked.bind(this));
-			me.input.registerPointerEvent("pointerleave", this, this.release.bind(this));
-			me.input.registerPointerEvent("pointercancel", this, this.release.bind(this));
+            me.input.registerPointerEvent("pointerenter", this, this.clicked.bind(this));
+            me.input.registerPointerEvent("pointerleave", this, this.release.bind(this));
+            me.input.registerPointerEvent("pointercancel", this, this.release.bind(this));
         },
 
         /**
@@ -121,18 +121,18 @@
          * @ignore
          */
         clicked : function (event) {
-			// Check if left mouse button is pressed OR if device has touch
-			if ((event.which === 1 || me.device.touch) && this.isClickable) {
-				this.updated = true;
-				if (this.isHoldable) {
-					if (this.holdTimeout !== null) {
-						me.timer.clearTimeout(this.holdTimeout);
-					}
-					this.holdTimeout = me.timer.setTimeout(this.hold.bind(this), this.holdThreshold, false);
-					this.released = false;
-				}
-				return this.onClick(event);
-			}
+            // Check if left mouse button is pressed OR if device has touch
+            if ((event.which === 1 || me.device.touch) && this.isClickable) {
+                this.updated = true;
+                if (this.isHoldable) {
+                    if (this.holdTimeout !== null) {
+                        me.timer.clearTimeout(this.holdTimeout);
+                    }
+                    this.holdTimeout = me.timer.setTimeout(this.hold.bind(this), this.holdThreshold, false);
+                    this.released = false;
+                }
+                return this.onClick(event);
+            }
         },
 
         /**
@@ -144,8 +144,8 @@
             me.timer.clearTimeout(this.holdTimeout);
             return this.onRelease(event);
         },
-		
-		/**
+        
+        /**
          * function called when the object is clicked <br>
          * to be extended <br>
          * return false if we need to stop propagating the event
@@ -207,9 +207,9 @@
         onDestroyEvent : function () {
             me.input.releasePointerEvent("pointerdown", this);
             me.input.releasePointerEvent("pointerup", this);
-			me.input.releasePointerEvent("pointerenter", this);
-			me.input.releasePointerEvent("pointerleave", this);
-			me.input.releasePointerEvent("pointercancel", this);
+            me.input.releasePointerEvent("pointerenter", this);
+            me.input.releasePointerEvent("pointerleave", this);
+            me.input.releasePointerEvent("pointercancel", this);
             me.timer.clearTimeout(this.holdTimeout);
         }
     });


### PR DESCRIPTION
I've finally been able to modify the event system.
##### pointer.js
I needed to modify the structure that keeps the reference of handlers for many reasons:
* when a _pointermove_ event goes out or inside the bounds of a rect, when need to fire _pointerleave_ or _pointerenter_ events. But for this to happen we need to process _pointermove_ events even if the object is not listening for them, because it may be listening for _pointerleave_ or _pointerenter_ instead.
* we needed a way to access to all the callbacks tied to a specific __rect__, in order to dispatch the right event
* we needed every callback to being able to access the pointerId, in order to know if the object is already clicked or not and by what touch

The "evtHandlers" structure is now a dictionary where the objects gets saved by their GUID (they are assigned one if they don't have it). For each object we save:
```javascript
evtHandlers[rect.GUID] = {
	rect : rect,		// the rect reference
	callbacks : {},		// a callbacks dictionary (to be accessed with the event names)
	pointerId : null,	// needed at this level, accessible for every callback
};
```
The callback dictionary contains, for each event name, an array containing callbacks.
Every time a pointerEventCallback gets registered, it's pushed into this array (this is pretty much how it was before, just a level deeper into the structure):
```javascript
evtHandlers[rect.GUID].callbacks[eventType].push(callback);
};
```
##### GUI.js
I also modified the GUI_Object to use the new event system.
I tested it on Google Chrome and on CocoonJS on Android (it finally handles correctly when a touch slides off the screen: it fires a "pointerCancel" and the button goes unpressed. It also behaved good when sliding a finger between 2 buttons: fires "pointerEnter" and "pointerLeave", the buttons get pressed and unpressed correctly).

It may need other tests, though.