### PR TITLE
added build helper docker to generate webdoc with correct relative paths

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /
+
+RUN apt update && \
+  apt install -y --no-install-recommends \
+  openssh-client \
+  ca-certificates \
+  rsync \
+  curl \
+  wget \
+  gnupg \
+  git
+
+RUN apt remove --purge -y nodejs npm
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_21.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+RUN apt update -qq && \
+  apt install -y --no-install-recommends \
+  nodejs
+
+RUN git clone https://github.com/melonjs/melonJS.git /melonjs
+RUN rsync -a /melonjs/ /
+RUN npm install

--- a/docker/generate-docs.sh
+++ b/docker/generate-docs.sh
@@ -1,0 +1,4 @@
+docker build . -t melonjs:latest --no-cache
+docker run --name melonjs-doc melonjs:latest npm run doc-prod
+docker cp melonjs-doc:/docs/ ../
+docker rm melonjs-doc

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test-node": "node build/melonjs.module.js",
     "doc-prod": "mkdirp docs/docs && webdoc --quiet --site-root melonJS/docs/ -R README.md",
     "doc-local": "mkdirp docs/docs && webdoc --quiet --site-root /docs/docs -R README.md",
-    "doc": "npm run doc-prod",
+    "doc": "cd docker && ./generate-docs.sh && cd ..",
     "serve": "python3 -m http.server",
     "prepublishOnly": "npm run dist && npm run test",
     "clean": "del-cli --force build/*.* dist/** docs/docs/**",


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include linting and tests.

Before submitting please read:

Contributors guide: https://github.com/melonjs/melonJS/blob/master/CONTRIBUTING.md
Code of Conduct: https://github.com/melonjs/melonJS/blob/master/CODE_OF_CONDUCT.md
-->

##### Description of change
Documentation build helper via a docker container to work around broken webdoc package's absolute-path html anchor generation. See issue #1216.
Run `cd docker && ./generate-docs.sh` to generate the webdoc `docs` with correct line-number references in html.

##### Merge Checklist
Irrelevant, this is an infrastructure change that doesn't affect any source code.