### PR TITLE
improve the build scripts to prevent accidental publishes without testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,10 +92,10 @@
     "dist": " npm run build && npm run minify && mkdirp dist && cp -f build/*.js dist/ && npm run types",
     "minify": "terser build/melonjs.js --compress --mangle --comments  '/(?:^!|@(?:license|preserve|cc_on))/' --output build/melonjs.min.js",
     "lint": "eslint src rollup.config.js",
-    "test": "npm run build && karma start tests/karma.conf.cjs",
+    "test": "karma start tests/karma.conf.cjs",
     "doc": "mkdirp docs && jsdoc -c jsdoc_conf.json",
     "webdoc": "mkdirp dist && webdoc --quiet -R README.md",
-    "release": "npm run dist && npm publish --access public",
+    "prepublish": "npm run dist && npm run test",
     "clean": "del-cli --force build/*.js dist/*.js dist/*.d.ts docs src/**/*.d.ts",
     "types": "tsc dist/melonjs.module.js --declaration --allowJs --emitDeclarationOnly"
   }


### PR DESCRIPTION
By overriding publish command (using "prepublish") instead of using the release script we can prevent accidentally doing the publish command without testing (as it's now enforced) and the command is more conventional