### PR TITLE
Fix for Sprite objects initialized with a string argument for "image".

### DIFF
--- a/src/renderable/sprite.js
+++ b/src/renderable/sprite.js
@@ -119,8 +119,8 @@
             // call the super constructor
             this._super(me.Renderable, "init", [
                 x, y,
-                settings.framewidth  || image.width,
-                settings.frameheight || image.height
+                settings.framewidth  || this.image.width,
+                settings.frameheight || this.image.height
             ]);
 
             // update anchorPoint


### PR DESCRIPTION
If you attempt to create a Sprite object by specifying a string corresponding to a preloaded resource, such as:

`this.bg = new me.Sprite(0, 0, {image: "intro_bg"});`

with the current code, you'll get the error `Uncaught me.Vector2d.Error: invalid x,y parameters (not a number)` because you're referring to the `image` passed in as an argument (which is a string, not an object) and thus without any `width` or `height` properties.  These are added by a call a few lines before this:

`this.image = me.utils.getImage(image);`