### PR TITLE
Patched Object.extend simple inheritance to fix conflict with Facebook SDK

### DIFF
--- a/examples/particles/js/editor/controls.js
+++ b/examples/particles/js/editor/controls.js
@@ -1,7 +1,7 @@
 (function() {
     var pe = game.ParticleEditor = game.ParticleEditor || {};
 
-    pe.EmitterList = Object.extend({
+    pe.EmitterList = me.Object.extend({
         init : function(emitterController, container) {
             this.emitterController = emitterController;
             this.emitters = [];
@@ -137,7 +137,7 @@
         }
     });
 
-    pe.EmitterController = Object.extend({
+    pe.EmitterController = me.Object.extend({
         init : function(container) {
             this.widgets = [];
             this.ingameWidgets = [];
@@ -419,7 +419,7 @@
         },
     });
 
-    pe.CodeGenerator = Object.extend({
+    pe.CodeGenerator = me.Object.extend({
         init : function(controller, container) {
             this.emitter = null;
             this.syncId = null;

--- a/examples/particles/js/editor/widgets.js
+++ b/examples/particles/js/editor/widgets.js
@@ -1,7 +1,7 @@
 (function() {
     var pe = game.ParticleEditor = game.ParticleEditor || {};
 
-    pe.PropertyWrapper = Object.extend({
+    pe.PropertyWrapper = me.Object.extend({
         init : function(propertyName) {
             this.object = null;
             this.propertyPath = propertyName.split(".");
@@ -35,7 +35,7 @@
         },
     });
 
-    pe.WidgetBase = Object.extend({
+    pe.WidgetBase = me.Object.extend({
         init : function(propertyName) {
             this.property = new pe.PropertyWrapper(propertyName);
             this.rootNode = null;

--- a/plugins/debug/debugPanel.js
+++ b/plugins/debug/debugPanel.js
@@ -21,7 +21,7 @@
 
     var DEBUG_HEIGHT = 50;
 
-    var Counters = Object.extend({
+    var Counters = me.Object.extend({
         init : function (stats) {
             this.stats = {};
             this.reset(stats);

--- a/src/lang/error.js
+++ b/src/lang/error.js
@@ -17,6 +17,15 @@
  * @constructor
  * @param {String} msg Error message.
  */
+
+/**
+* First, grab the extend method from me.BaseClass.prototype
+* and attach it to Error object
+*/
+if (!Error.extend) {
+    Error.extend = me.Object.extend;
+}
+
 me.Error = Error.extend({
     init : function (msg) {
         this.name = "me.Error";

--- a/src/lang/error.js
+++ b/src/lang/error.js
@@ -19,7 +19,7 @@
  */
 
 /**
-* First, grab the extend method from me.BaseClass.prototype
+* First, grab the extend method from me.Object
 * and attach it to Error object
 */
 if (!Error.extend) {

--- a/src/lang/object.js
+++ b/src/lang/object.js
@@ -217,7 +217,7 @@ if (!Object.assign) {
  * console.log(r instanceof Ninja); // => false
  */
 (function () {
-    Object.defineProperty(me.BaseClass.prototype, "extend", {
+    Object.defineProperty(me.Object, "extend", {
         "value" : function () {
             var methods = {};
             var mixins = new Array(arguments.length);

--- a/src/lang/object.js
+++ b/src/lang/object.js
@@ -165,7 +165,7 @@ if (!Object.assign) {
  * prototype.
  * @return {Object}
  * @example
- * var Person = Object.extend({
+ * var Person = me.Object.extend({
  *     "init" : function (isDancing) {
  *         this.dancing = isDancing;
  *     },
@@ -217,7 +217,7 @@ if (!Object.assign) {
  * console.log(r instanceof Ninja); // => false
  */
 (function () {
-    Object.defineProperty(Object.prototype, "extend", {
+    Object.defineProperty(me.BaseClass.prototype, "extend", {
         "value" : function () {
             var methods = {};
             var mixins = new Array(arguments.length);
@@ -260,6 +260,9 @@ if (!Object.assign) {
             Object.defineProperty(Class, "__methods__", {
                 "value" : methods
             });
+
+            // Make this class extendable
+            Class.extend = this.extend;
 
             return Class;
         }

--- a/src/lang/window.js
+++ b/src/lang/window.js
@@ -22,6 +22,19 @@
      */
     window.me = window.me || {};
 
+    /**
+    * Empty BaseClass constructor and prototype attached to 
+    * `me` global object to act as the base class for inheritance 
+    */
+    me.BaseClass = function () {};
+    me.BaseClass.prototype = Object.create(Object);
+
+    /**
+    * Instantiate new me.BaseClass and attach to me.Object
+    * to allow new sub-classes to be created using me.Object.extend
+    */
+    me.Object = new me.BaseClass();
+
     /*
      * DOM loading stuff
      */

--- a/src/lang/window.js
+++ b/src/lang/window.js
@@ -23,17 +23,14 @@
     window.me = window.me || {};
 
     /**
-    * Empty BaseClass constructor and prototype attached to 
+    * me.Object constructor and prototype inherits from Object and is attached to 
     * `me` global object to act as the base class for inheritance 
     */
-    me.BaseClass = function () {};
-    me.BaseClass.prototype = Object.create(Object);
-
-    /**
-    * Instantiate new me.BaseClass and attach to me.Object
-    * to allow new sub-classes to be created using me.Object.extend
-    */
-    me.Object = new me.BaseClass();
+    me.Object = function () {
+        Object.apply(this, arguments);
+    };
+    me.Object.prototype = Object.create(Object.prototype);
+    me.Object.prototype.constructor = me.Object;
 
     /*
      * DOM loading stuff

--- a/src/level/TMXMapReader.js
+++ b/src/level/TMXMapReader.js
@@ -16,7 +16,7 @@
      * @constructor
      * @ignore
      */
-    me.TMXMapReader = Object.extend({
+    me.TMXMapReader = me.Object.extend({
         init: function () {},
 
         readMap: function (map, data) {

--- a/src/level/TMXObjectGroup.js
+++ b/src/level/TMXObjectGroup.js
@@ -19,7 +19,7 @@
      * @memberOf me
      * @constructor
      */
-    me.TMXObjectGroup = Object.extend({
+    me.TMXObjectGroup = me.Object.extend({
         init : function (name, tmxObjGroup, orientation, tilesets, z) {
             /**
              * group name
@@ -128,7 +128,7 @@
      * @memberOf me
      * @constructor
      */
-    me.TMXObject = Object.extend({
+    me.TMXObject = me.Object.extend({
         init :  function (tmxObj, orientation, tilesets, z) {
 
             /**

--- a/src/level/TMXRenderer.js
+++ b/src/level/TMXRenderer.js
@@ -30,7 +30,7 @@
      * @ignore
      * @constructor
      */
-    me.TMXOrthogonalRenderer = Object.extend({
+    me.TMXOrthogonalRenderer = me.Object.extend({
         // constructor
         init: function (cols, rows, tilewidth, tileheight) {
             this.cols = cols;
@@ -160,7 +160,7 @@
      * @ignore
      * @constructor
      */
-    me.TMXIsometricRenderer = Object.extend({
+    me.TMXIsometricRenderer = me.Object.extend({
         // constructor
         init: function (cols, rows, tilewidth, tileheight) {
             this.cols = cols;
@@ -359,7 +359,7 @@
      * @ignore
      * @constructor
      */
-    me.TMXHexagonalRenderer = Object.extend({
+    me.TMXHexagonalRenderer = me.Object.extend({
         
          // constructor
         init: function (cols, rows, tilewidth, tileheight, hexsidelength, staggeraxis, staggerindex) {

--- a/src/level/TMXTileset.js
+++ b/src/level/TMXTileset.js
@@ -15,7 +15,7 @@
      * @memberOf me
      * @constructor
      */
-    me.TMXTileset = Object.extend({
+    me.TMXTileset = me.Object.extend({
         // constructor
         init: function (tileset) {
             var i = 0;
@@ -263,7 +263,7 @@
      * @memberOf me
      * @constructor
      */
-    me.TMXTilesetGroup = Object.extend({
+    me.TMXTilesetGroup = me.Object.extend({
         // constructor
         init: function () {
             this.tilesets = [];

--- a/src/math/matrix2.js
+++ b/src/math/matrix2.js
@@ -16,7 +16,7 @@
      * @param {me.Matrix2d} [mat2d] An instance of me.Matrix2d to copy from
      * @param {Number[]} [arguments...] Matrix elements. See {@link me.Matrix2d.set}
      */
-    me.Matrix2d = Object.extend(
+    me.Matrix2d = me.Object.extend(
     /** @scope me.Matrix2d.prototype */    {
 
         /** @ignore */

--- a/src/math/vector2.js
+++ b/src/math/vector2.js
@@ -14,7 +14,7 @@
      * @param {Number} [x=0] x value of the vector
      * @param {Number} [y=0] y value of the vector
      */
-    me.Vector2d = Object.extend(
+    me.Vector2d = me.Object.extend(
     /** @scope me.Vector2d.prototype */
     {
         /** @ignore */

--- a/src/math/vector3.js
+++ b/src/math/vector3.js
@@ -15,7 +15,7 @@
      * @param {Number} [y=0] y value of the vector
      * @param {Number} [z=0] z value of the vector
      */
-    me.Vector3d = Object.extend(
+    me.Vector3d = me.Object.extend(
     /** @scope me.Vector3d.prototype */
     {
         /** @ignore */

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -28,7 +28,7 @@
         * @memberOf me
         * @constructor
         */
-        singleton.Base = Object.extend(
+        singleton.Base = me.Object.extend(
         /** @scope me.plugin.Base.prototype */
         {
             /** @ignore */
@@ -68,7 +68,7 @@
             if (typeof proto.prototype !== "undefined") {
                 proto = proto.prototype;
             }
-            // reuse the logic behind Object.extend
+            // reuse the logic behind me.Object.extend
             if (typeof(proto[name]) === "function") {
                 // save the original function
                 var _parent = proto[name];

--- a/src/shapes/ellipse.js
+++ b/src/shapes/ellipse.js
@@ -16,7 +16,7 @@
      * @param {Number} w width (diameter) of the ellipse
      * @param {Number} h height (diameter) of the ellipse
      */
-    me.Ellipse = Object.extend(
+    me.Ellipse = me.Object.extend(
     {
         /** @scope me.Ellipse.prototype */
         /** @ignore */

--- a/src/shapes/poly.js
+++ b/src/shapes/poly.js
@@ -20,7 +20,7 @@
      * @param {Number} y origin point of the Polygon
      * @param {me.Vector2d[]} points array of vector defining the Polygon
      */
-    me.Polygon = Object.extend(
+    me.Polygon = me.Object.extend(
     /** @scope me.Polygon.prototype */ {
 
         /** @ignore */

--- a/src/state/state.js
+++ b/src/state/state.js
@@ -18,7 +18,7 @@
      * @constructor
      * @see me.state
      */
-    me.ScreenObject = Object.extend(
+    me.ScreenObject = me.Object.extend(
     /** @scope me.ScreenObject.prototype */
     {
         /** @ignore */

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -176,7 +176,7 @@
      * @param {Number} [b=0] blue component
      * @param {Number} [alpha=1.0] alpha value
      */
-    me.Color = Object.extend(
+    me.Color = me.Object.extend(
     /** @scope me.Color.prototype */
     {
 

--- a/src/video/canvas/texture.js
+++ b/src/video/canvas/texture.js
@@ -39,7 +39,7 @@
      *     me.loader.getImage("spritesheet")
      * );
      */
-    me.CanvasRenderer.prototype.Texture = Object.extend(
+    me.CanvasRenderer.prototype.Texture = me.Object.extend(
     /** @scope me.video.renderer.Texture.prototype */
     {
         /**

--- a/src/video/renderer.js
+++ b/src/video/renderer.js
@@ -23,7 +23,7 @@
      * @param {Number} [options.zoomX=width] The actual width of the canvas with scaling applied
      * @param {Number} [options.zoomY=height] The actual height of the canvas with scaling applied
      */
-    me.Renderer = Object.extend(
+    me.Renderer = me.Object.extend(
     /** @scope me.Renderer.prototype */
     {
         /**

--- a/src/video/texture_cache.js
+++ b/src/video/texture_cache.js
@@ -10,7 +10,7 @@
      * a basic texture cache object
      * @ignore
      */
-    me.Renderer.TextureCache = Object.extend({
+    me.Renderer.TextureCache = me.Object.extend({
         /**
          * @ignore
          */

--- a/src/video/webgl/compositor.js
+++ b/src/video/webgl/compositor.js
@@ -40,7 +40,7 @@
      * @param {me.Matrix2d} matrix Global transformation matrix
      * @param {me.Color} color Global color
      */
-    me.WebGLRenderer.Compositor = Object.extend(
+    me.WebGLRenderer.Compositor = me.Object.extend(
     /** @scope me.WebGLRenderer.Compositor.prototype */
     {
         /**

--- a/tests/spec/inheritance-spec.js
+++ b/tests/spec/inheritance-spec.js
@@ -1,6 +1,6 @@
 describe("Jay Inheritance", function () {
     describe("Simple inheritance tests", function () {
-        var Person = Object.extend({
+        var Person = me.Object.extend({
             "init" : function (isDancing) {
                 this.dancing = isDancing;
             },
@@ -153,7 +153,7 @@ describe("Jay Inheritance", function () {
         });
 
         describe("d = new D()", function () {
-            var A = Object.extend({
+            var A = me.Object.extend({
                 "init" : function () {},
                 "foo" : function () {
                     stepper.step("A.foo");
@@ -203,7 +203,7 @@ describe("Jay Inheritance", function () {
         });
 
         describe("z = new Z()", function () {
-            var X = Object.extend({
+            var X = me.Object.extend({
                 "init" : function () {},
                 "foo" : function () {
                     stepper.step("X.foo");
@@ -249,11 +249,11 @@ describe("Jay Inheritance", function () {
 
     describe("Correctness tests", function () {
         function missingConstructor() {
-            Object.extend({});
+            me.Object.extend({});
         }
 
         function nonMethod() {
-            Object.extend({
+            me.Object.extend({
                 "init" : function () {},
                 "bad" : 0
             });
@@ -270,7 +270,7 @@ describe("Jay Inheritance", function () {
 
 
     describe("Mixin tests", function () {
-        var Base = Object.extend({
+        var Base = me.Object.extend({
             "init" : function () {}
         });
 

--- a/tests/spec/plugin-spec.js
+++ b/tests/spec/plugin-spec.js
@@ -1,6 +1,6 @@
 describe("me.plugin", function () {
     describe("#patch", function () {
-        var BaseObject = Object.extend({
+        var BaseObject = me.Object.extend({
             init : function () {
                 this.name = "John Doe";
             },


### PR DESCRIPTION
Issue: Object.extend in melonJS conflicts with the Facebook SDK causing the SDK to not load properly. melonJS games that try to use the Facebook SDK with melonJS are not able to do so.

Fixes #699. Related to #666. Changes include...

- attached extend property to me.Object rather than Object (i.e. me.Object.extend)
- attached me.Object.extend to Error.extend
- changed all instances of Object.extend to me.Object.extend

Also...
- I updated this jsFiddle with the new changes as well: http://jsfiddle.net/jdrorrer/7z3t2o4s/
- all tests are passing

<img width="194" alt="screen shot 2015-07-07 at 11 49 13 am" src="https://cloud.githubusercontent.com/assets/5571603/8550385/3923d380-249e-11e5-8a4f-3ef2d895656e.png">

The issue can be recreated by forking and building a game built on melonJS that uses the Facebook SDK. A good example of this is Clumsy Bird: https://github.com/ellisonleao/clumsy-bird. It has a Facebook share button when the game ends.

Side note (maybe for a future update):
However, I think an ideal fix (one that should fix #666 completely) would be similar to how string.js uses `S()`: http://stringjs.com/.  melonJS could use the me global and attach all javascript language extensions to it, so that you could call extend like this: `me(Rect).extend`. string.js also has an `extendPrototype()` method. Something like that in melonJS would allow developers to add one line of code in their game and still use `Object.extend()`, `me.Rect.extend()`, etc. the same as they use it today.