### PR TITLE
Remove adjust position for non-tiled map

### DIFF
--- a/src/level/TMXObject.js
+++ b/src/level/TMXObject.js
@@ -186,7 +186,9 @@
             }
 
             // Adjust the Position to match Tiled
-            map.getRenderer().adjustPosition(this);
+            if (map.isTiled) {
+                map.getRenderer().adjustPosition(this);
+            }
 
             // set the object properties
             me.TMXUtils.applyTMXProperties(this, tmxObj);

--- a/src/level/TMXObject.js
+++ b/src/level/TMXObject.js
@@ -186,7 +186,7 @@
             }
 
             // Adjust the Position to match Tiled
-            if (map.isTiled) {
+            if (!map.isEditor) {
                 map.getRenderer().adjustPosition(this);
             }
 

--- a/src/level/TMXTiledMap.js
+++ b/src/level/TMXTiledMap.js
@@ -182,6 +182,7 @@
 
             // tilemap version
             this.version = data.version;
+            this.isTiled = !!data.tiledversion;
 
             // map type (orthogonal or isometric)
             this.orientation = data.orientation;

--- a/src/level/TMXTiledMap.js
+++ b/src/level/TMXTiledMap.js
@@ -182,7 +182,9 @@
 
             // tilemap version
             this.version = data.version;
-            this.isTiled = !!data.tiledversion;
+
+            // Check if map is from melon editor
+            this.isEditor = data.editor === "melon-editor";
 
             // map type (orthogonal or isometric)
             this.orientation = data.orientation;


### PR DESCRIPTION
The object position for isometric map in melon editor and in melonJS is already the same, unlike in tiled, so there is no need to adjust position. 
For now, I use data.tiledversion in the map object to check if a map is from tiled