### PR TITLE
fix container clipping bug

### DIFF
--- a/src/renderable/container.js
+++ b/src/renderable/container.js
@@ -854,9 +854,6 @@
 
             this.drawCount = 0;
 
-            // adjust position if required (e.g. canvas/window centering)
-            renderer.translate(this.pos.x, this.pos.y);
-
             // clip the containter children to the container bounds
             if (this._root === false && this.clipping === true && this.childBounds.isFinite() === true) {
                 renderer.clipRect(
@@ -866,6 +863,9 @@
                     this.childBounds.height
                 );
             }
+
+            // adjust position if required (e.g. canvas/window centering)
+            renderer.translate(this.pos.x, this.pos.y);
 
             for (var i = this.children.length, obj; i--, (obj = this.children[i]);) {
                 if (obj.isRenderable) {


### PR DESCRIPTION
the currect clipping doesn't clip the correct region because it clips at two times the actual position, for example when x=100 the clipping start at x=200. I think the clipping should be done 1st before translating the renderer