### PR TITLE
Fix running of tests on windows machine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+on: [push]
+jobs:
+  test:
+    strategy:
+      matrix:
+        node: [20, 22]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,10 +15,10 @@ export default [
     {
         name: "eslint/global-rules",
         languageOptions: {
-            "ecmaVersion" : 2020,
+            "ecmaVersion" : 2022,
             "sourceType": "module"
         },
-        files: ["src/**/*.js"],
+        files: ["src/**/*.js", "scripts/**"],
         plugins: {
             jsdoc
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "melonjs",
-  "version": "17.4.0",
+  "version": "17.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "melonjs",
-      "version": "17.4.0",
+      "version": "17.4.1",
       "license": "MIT",
       "dependencies": {
         "@teppeis/multimaps": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
   "scripts": {
     "build": "npm run lint && rollup -c --silent",
     "build:cd": "npm run lint && rollup -c --failAfterWarnings",
-    "dist": " npm run clean && npm run build && mkdirp dist && cp -fR build/*.* dist/ && npm run types && npm run doc",
+    "dist": " npm run clean && npm run build && mkdirp dist && node scripts/dist.js && npm run types && npm run doc",
     "lint": "eslint",
-    "pretest": "mkdirp tests/browser/public/lib && cp -f build/melonjs.module.js tests/browser/public/lib",
+    "pretest": "mkdirp tests/browser/public/lib && node scripts/pretest.js",
     "test": "npm run test-node && mocha ./tests/browser/spec/*.js --reporter spec --bail --timeout 10000",
     "test-node": "node build/melonjs.module.js",
     "doc-prod": "mkdirp docs/docs && webdoc --quiet --site-root melonJS/docs/ -R README.md && npm run fix_doc",

--- a/package.json
+++ b/package.json
@@ -102,5 +102,6 @@
     "prepublishOnly": "npm run dist && npm run test",
     "clean": "del-cli --force build/*.* dist/** docs/docs/**",
     "types": "tsc"
-  }
+  },
+  "packageManager": "npm@10.7.0"
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,7 +5,7 @@ import bundleSize from "rollup-plugin-bundle-size";
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import json from '@rollup/plugin-json';
-import pkg from "./package.json" assert { type: 'json' };
+import pkg from "./package.json" with { type: 'json' };
 
 // credit/license information
 const license = [

--- a/scripts/dist.js
+++ b/scripts/dist.js
@@ -1,0 +1,3 @@
+import { cp } from "node:fs/promises";
+
+await cp("build", "dist", {recursive:true});

--- a/scripts/pretest.js
+++ b/scripts/pretest.js
@@ -1,0 +1,3 @@
+import { cp } from "node:fs/promises";
+
+await cp("./build/melonjs.module.js", "./tests/browser/public/lib/melonjs.module.js");


### PR DESCRIPTION
- Fixed so that Windows users can run the test suite.  
- Added a GH workflow that runs the tests in both node 20(lts) and node 22 and in both ubuntu and windows environment.
- Pinned version of package manager to the npm version of the npm version provided in the latest node lts version to ensure better reliability during installation of dependencies.

<!--
Thank you for your pull request!

Bug fixes and new features should include linting and tests.

Before submitting please read:

Contributors guide: https://github.com/melonjs/melonJS/blob/master/CONTRIBUTING.md
Code of Conduct: https://github.com/melonjs/melonJS/blob/master/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Merge Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] Build process passed (`npm run build`)
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
