### PR TITLE
Fix Camera2d.WorldToLocal to translate game.world.pos also

### DIFF
--- a/src/camera/camera2d.js
+++ b/src/camera/camera2d.js
@@ -636,8 +636,8 @@ export default class Camera2d extends Renderable {
         v = v || pool.pull("Vector2d");
         v.set(x, y);
 
-        let worldPos = pool.pull("Vector2d")
-        worldPos.set(game.world.pos.x, game.world.pos.y)
+        let worldPos = pool.pull("Vector2d");
+        worldPos.set(game.world.pos.x, game.world.pos.y);
         
         if (!this.currentTransform.isIdentity()) {
             this.currentTransform.apply(v);

--- a/src/camera/camera2d.js
+++ b/src/camera/camera2d.js
@@ -623,6 +623,7 @@ export default class Camera2d extends Renderable {
 
     /**
      * convert the given world coordinates into "local" (screen) coordinates
+     * If a transform is applied to the camera, apply it to the x,y and world position
      * @name worldToLocal
      * @memberof Camera2d
      * @param {number} x
@@ -634,10 +635,15 @@ export default class Camera2d extends Renderable {
         // TODO memoization for one set of coords (multitouch)
         v = v || pool.pull("Vector2d");
         v.set(x, y);
+
+        let worldPos = pool.pull("Vector2d")
+        worldPos.set(game.world.pos.x, game.world.pos.y)
+        
         if (!this.currentTransform.isIdentity()) {
             this.currentTransform.apply(v);
+            this.currentTransform.apply(worldPos);
         }
-        return v.sub(this.pos).add(game.world.pos);
+        return v.sub(this.pos).add(worldPos);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include linting and tests.

Before submitting please read:

Contributors guide: https://github.com/melonjs/melonJS/blob/master/CONTRIBUTING.md
Code of Conduct: https://github.com/melonjs/melonJS/blob/master/CODE_OF_CONDUCT.md
-->

##### Description of change
WorldToLocal applies transformation on the passed vector if the camera has transformation applied to it, however it does not apply it to the game.world.pos which is added to get the file result. This results an incorrect world to local translation. This change copies the world pos vector to a local variable and applies transformation to it, before adding it to the vector.

##### Merge Checklist
<!-- For completed items, change [ ] to [x]. -->

- [ ] Build process passed (`npm run build`)
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
