### PR TITLE
Fixed for Wechat mini game platform.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -167,7 +167,8 @@
     function parseHash() {
         var hash = {};
 
-        if (document.location.hash) {
+        // No "document.location" exist for Wechat mini game platform.
+        if (document.location && document.location.hash) {
             document.location.hash.substr(1).split("&").filter(function (value) {
                 return (value !== "");
             }).forEach(function (value) {


### PR DESCRIPTION
There is no "document.location" for Wechat mini game platform.

![image](https://user-images.githubusercontent.com/39784/48175125-babd0b00-e345-11e8-91a3-5a379a252302.png)
