### PR TITLE
docs(ui): fix floating default shown for UIBaseElement/UISpriteElement

### DIFF
--- a/packages/melonjs/src/renderable/ui/uibaseelement.js
+++ b/packages/melonjs/src/renderable/ui/uibaseelement.js
@@ -15,6 +15,15 @@ export default class UIBaseElement extends Container {
 	#boundPointerMoveHandler;
 
 	/**
+	 * UI base elements use screen coordinates by default
+	 * (Note: any child elements added to a UIBaseElement should have their floating property to false)
+	 * @see Renderable.floating
+	 * @type {boolean}
+	 * @default true
+	 */
+	floating = true;
+
+	/**
 	 *
 	 * @param {number} x - The x position of the container
 	 * @param {number} y - The y position of the container
@@ -64,15 +73,6 @@ export default class UIBaseElement extends Container {
 		 * @default false
 		 */
 		this.released = true;
-
-		/**
-		 * UI base elements use screen coordinates by default
-		 * (Note: any child elements added to a UIBaseElement should have their floating property to false)
-		 * @see Renderable.floating
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.floating = true;
 
 		// object has been updated (clicked,etc..)
 		this.holdTimeout = -1;

--- a/packages/melonjs/src/renderable/ui/uispriteelement.js
+++ b/packages/melonjs/src/renderable/ui/uispriteelement.js
@@ -10,6 +10,15 @@ import Sprite from "./../sprite.js";
  */
 export default class UISpriteElement extends Sprite {
 	/**
+	 * if this UISpriteElement should use screen coordinates or local coordinates
+	 * (Note: any UISpriteElement elements added to a floating parent container should have their floating property to false)
+	 * @see Renderable.floating
+	 * @type {boolean}
+	 * @default true
+	 */
+	floating = true;
+
+	/**
 	 * @param {number} x - the x coordinate of the UISpriteElement Object
 	 * @param {number} y - the y coordinate of the UISpriteElement Object
 	 * @param {object} settings - See {@link Sprite}
@@ -72,15 +81,6 @@ export default class UISpriteElement extends Sprite {
 		// object has been updated (clicked,etc..)
 		this.holdTimeout = -1;
 		this.released = true;
-
-		/**
-		 * if this UISpriteElement should use screen coordinates or local coordinates
-		 * (Note: any UISpriteElement elements added to a floating parent container should have their floating property to false)
-		 * @see Renderable.floating
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.floating = true;
 
 		// enable event detection
 		this.isKinematic = false;


### PR DESCRIPTION
## Summary
Fixes docs mismatch where `UIBaseElement.floating` and `UISpriteElement.floating` were shown as inheriting Renderable's default (`false`) even though both UI classes set it to `true` at runtime.

This change declares `floating = true` as class fields (with JSDoc), so TypeDoc renders class-specific defaults instead of inherited defaults.

Closes #1237

## Validation
- Ran `pnpm -F melonjs doc`
- Verified generated docs now show `floating = true` on both pages:
  - `docs/classes/UIBaseElement.html`
  - `docs/classes/UISpriteElement.html`
