### PR TITLE
Floating renderable's bounds still follows its container position

### DIFF
--- a/src/renderable/container.js
+++ b/src/renderable/container.js
@@ -497,7 +497,7 @@
 
             // Update container's absolute position
             this._absPos.set(newX, newY);
-            if (this.ancestor) {
+            if (this.ancestor && !this.floating) {
                 this._absPos.add(this.ancestor._absPos);
             }
 

--- a/src/renderable/renderable.js
+++ b/src/renderable/renderable.js
@@ -397,7 +397,7 @@
             var bounds = this.getBounds();
             bounds.pos.set(newX, newY, bounds.pos.z);
             // XXX: This is called from the constructor, before it gets an ancestor
-            if (this.ancestor) {
+            if (this.ancestor && !this.floating) {
                 bounds.pos.add(this.ancestor._absPos);
             }
             return bounds;

--- a/src/renderable/sprite.js
+++ b/src/renderable/sprite.js
@@ -510,7 +510,7 @@
                 newY - (this.anchorPoint.y * bounds.height)
             );
             // XXX: This is called from the constructor, before it gets an ancestor
-            if (this.ancestor) {
+            if (this.ancestor && !this.floating) {
                 bounds.pos.add(this.ancestor._absPos);
             }
             return bounds;


### PR DESCRIPTION
When a renderable is floating, the location of the image and the bound is different (the image is floating but the bound still follow its container). I found problem like gui_object become unclickable because of this. However I'm not sure if this can affect other function