### PR TITLE
[#872] Add touchstart to pointer event check

### DIFF
--- a/src/input/pointer.js
+++ b/src/input/pointer.js
@@ -582,7 +582,7 @@
 
         // check if mapped to a key
         if (keycode) {
-            if (e.type === POINTER_DOWN[0] || e.type === POINTER_DOWN[1] || e.type === POINTER_DOWN[2] || e.type === POINTER_DOWN[3]) {
+            if (POINTER_DOWN.indexOf(e.type) !== -1) {
                 return api._keydown(e, keycode, button + 1);
             }
             else { // 'mouseup' or 'touchend'

--- a/src/input/pointer.js
+++ b/src/input/pointer.js
@@ -582,7 +582,7 @@
 
         // check if mapped to a key
         if (keycode) {
-            if (e.type === POINTER_DOWN[0] || e.type === POINTER_DOWN[1] || e.type === POINTER_DOWN[2]) {
+            if (e.type === POINTER_DOWN[0] || e.type === POINTER_DOWN[1] || e.type === POINTER_DOWN[2] || e.type === POINTER_DOWN[3]) {
                 return api._keydown(e, keycode, button + 1);
             }
             else { // 'mouseup' or 'touchend'


### PR DESCRIPTION
Just adding the 4th element of the POINTER_DOWN array to the check for bound pointer events.