### PR TITLE
Melon editor dev/web gl rendering fix

### DIFF
--- a/packages/melonjs/src/renderable/light2d.js
+++ b/packages/melonjs/src/renderable/light2d.js
@@ -175,6 +175,17 @@ export default class Light2d extends Renderable {
 	}
 
 	/**
+	 * preDraw this Light2d (automatically called by melonJS)
+	 * Note: The renderer should set the blend mode again (after drawing other Light2d objects)
+	 * to ensure colors blend correctly in the CanvasRenderer.
+	 * @param {CanvasRenderer|WebGLRenderer} renderer - a renderer instance
+	 */
+	preDraw(renderer) {
+		super.preDraw(renderer);
+		renderer.setBlendMode(this.blendMode);
+	}
+
+	/**
 	 * draw this Light2d (automatically called by melonJS)
 	 * @param {CanvasRenderer|WebGLRenderer} renderer - a renderer instance
 	 * @param {Camera2d} [viewport] - the viewport to (re)draw

--- a/packages/melonjs/src/renderable/renderable.js
+++ b/packages/melonjs/src/renderable/renderable.js
@@ -10,7 +10,6 @@ import { ObservableVector3d } from "../math/observableVector3d.ts";
 import { vector2dPool } from "../math/vector2d.ts";
 import { matrix2dPool } from "../math/matrix2d.ts";
 import { ObservablePoint } from "../geometries/observablePoint.ts";
-import Light2d from "./light2d.js";
 
 /**
  * additional import for TypeScript
@@ -714,7 +713,7 @@ export default class Renderable extends Rect {
 		renderer.setTint(this.tint, this.getOpacity());
 
 		// apply blending if different from "normal"
-		if (this.blendMode !== renderer.getBlendMode() || this instanceof Light2d) {
+		if (this.blendMode !== renderer.getBlendMode()) {
 			renderer.setBlendMode(this.blendMode);
 		}
 	}

--- a/packages/melonjs/src/renderable/renderable.js
+++ b/packages/melonjs/src/renderable/renderable.js
@@ -10,6 +10,7 @@ import { ObservableVector3d } from "../math/observableVector3d.ts";
 import { vector2dPool } from "../math/vector2d.ts";
 import { matrix2dPool } from "../math/matrix2d.ts";
 import { ObservablePoint } from "../geometries/observablePoint.ts";
+import Light2d from "./light2d.js";
 
 /**
  * additional import for TypeScript
@@ -713,7 +714,7 @@ export default class Renderable extends Rect {
 		renderer.setTint(this.tint, this.getOpacity());
 
 		// apply blending if different from "normal"
-		if (this.blendMode !== renderer.getBlendMode()) {
+		if (this.blendMode !== renderer.getBlendMode() || this instanceof Light2d) {
 			renderer.setBlendMode(this.blendMode);
 		}
 	}

--- a/packages/melonjs/src/video/webgl/compositors/quad_compositor.js
+++ b/packages/melonjs/src/video/webgl/compositors/quad_compositor.js
@@ -100,7 +100,7 @@ export default class QuadCompositor extends Compositor {
 		h = pixels.height,
 		premultipliedAlpha = true,
 		mipmap = true,
-		texture
+		texture,
 	) {
 		const gl = this.gl;
 		const isPOT = isPowerOfTwo(w) && isPowerOfTwo(h);
@@ -115,7 +115,7 @@ export default class QuadCompositor extends Compositor {
 				? gl.REPEAT
 				: gl.CLAMP_TO_EDGE;
 
-		const currentTexture = texture;
+		let currentTexture = texture;
 		if (!currentTexture) currentTexture = gl.createTexture();
 
 		this.bindTexture2D(currentTexture, unit);
@@ -253,7 +253,7 @@ export default class QuadCompositor extends Compositor {
 				h,
 				texture.premultipliedAlpha,
 				undefined,
-				texture2D
+				texture2D,
 			);
 		} else {
 			this.bindTexture2D(texture2D, unit);

--- a/packages/melonjs/src/video/webgl/compositors/quad_compositor.js
+++ b/packages/melonjs/src/video/webgl/compositors/quad_compositor.js
@@ -100,6 +100,7 @@ export default class QuadCompositor extends Compositor {
 		h = pixels.height,
 		premultipliedAlpha = true,
 		mipmap = true,
+		texture
 	) {
 		const gl = this.gl;
 		const isPOT = isPowerOfTwo(w) && isPowerOfTwo(h);
@@ -114,9 +115,10 @@ export default class QuadCompositor extends Compositor {
 				? gl.REPEAT
 				: gl.CLAMP_TO_EDGE;
 
-		const texture = gl.createTexture();
+		const currentTexture = texture;
+		if (!currentTexture) currentTexture = gl.createTexture();
 
-		this.bindTexture2D(texture, unit);
+		this.bindTexture2D(currentTexture, unit);
 
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, rs);
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, rt);
@@ -170,7 +172,7 @@ export default class QuadCompositor extends Compositor {
 			gl.generateMipmap(gl.TEXTURE_2D);
 		}
 
-		return texture;
+		return currentTexture;
 	}
 
 	/**
@@ -250,6 +252,8 @@ export default class QuadCompositor extends Compositor {
 				w,
 				h,
 				texture.premultipliedAlpha,
+				undefined,
+				texture2D
 			);
 		} else {
 			this.bindTexture2D(texture2D, unit);

--- a/packages/melonjs/src/video/webgl/compositors/quad_compositor.js
+++ b/packages/melonjs/src/video/webgl/compositors/quad_compositor.js
@@ -116,7 +116,9 @@ export default class QuadCompositor extends Compositor {
 				: gl.CLAMP_TO_EDGE;
 
 		let currentTexture = texture;
-		if (!currentTexture) currentTexture = gl.createTexture();
+		if (!currentTexture) {
+			currentTexture = gl.createTexture();
+		}
 
 		this.bindTexture2D(currentTexture, unit);
 


### PR DESCRIPTION
##### Description of change
- Updated the way the Quad Compositor renders when updating textures repeatedly.
- Fixed color blending issue in CanvasRenderer when using multiple Light2D objects at the same position. Previously, when multiple Light2D objects were placed at the same position using the CanvasRenderer, the colors didn't blend correctly. This issue has now been resolved, and Light2D objects properly blend colors in the CanvasRenderer. **Explanation**: In the CanvasRenderer context, the first Light2D object will set the blend mode to this.blendMode. However, subsequent Light2D objects do not reset the blend mode after calling ctx.save() and ctx.restore(). This was causing the incorrect color blending behavior. If ctx.save() and ctx.restore() were not used, the blend mode would only need to be set once, and the blending would work as expected.

##### Merge Checklist

- [ x ] Build process passed (`npm run build`)
- [ x ] Lint process passed (`npm run lint`)
- [ x ] Tests passed (`npm run test`)
