### PR TITLE
Use tmxData.type instead of file extension and also return a result for xml extension

### DIFF
--- a/src/loader/parsers/tmx.js
+++ b/src/loader/parsers/tmx.js
@@ -66,18 +66,8 @@ export function preloadTMX(tmxData, onload, onerror, settings) {
                     const xmlDoc = parser.parseFromString(response, "text/xml");
                     const data = TMXUtils.parse(xmlDoc);
 
-                    switch (tmxData.type || fileUtil.getExtension(tmxData.src)) {
-                        case "tmx":
-                            result = data.map;
-                            break;
+                    result = data.map || data.tilesets[0] || data;
 
-                        case "tsx":
-                            result = data.tilesets[0];
-                            break;
-
-                        default:
-                            result = data;
-                    }
                     break;
                 }
                 case "json":

--- a/src/loader/parsers/tmx.js
+++ b/src/loader/parsers/tmx.js
@@ -66,7 +66,7 @@ export function preloadTMX(tmxData, onload, onerror, settings) {
                     const xmlDoc = parser.parseFromString(response, "text/xml");
                     const data = TMXUtils.parse(xmlDoc);
 
-                    switch (fileUtil.getExtension(tmxData.src)) {
+                    switch (tmxData.type || fileUtil.getExtension(tmxData.src)) {
                         case "tmx":
                             result = data.map;
                             break;
@@ -74,6 +74,9 @@ export function preloadTMX(tmxData, onload, onerror, settings) {
                         case "tsx":
                             result = data.tilesets[0];
                             break;
+
+                        default:
+                            result = data;
                     }
                     break;
                 }


### PR DESCRIPTION
Dear Olivier,

I would like to suggest this change as for those of us using a build step (React / Vue), "tsx" is usually recognised as a typescript-jsx file type which renders us unable to import an asset with that extension as it would be parsed wrongly. Therefore, I suggest to use the type attribute instead of the file extension if available. Also, if the type is XML, it should allow the user to deal with whatever was parsed rather than simply returning nothing.