### PR TITLE
Fix jsdoc for `me.Entity` so that `renderable` reflects that it is a me.Sprite

### DIFF
--- a/src/entity/entity.js
+++ b/src/entity/entity.js
@@ -37,7 +37,7 @@
             /**
              * The entity renderable object (if defined)
              * @public
-             * @type me.Renderable
+             * @type me.Sprite
              * @name renderable
              * @memberOf me.Entity
              */


### PR DESCRIPTION
It is slightly confusing when reading the various code/samples and comparing what APIs are available on the doc site when trying to figure out how to set up animations. My confusion was corrected when I read the source to realize `renderable` was actually a sprite and that the docs listed it as a `Renderable`.