### PR TITLE
Fix all DocParser errors in webdoc

### DIFF
--- a/src/entity/entity.js
+++ b/src/entity/entity.js
@@ -95,7 +95,7 @@ class Entity extends Renderable {
         /**
          * the entity body object
          * @public
-         * @type {Body}
+         * @member {Body}
          * @name body
          * @memberof Entity
          */

--- a/src/geometries/poly.js
+++ b/src/geometries/poly.js
@@ -32,7 +32,7 @@ class Polygon {
         /**
          * The bounding rectangle for this shape
          * @ignore
-         * @type {Bounds}
+         * @member {Bounds}
          * @name _bounds
          * @memberof Polygon
          */

--- a/src/input/gamepad.js
+++ b/src/input/gamepad.js
@@ -86,10 +86,7 @@ var remap = new Map();
 
 var updateEventHandler;
 
-/**
- * Default gamepad mappings
- * @ignore
- */
+// Default gamepad mappings
 [
     // Firefox mappings
     [
@@ -261,18 +258,14 @@ var updateGamepads = function () {
     });
 };
 
-/**
- * gamepad connected callback
- * @ignore
- */
+// gamepad connected callback
 if (globalThis.navigator && typeof globalThis.navigator.getGamepads === "function") {
     globalThis.addEventListener("gamepadconnected", function (e) {
         event.emit(event.GAMEPAD_CONNECTED, e.gamepad);
     }, false);
 
-    /**
+    /*
      * gamepad disconnected callback
-     * @ignore
      */
     globalThis.addEventListener("gamepaddisconnected", function (e) {
         event.emit(event.GAMEPAD_DISCONNECTED, e.gamepad);

--- a/src/lang/deprecated.js
+++ b/src/lang/deprecated.js
@@ -4,7 +4,7 @@ import { TextureAtlas } from "./../video/texture/atlas.js";
 import Renderer from "./../video/renderer.js";
 import { Draggable, DropTarget } from "./../renderable/dragndrop.js";
 
-/**
+/*
  * placeholder for all deprecated classes and corresponding alias for backward compatibility
  */
 
@@ -72,8 +72,11 @@ device.turnOffPointerLock = function () {
 };
 
 /**
+ * Alias of {@link TextureAtlas}
+ *
  * @public
  * @name Texture
+ * @class
  * @memberof Renderer#
  * @deprecated since 10.4.0
  * @see TextureAtlas

--- a/src/math/vector2.js
+++ b/src/math/vector2.js
@@ -51,7 +51,7 @@ class Vector2d {
         /**
          * x value of the vector
          * @public
-         * @type {number}
+         * @member {number}
          * @name x
          * @memberof Vector2d
          */
@@ -60,7 +60,7 @@ class Vector2d {
         /**
          * y value of the vector
          * @public
-         * @type {number}
+         * @member {number}
          * @name y
          * @memberof Vector2d
          */
@@ -297,6 +297,7 @@ class Vector2d {
      * return true if the two vectors are the same
      * @name equals
      * @memberof Vector2d
+     * @method
      * @param {Vector2d} v
      * @returns {boolean}
      */

--- a/src/math/vector3.js
+++ b/src/math/vector3.js
@@ -55,7 +55,7 @@ class Vector3d {
         /**
          * x value of the vector
          * @public
-         * @type {number}
+         * @member {number}
          * @name x
          * @memberof Vector3d
          */
@@ -64,7 +64,7 @@ class Vector3d {
         /**
          * y value of the vector
          * @public
-         * @type {number}
+         * @member {number}
          * @name y
          * @memberof Vector3d
          */
@@ -73,7 +73,7 @@ class Vector3d {
         /**
          * z value of the vector
          * @public
-         * @type {number}
+         * @member {number}
          * @name z
          * @memberof Vector3d
          */
@@ -314,6 +314,7 @@ class Vector3d {
      * return true if the two vectors are the same
      * @name equals
      * @memberof Vector3d
+     * @method
      * @param {Vector2d|Vector3d} v
      * @returns {boolean}
      */

--- a/src/physics/body.js
+++ b/src/physics/body.js
@@ -509,6 +509,7 @@ class Body {
 
     /**
      * Returns true if the any of the shape composing the body contains the given point.
+     * @method Body#contains
      * @param {Vector2d} point
      * @returns {boolean} true if contains
      */

--- a/src/renderable/imagelayer.js
+++ b/src/renderable/imagelayer.js
@@ -75,7 +75,7 @@ class ImageLayer extends Sprite {
              * - a number, to change the value for both axis <br>
              * - a json expression like `json:{"x":0.5,"y":0.5}` if you wish to specify a different value for both x and y
              * @public
-             * @type {Vector2d}
+             * @member {Vector2d}
              * @default <0.0,0.0>
              * @name ImageLayer#anchorPoint
              */

--- a/src/state/state.js
+++ b/src/state/state.js
@@ -500,7 +500,6 @@ var state = {
             }
             // if fading effect
             if (_fade.duration && _stages[state].transition) {
-                /** @ignore */
                 _onSwitchComplete = () => {
                     game.viewport.fadeOut(_fade.color, _fade.duration);
                 };

--- a/src/system/device.js
+++ b/src/system/device.js
@@ -5,11 +5,6 @@ import { prefixed } from "./../utils/agent.js";
 import state from "./../state/state.js";
 import * as event from "./../system/event.js";
 
-/**
- * The device capabilities and specific events
- * @namespace device
- */
-
 // private properties
 let accelInitialized = false;
 let deviceOrientationInitialized = false;
@@ -250,6 +245,11 @@ event.on(event.BOOT, () => {
 
 
 // public export
+/**
+ * The device capabilities and specific events
+ *
+ * @namespace
+ */
 let device = {
 
     /**
@@ -257,7 +257,6 @@ let device = {
      * @type {string}
      * @readonly
      * @name ua
-     * @memberof device
      */
     ua : typeof globalThis.navigator !== "undefined" ? globalThis.navigator.userAgent : "",
 
@@ -267,7 +266,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name localStorage
-     * @memberof device
      */
     localStorage : false,
 
@@ -276,7 +274,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name hasAccelerometer
-     * @memberof device
      */
     hasAccelerometer : false,
 
@@ -285,7 +282,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name hasDeviceOrientation
-     * @memberof device
      */
     hasDeviceOrientation : false,
 
@@ -295,7 +291,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name ScreenOrientation
-     * @memberof device
      */
     ScreenOrientation : false,
 
@@ -304,7 +299,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name hasFullscreenSupport
-     * @memberof device
      */
     hasFullscreenSupport : false,
 
@@ -313,7 +307,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name hasPointerLockSupport
-     * @memberof device
      */
     hasPointerLockSupport : false,
 
@@ -322,7 +315,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name hasWebAudio
-     * @memberof device
      */
     hasWebAudio : false,
 
@@ -331,7 +323,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name nativeBase64
-     * @memberof device
      */
     nativeBase64 : (typeof(globalThis.atob) === "function"),
 
@@ -340,7 +331,6 @@ let device = {
      * @type {number}
      * @readonly
      * @name maxTouchPoints
-     * @memberof device
      * @example
      * if (me.device.maxTouchPoints > 1) {
      *     // device supports multi-touch
@@ -353,7 +343,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name touch
-     * @memberof device
      */
     touch : false,
 
@@ -362,7 +351,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name wheel
-     * @memberof device
      */
     wheel : false,
 
@@ -372,7 +360,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name isMobile
-     * @memberof device
      */
     isMobile : false,
 
@@ -381,7 +368,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name iOS
-     * @memberof device
      */
     iOS : false,
 
@@ -390,7 +376,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name android
-     * @memberof device
      */
     android : false,
 
@@ -399,7 +384,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name android2
-     * @memberof device
      */
     android2 : false,
 
@@ -408,7 +392,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name linux
-     * @memberof device
      */
     linux : false,
 
@@ -418,7 +401,6 @@ let device = {
      * @readonly
      * @see http://impactjs.com/ejecta
      * @name ejecta
-     * @memberof device
      */
     ejecta : false,
 
@@ -427,7 +409,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name isWeixin
-     * @memberof device
      */
     isWeixin : false,
 
@@ -436,7 +417,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name nodeJS
-     * @memberof device
      */
     nodeJS : (typeof process !== "undefined") && (process.release.name === "node"),
 
@@ -445,7 +425,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name chromeOS
-     * @memberof device
      */
     chromeOS : false,
 
@@ -454,7 +433,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name wp
-     * @memberof device
      */
     wp : false,
 
@@ -463,7 +441,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name BlackBerry
-     * @memberof device
      */
     BlackBerry : false,
 
@@ -472,7 +449,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name Kindle
-     * @memberof device
      */
     Kindle : false,
 
@@ -483,7 +459,6 @@ let device = {
      * @readonly
      * @name accelerationX
      * @see device.watchAccelerometer
-     * @memberof device
      */
     accelerationX : 0,
 
@@ -494,7 +469,6 @@ let device = {
      * @readonly
      * @name accelerationY
      * @see device.watchAccelerometer
-     * @memberof device
      */
     accelerationY : 0,
 
@@ -505,7 +479,6 @@ let device = {
      * @readonly
      * @name accelerationZ
      * @see device.watchAccelerometer
-     * @memberof device
      */
     accelerationZ : 0,
 
@@ -516,7 +489,6 @@ let device = {
      * @readonly
      * @name gamma
      * @see device.watchDeviceOrientation
-     * @memberof device
      */
     gamma : 0,
 
@@ -527,7 +499,6 @@ let device = {
      * @readonly
      * @name beta
      * @see device.watchDeviceOrientation
-     * @memberof device
      */
     beta: 0,
 
@@ -539,7 +510,6 @@ let device = {
      * @readonly
      * @name alpha
      * @see device.watchDeviceOrientation
-     * @memberof device
      */
     alpha : 0,
 
@@ -551,7 +521,6 @@ let device = {
      * @readonly
      * @see http://www.w3schools.com/tags/ref_language_codes.asp
      * @name language
-     * @memberof device
      */
     language : typeof globalThis.navigator !== "undefined" ? globalThis.navigator.language || globalThis.navigator.browserLanguage || globalThis.navigator.userLanguage || "en" : "en",
 
@@ -559,7 +528,6 @@ let device = {
      * Specify whether to pause the game when losing focus
      * @type {boolean}
      * @default true
-     * @memberof device
      */
     pauseOnBlur : true,
 
@@ -567,7 +535,6 @@ let device = {
      * Specify whether to unpause the game when gaining focus
      * @type {boolean}
      * @default true
-     * @memberof device
      */
     resumeOnFocus : true,
 
@@ -575,7 +542,6 @@ let device = {
      * Specify whether to automatically bring the window to the front
      * @type {boolean}
      * @default true
-     * @memberof device
      */
     autoFocus : true,
 
@@ -584,7 +550,6 @@ let device = {
      * The engine restarts on focus if this is enabled.
      * @type {boolean}
      * @default false
-     * @memberof device
      */
     stopOnBlur : false,
 
@@ -593,7 +558,6 @@ let device = {
      * @type {boolean}
      * @readonly
      * @name OffScreenCanvas
-     * @memberof device
      */
     OffscreenCanvas : false,
 
@@ -1110,10 +1074,9 @@ let device = {
 
 /**
  * Ratio of the resolution in physical pixels to the resolution in CSS pixels for the current display device.
- * @name devicePixelRatio
- * @memberof device
+ * @name device.devicePixelRatio
  * @public
- * @type {number}
+ * @member {number}
  * @readonly
  * @returns {number}
  */
@@ -1128,10 +1091,9 @@ Object.defineProperty(device, "devicePixelRatio", {
 
 /**
  * Returns true if the browser/device is in full screen mode.
- * @name isFullscreen
- * @memberof device
+ * @name device.isFullscreen
  * @public
- * @type {boolean}
+ * @member {boolean}
  * @readonly
  * @returns {boolean}
  */
@@ -1151,10 +1113,9 @@ Object.defineProperty(device, "isFullscreen", {
 
 /**
  * Returns true if the browser/device has audio capabilities.
- * @name sound
- * @memberof device
+ * @name device.sound
  * @public
- * @type {boolean}
+ * @member {boolean}
  * @readonly
  * @returns {boolean}
  */

--- a/src/text/text.js
+++ b/src/text/text.js
@@ -84,7 +84,8 @@ class Text extends Renderable {
         /**
          * defines the color used to draw the font stroke.<br>
          * @public
-         * @type {Color}
+         * @member {Color}
+         * @name strokeStyle
          * @default black
          */
          if (typeof settings.strokeStyle !== "undefined") {

--- a/src/tweens/easing.js
+++ b/src/tweens/easing.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Tween.js - Licensed under the MIT license
  * https://github.com/tweenjs/tween.js
  */

--- a/src/tweens/interpolation.js
+++ b/src/tweens/interpolation.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Tween.js - Licensed under the MIT license
  * https://github.com/tweenjs/tween.js
  */
@@ -76,7 +76,7 @@ export let Interpolation = {
             return fc( n ) / fc( i ) / fc( n - i );
 
         },
-        /** @ignore */
+        /* @ignore */
         Factorial: ( function () {
 
             var a = [ 1 ];

--- a/src/tweens/tween.js
+++ b/src/tweens/tween.js
@@ -4,7 +4,7 @@ import { world, lastUpdate } from "./../game.js";
 import { Easing } from "./easing.js";
 import { Interpolation } from "./interpolation.js";
 
-/**
+/*
  * Tween.js - Licensed under the MIT license
  * https://github.com/tweenjs/tween.js
  */

--- a/src/video/webgl/utils/uniforms.js
+++ b/src/video/webgl/utils/uniforms.js
@@ -47,9 +47,8 @@ export function extractUniforms(gl, shader) {
 
         descriptor[name] = {
             "get" : (function (name) {
-                /**
+                /*
                  * A getter for the uniform location
-                 * @ignore
                  */
                 return function () {
                     return locations[name];
@@ -57,18 +56,16 @@ export function extractUniforms(gl, shader) {
             })(name),
             "set" : (function (name, type, fn) {
                 if (type.indexOf("mat") === 0) {
-                    /**
+                    /*
                      * A generic setter for uniform matrices
-                     * @ignore
                      */
                     return function (val) {
                         gl[fn](locations[name], false, val);
                     };
                 }
                 else {
-                    /**
+                    /*
                      * A generic setter for uniform vectors
-                     * @ignore
                      */
                     return function (val) {
                         var fnv = fn;


### PR DESCRIPTION
* Use @member instead of @type so webdoc knows we're documenting a class member.
* Change `/**` to `/*` where it's not an actual _documentation_ comment.
* Fix the "device" namespace so the namespace is the actual object and remove all @memberof tags pointing to that 
namespace in the object properties (webdoc parses the object properties automatically!)≈
