### PR TITLE
Directly defining the size of a level in tmx

### DIFF
--- a/src/level/TMXTiledMap.js
+++ b/src/level/TMXTiledMap.js
@@ -185,7 +185,12 @@
 
             // map type (orthogonal or isometric)
             this.orientation = data.orientation;
-            if (this.orientation === "isometric") {
+
+            // manually defined level size
+            if (data.levelWidth && data.levelHeight) {
+                this.width = data.levelWidth;
+                this.height = data.levelHeight;
+            } else if (this.orientation === "isometric") {
                 this.width = (this.cols + this.rows) * (this.tilewidth / 2);
                 this.height = (this.cols + this.rows) * (this.tileheight / 2);
             } else {


### PR DESCRIPTION
Since in the IDE I let the user define their own level size (they don't need to define column and row of the tile layer), I put the size in level json file in levelWidth and levelHeight