### PR TITLE
Changed this.releasePointerEvent to releasePointerEvent as it was causing a "this is undefined" error.

### DIFF
--- a/src/input/pointerevent.js
+++ b/src/input/pointerevent.js
@@ -771,7 +771,7 @@ export function releasePointerEvent(eventType, region, callback) {
 export function releaseAllPointerEvents(region) {
     if (eventHandlers.has(region)) {
         for (var i = 0; i < pointerEventList.length; i++) {
-            this.releasePointerEvent(pointerEventList[i], region);
+            releasePointerEvent(pointerEventList[i], region);
         }
     };
 };


### PR DESCRIPTION
Dear Olivier, I believe this fixes the bug. I have checked releasePointerEvent and it does not refer to "this" at all. Cheers, Wilson.