### PR TITLE
feat: handle assets load error

### DIFF
--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -302,12 +302,12 @@ export function preload(assets, onloadcb, switchToLoadState = true) {
  *          // custom function
  *          showErrorNotification({
  *              text: `Error during loading content: ${res.name}`,
- *              done: loader.rePreload(res.src);
+ *              done: loader.reload(res.src);
  *          })
  *      }
  *  );
 **/
-export function rePreload(src) {
+export function reload(src) {
     const assetToReload = failureLoadedAssets[src];
     this.unload(assetToReload);
     resourceCount -= 1;

--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -76,7 +76,7 @@ let timerId = 0;
 /**
  * Assets uploaded with an error
  */
-const failureLoadedAssets = {}
+const failureLoadedAssets = {};
 
 /**
  * init all supported parsers
@@ -128,7 +128,7 @@ function checkLoadStatus(onloadcb) {
  * @ignore
  */
 function onResourceLoaded(res) {
-    delete failureLoadedAssets[res.src]
+    delete failureLoadedAssets[res.src];
     // increment the loading counter
     loadCount++;
 
@@ -149,11 +149,11 @@ function onResourceLoaded(res) {
  * @ignore
  */
 function onLoadingError(res) {
-    failureLoadedAssets[res.src] = res
+    failureLoadedAssets[res.src] = res;
     if (this.onError) {
         this.onError(res);
     }
-    emit(event.LOADER_ERROR, res);
+    event.emit(event.LOADER_ERROR, res);
     throw new Error("Failed loading resource " + res.src);
 }
 
@@ -295,7 +295,7 @@ export function preload(assets, onloadcb, switchToLoadState = true) {
  * preload assets after failure load
  * @memberof loader
  * @param {string} src - src of failure loaded asset
- * @example 
+ * @example
  *  event.on(
  *      event.LOADER_ERROR,
  *      (res) => {
@@ -309,13 +309,13 @@ export function preload(assets, onloadcb, switchToLoadState = true) {
 **/
 export function rePreload(src) {
     const assetToReload = failureLoadedAssets[src];
-    this.unload(assetToReload)
-    resourceCount -= 1
+    this.unload(assetToReload);
+    resourceCount -= 1;
     resourceCount += this.load(
         assetToReload,
         this.onResourceLoaded.bind(this, assetToReload),
         this.onLoadingError.bind(this, assetToReload)
-    )
+    );
     // check load status
     checkLoadStatus(this.onload);
 }

--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -48,7 +48,7 @@ export let onProgress;
 /**
  * onError callback<br>
  * each time a resource loading is failed, the loader will fire the specified function,
- * giving the actual progress [0 ... 1], as argument, and an object describing the resource loaded
+ * giving the actual asset, as argument, describing the resource
  * @default undefined
  * @memberof loader
  * @type {function}

--- a/src/system/event.js
+++ b/src/system/event.js
@@ -280,6 +280,18 @@ export const LOADER_COMPLETE = "me.loader.onload";
 export const LOADER_PROGRESS = "me.loader.onProgress";
 
 /**
+ * Event for displaying a error during loading <br>
+ * Data passed : {Resource} resource object<br>
+ * @public
+ * @constant
+ * @type {string}
+ * @name LOADER_ERROR
+ * @memberof event
+ * @see event.on
+ */
+export const LOADER_ERROR = "me.loader.onError";
+
+/**
  * Event for pressing a binded key <br>
  * Data passed : {string} user-defined action, {number} keyCode,
  * {boolean} edge state <br>


### PR DESCRIPTION
- [x] add event for displaying a error during loading `LOADER_ERROR`
- [x] add function `rePreload` to load asset, that was loaded with error

Userstory: I am trying to load project, but due to problems with the internet connection some of my assets load fails. I don't want to reload page and load whole project again. I want to upload again only failed assets.

Example decision: add notification about load failure with button to upload this asset again using `rePreload` function