### PR TITLE
Gui_object doesn't play animation

### DIFF
--- a/src/renderable/GUI.js
+++ b/src/renderable/GUI.js
@@ -110,7 +110,7 @@
          * return true if the object has been clicked
          * @ignore
          */
-        update : function () {
+        update : function (dt) {
             if (this.updated) {
                 // clear the flag
                 if (!this.released) {

--- a/src/renderable/GUI.js
+++ b/src/renderable/GUI.js
@@ -118,7 +118,7 @@
                 }
                 return true;
             }
-            return false;
+            return me.Sprite.prototype.update.apply(this, [ dt ]);
         },
 
         /**


### PR DESCRIPTION
My name is Yosua and I'm from Melon Gaming. 

I noticed that the gui object in melonJS can't play animation even though it extends sprite. I try adding super function to gui_object's update function and the animation can start working.