### PR TITLE
Corrected incorrect pointer offset - Please check - Critical

### DIFF
--- a/src/input/pointer.js
+++ b/src/input/pointer.js
@@ -245,8 +245,8 @@
 
             this.type = event.type;
 
-            this.gameScreenX = this.pos.x;
-            this.gameScreenY = this.pos.y;
+            this.gameScreenX = event.layerX;
+            this.gameScreenY = event.layerY;
 
             // get the current screen to world offset
             if (typeof me.game.viewport !== "undefined") {


### PR DESCRIPTION
This is a potentially critical problem.  The click was off on an UI click events.. the previous setting this.pos.x  registered to the incorrect location.  I could not exactly nail down which coordinate this.pos.x.  I think it was the clientX which seemed to be consistently different from the canvas element position which is given by either event.layerX/Y  or event.offsetX/Y... So it seems that the clientXY is different from the canvas application position.  I tested this in my application and it seems to work well.