### PR TITLE
prevent load previously loaded resource

### DIFF
--- a/src/loader/parsers/image.js
+++ b/src/loader/parsers/image.js
@@ -17,6 +17,10 @@ import { crossOrigin, nocache } from "../settings.js";
  * ]);
  */
 export function preloadImage(img, onload, onerror) {
+    if (imgList[img.name]) {
+        onload()
+        return
+    }  
     // create new Image object and add to list
     imgList[img.name] = new Image();
     if (typeof onload === "function") {

--- a/src/loader/parsers/json.js
+++ b/src/loader/parsers/json.js
@@ -11,6 +11,10 @@ import { nocache, withCredentials } from "../settings.js";
  * @ignore
  */
 export function preloadJSON(data, onload, onerror) {
+    if (jsonList[data.name]) {
+        onload()
+        return
+    }
     let xmlhttp = new XMLHttpRequest();
 
     if (xmlhttp.overrideMimeType) {

--- a/src/loader/parsers/tmx.js
+++ b/src/loader/parsers/tmx.js
@@ -15,6 +15,10 @@ import { nocache, withCredentials } from "../settings.js";
  * @ignore
  */
 export function preloadTMX(tmxData, onload, onerror) {
+    if (tmxList[tmxData.name]) {
+        onload()
+        return
+    }
     /**
      * @ignore
      */


### PR DESCRIPTION
Userstory: I have several levels with separate manifests. This manifests contains some part of the same assets. If I load second level after complete first, I don't want to load asset I previously loaded.

- [x] check if asset has already loaded and skip download