### PR TITLE
implement persistence for child bodies during reset

### DIFF
--- a/packages/melonjs/src/physics/world.js
+++ b/packages/melonjs/src/physics/world.js
@@ -140,7 +140,7 @@ export default class World extends Container {
 		// insert persistent child bodies into the new state
 		if (persistentBodies.length > 0) {
 			persistentBodies.forEach((body) => {
-				return this.bodies.add(body);
+				this.bodies.add(body);
 			});
 		}
 	}


### PR DESCRIPTION
##### Description of change
Implement persistence for child bodies during reset.

The body of an object marked as isPersistent was being ignored by the world update during stage transitions. This occurred because this.bodies.clear() removed it without re-adding it during the reset() process. This fix ensures the body is retained.

##### Merge Checklist
<!-- For completed items, change [ ] to [x]. -->

- [-] Build process passed (`npm run build`)
- [-] Lint process passed (`npm run lint`)
- [-] Tests passed (`npm run test`)
