### PR TITLE
Shorter _super function

### DIFF
--- a/src/lang/jay-extend.js
+++ b/src/lang/jay-extend.js
@@ -103,8 +103,13 @@
         }
 
         // Apply syntactic sugar for accessing methods on super classes
-        Object.defineProperty(Class.prototype, "_super", {
-            "value" : _super
+        Object.defineProperties(Class.prototype, {
+            "_super": {
+                "value" : _super
+            },
+            "_superClass": {
+                "value" : this
+            }
         });
 
         // Create a hidden property on the class itself
@@ -146,6 +151,11 @@
      * @ignore
      */
     function _super(superClass, method, args) {
+        if (typeof superClass === "string") {
+            args = method;
+            method = superClass;
+            superClass = this._superClass;
+        }
         return superClass.prototype[method].apply(this, args);
     }
 


### PR DESCRIPTION
I have a suggestion, what if we store the reference for the super class whenever an object is extended. This way, the user don't have to write the super class when calling _super function. 
So instead of :
this._super(me.Sprite, 'init', [x, y, settings]);
we can just write:
this._super('init', [x, y, settings]);