### PR TITLE
Fix for flat-top hexagonal rendering bug

### DIFF
--- a/src/level/TMXRenderer.js
+++ b/src/level/TMXRenderer.js
@@ -483,10 +483,10 @@
 				if(this.staggerindex === "odd")
 				{
 					y = r * (this.tileheight + this.sidelengthy);
-					y = y + (this.rowheight*(r&1));
+					y = y + (this.rowheight*(q&1));
 				} else {
 					y = r * (this.tileheight + this.sidelengthy);
-					y = y + (this.rowheight*(1-(r&1)));
+					y = y + (this.rowheight*(1-(q&1)));
 				}
 			}
 			else //pointy top


### PR DESCRIPTION
Corrected staggering logic for flat top hexagons. Will add a flat-top example later to show that the rendering works fine for both types of rotation but wanted to get this bug fix in ASAP.