### PR TITLE
Fix nodeBounds calculation in onresize()

### DIFF
--- a/src/application/resize.js
+++ b/src/application/resize.js
@@ -57,7 +57,7 @@ export function onresize(game) {
         }
 
         // get the maximum canvas size within the parent div containing the canvas container
-        let nodeBounds = device.getParentBounds(game.getParentElement());
+        let nodeBounds = device.getElementBounds(game.getParentElement());
 
         let _max_width = Math.min(canvasMaxWidth, nodeBounds.width);
         let _max_height = Math.min(canvasMaxHeight, nodeBounds.height);


### PR DESCRIPTION
It used to use the dimensions of the parent of the parent of the game, when it should just be the parent. Now we just get the element bounds of the parent element.