### PR TITLE
[#1201][#1214] Fix body-renderable misalignment with trimmed TexturePacker atlas frames

### DIFF
--- a/packages/examples/src/examples/texturePacker/ExampleTexturePacker.tsx
+++ b/packages/examples/src/examples/texturePacker/ExampleTexturePacker.tsx
@@ -1,7 +1,9 @@
+import { DebugPanelPlugin } from "@melonjs/debug-plugin";
 import {
 	Entity,
 	game,
 	loader,
+	plugin,
 	type Sprite,
 	Stage,
 	state,
@@ -16,7 +18,7 @@ let texture: TextureAtlas;
 
 class CapGuyEntity extends Entity {
 	constructor() {
-		super(0, 200, { width: 100, height: 300 });
+		super(0, 50, { width: 100, height: 300 });
 		this.body.setStatic();
 		this.renderable = texture.createAnimationFromName([
 			"capguy/walk/0001",
@@ -62,6 +64,9 @@ const createGame = () => {
 		alert("Your browser does not support HTML5 canvas.");
 		return;
 	}
+
+	// register the debug plugin
+	plugin.register(DebugPanelPlugin, "debugPanel");
 
 	const resources = [
 		{ name: "cityscene", type: "json", src: `${base}cityscene.json` },

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -23,6 +23,10 @@
 - Renderer: fix `PrimitiveCompositor.drawVertices()` ignoring the `vertexCount` parameter
 - Texture: fix tint cache bug where `Map.set()` return value was incorrectly used as the inner cache map, causing duplicate tinted images to be created
 - TMX: fix crash when loading XML maps due to missing node type guard in the XML parser
+- Sprite: fix body-renderable misalignment when using `createAnimationFromName()` with trimmed TexturePacker atlas frames (#1201)
+- Sprite: fix visual "vibration" on flip with trimmed atlas frames — stable dimensions and anchor across all frames (#1214)
+- Sprite: fix sprite jumping on rotated atlas frames — trim offset now applied after rotation with correct coordinate transform
+- Entity: auto-inherit renderable's anchorPoint when entity anchor is at default (0,0), aligning body and sprite centers
 
 ### Performance
 - Path2D: replace `Math.pow()` with inline multiplication in quadratic/cubic Bézier and arc interpolation

--- a/packages/melonjs/src/renderable/entity/entity.js
+++ b/packages/melonjs/src/renderable/entity/entity.js
@@ -128,6 +128,10 @@ export default class Entity extends Renderable {
 		if (value instanceof Renderable) {
 			this.children[0] = value;
 			this.children[0].ancestor = this;
+			// auto-align: inherit renderable's anchor if entity is still at default
+			if (this.anchorPoint.x === 0 && this.anchorPoint.y === 0) {
+				this.anchorPoint.setMuted(value.anchorPoint.x, value.anchorPoint.y);
+			}
 			this.updateBounds();
 		} else {
 			throw new Error(value + "should extend me.Renderable");

--- a/packages/melonjs/src/renderable/sprite.js
+++ b/packages/melonjs/src/renderable/sprite.js
@@ -125,6 +125,8 @@ export default class Sprite extends Renderable {
 			angle: 0,
 			// current frame index
 			idx: 0,
+			// trim offset for trimmed sprites
+			trim: null,
 		};
 
 		// animation frame delta
@@ -544,20 +546,42 @@ export default class Sprite extends Renderable {
 		this.current.offset.setV(region.offset);
 		// set angle if defined
 		this.current.angle = typeof region.angle === "number" ? region.angle : 0;
-		// update the default "current" size
-		this.width = this.current.width = region.width;
-		this.height = this.current.height = region.height;
-		// set global anchortPoint if defined
-		if (region.anchorPoint) {
-			this.anchorPoint.setMuted(
-				this._flip.x && region.trimmed === true
-					? 1 - region.anchorPoint.x
-					: region.anchorPoint.x,
-				this._flip.y && region.trimmed === true
-					? 1 - region.anchorPoint.y
-					: region.anchorPoint.y,
-			);
+		// update the current frame size (trimmed dimensions, used for drawing)
+		this.current.width = region.width;
+		this.current.height = region.height;
+		// cache trim offset for drawing
+		this.current.trim = region.trim || null;
+
+		if (region.trimmed && region.sourceSize) {
+			// use the original untrimmed size for stable bounds across trimmed frames
+			this.width = region.sourceSize.w;
+			this.height = region.sourceSize.h;
+			// recover the original pivot relative to sourceSize for stable anchor
+			if (region.anchorPoint) {
+				const pivotX =
+					(region.trim.x + region.width * region.anchorPoint.x) / this.width;
+				const pivotY =
+					(region.trim.y + region.height * region.anchorPoint.y) / this.height;
+				this.anchorPoint.setMuted(
+					this._flip.x ? 1 - pivotX : pivotX,
+					this._flip.y ? 1 - pivotY : pivotY,
+				);
+			}
+		} else {
+			this.width = region.width;
+			this.height = region.height;
+			if (region.anchorPoint) {
+				this.anchorPoint.setMuted(
+					this._flip.x && region.trimmed === true
+						? 1 - region.anchorPoint.x
+						: region.anchorPoint.x,
+					this._flip.y && region.trimmed === true
+						? 1 - region.anchorPoint.y
+						: region.anchorPoint.y,
+				);
+			}
 		}
+
 		// update the sprite bounding box
 		this.updateBounds();
 		this.isDirty = true;
@@ -687,7 +711,7 @@ export default class Sprite extends Renderable {
 
 		// cache the current position and size
 		let xpos = this.pos.x;
-		const ypos = this.pos.y;
+		let ypos = this.pos.y;
 
 		let w = frame.width;
 		let h = frame.height;
@@ -703,6 +727,15 @@ export default class Sprite extends Renderable {
 			xpos -= h;
 			w = frame.height;
 			h = frame.width;
+			// apply trim in rotated space: (tx, ty) → (-ty, tx) for -π/2
+			if (frame.trim) {
+				xpos -= frame.trim.y;
+				ypos += frame.trim.x;
+			}
+		} else if (frame.trim) {
+			// apply trim offset for non-rotated trimmed sprites
+			xpos += frame.trim.x;
+			ypos += frame.trim.y;
 		}
 
 		renderer.drawImage(

--- a/packages/melonjs/src/video/texture/atlas.js
+++ b/packages/melonjs/src/video/texture/atlas.js
@@ -501,9 +501,12 @@ export class TextureAtlas {
 			tpAtlas.push(region);
 			// save the corresponding index
 			indices[name] = tpAtlas.length - 1;
+			// use sourceSize (original untrimmed size) if available for stable bounds
+			const frameW = region.sourceSize ? region.sourceSize.w : region.width;
+			const frameH = region.sourceSize ? region.sourceSize.h : region.height;
 			// calculate the max size of a frame
-			width = Math.max(region.width, width);
-			height = Math.max(region.height, height);
+			width = Math.max(frameW, width);
+			height = Math.max(frameH, height);
 		}
 
 		// instantiate a new animation sheet object

--- a/packages/melonjs/src/video/texture/parser/texturepacker.js
+++ b/packages/melonjs/src/video/texture/parser/texturepacker.js
@@ -49,6 +49,7 @@ export function parseTexturePacker(data, textureAtlas) {
 				trim: trim,
 				width: s.w,
 				height: s.h,
+				sourceSize: frame.sourceSize || { w: s.w, h: s.h },
 				angle: frame.rotated === true ? -ETA : 0,
 			};
 			textureAtlas.addUVs(

--- a/packages/melonjs/tests/sprite-trimming.spec.js
+++ b/packages/melonjs/tests/sprite-trimming.spec.js
@@ -1,0 +1,409 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { boot, Entity, Renderable, Sprite, video } from "../src/index.js";
+
+describe("Sprite trimming and Entity anchor sync", () => {
+	let mockImage;
+
+	beforeAll(async () => {
+		boot();
+		video.init(800, 600, {
+			parent: "screen",
+			scale: "auto",
+			renderer: video.AUTO,
+		});
+		// create a mock image for sprite creation
+		mockImage = video.createCanvas(512, 512);
+	});
+
+	/**
+	 * Build a mock TexturePacker atlas region.
+	 */
+	function buildRegion({
+		name = "frame",
+		x = 0,
+		y = 0,
+		w = 64,
+		h = 64,
+		trimmed = false,
+		trim = null,
+		sourceSize = null,
+		anchorX = null,
+		anchorY = null,
+		angle = 0,
+	}) {
+		const region = {
+			name,
+			offset: { x, y, setV() {} },
+			width: w,
+			height: h,
+			trimmed,
+			trim,
+			sourceSize,
+			angle,
+			anchorPoint: anchorX !== null ? { x: anchorX, y: anchorY } : null,
+		};
+		return region;
+	}
+
+	/**
+	 * Build a trimmed region with proper anchorPoint from pivot (0.5, 0.5).
+	 */
+	function buildTrimmedRegion({
+		name = "frame",
+		atlasX = 0,
+		atlasY = 0,
+		frameW,
+		frameH,
+		trimX,
+		trimY,
+		sourceW,
+		sourceH,
+		rotated = false,
+	}) {
+		// Compute anchorPoint the same way TexturePacker parser does:
+		// originX = sourceW * 0.5 - trimX, anchorPoint.x = originX / frameW
+		const originX = sourceW * 0.5 - trimX;
+		const originY = sourceH * 0.5 - trimY;
+		return buildRegion({
+			name,
+			x: atlasX,
+			y: atlasY,
+			w: frameW,
+			h: frameH,
+			trimmed: true,
+			trim: { x: trimX, y: trimY, w: frameW, h: frameH },
+			sourceSize: { w: sourceW, h: sourceH },
+			anchorX: originX / frameW,
+			anchorY: originY / frameH,
+			angle: rotated ? -Math.PI / 2 : 0,
+		});
+	}
+
+	describe("Sprite.setRegion with trimmed frames", () => {
+		it("should use sourceSize for width/height on trimmed frames", () => {
+			const sprite = new Sprite(0, 0, {
+				framewidth: 64,
+				frameheight: 64,
+				image: mockImage,
+			});
+
+			const region = buildTrimmedRegion({
+				frameW: 156,
+				frameH: 314,
+				trimX: 16,
+				trimY: 4,
+				sourceW: 187,
+				sourceH: 324,
+			});
+
+			// mock the source.getTexture
+			sprite.source = {
+				getTexture: () => {
+					return mockImage;
+				},
+			};
+			sprite.setRegion(region);
+
+			expect(sprite.width).toBe(187);
+			expect(sprite.height).toBe(324);
+		});
+
+		it("should use frame size for width/height on non-trimmed frames", () => {
+			const sprite = new Sprite(0, 0, {
+				framewidth: 64,
+				frameheight: 64,
+				image: mockImage,
+			});
+
+			const region = buildRegion({ w: 100, h: 80 });
+			sprite.source = {
+				getTexture: () => {
+					return mockImage;
+				},
+			};
+			sprite.setRegion(region);
+
+			expect(sprite.width).toBe(100);
+			expect(sprite.height).toBe(80);
+		});
+
+		it("should recover stable anchor (0.5, 0.5) for all trimmed frames with pivot (0.5, 0.5)", () => {
+			const sprite = new Sprite(0, 0, {
+				framewidth: 187,
+				frameheight: 324,
+				image: mockImage,
+			});
+			sprite.source = {
+				getTexture: () => {
+					return mockImage;
+				},
+			};
+
+			// Simulate multiple animation frames with different trims
+			const frames = [
+				{ frameW: 156, frameH: 314, trimX: 16, trimY: 4 },
+				{ frameW: 166, frameH: 301, trimX: 1, trimY: 9 },
+				{ frameW: 150, frameH: 305, trimX: 27, trimY: 3 },
+				{ frameW: 139, frameH: 304, trimX: 43, trimY: 2 },
+			];
+
+			for (const f of frames) {
+				const region = buildTrimmedRegion({
+					...f,
+					sourceW: 187,
+					sourceH: 324,
+				});
+				sprite.setRegion(region);
+
+				expect(sprite.anchorPoint.x).toBeCloseTo(0.5, 10);
+				expect(sprite.anchorPoint.y).toBeCloseTo(0.5, 10);
+			}
+		});
+
+		it("should keep width/height constant across trimmed frames with same sourceSize", () => {
+			const sprite = new Sprite(0, 0, {
+				framewidth: 187,
+				frameheight: 324,
+				image: mockImage,
+			});
+			sprite.source = {
+				getTexture: () => {
+					return mockImage;
+				},
+			};
+
+			const frames = [
+				{ frameW: 156, frameH: 314, trimX: 16, trimY: 4 },
+				{ frameW: 166, frameH: 301, trimX: 1, trimY: 9 },
+				{ frameW: 139, frameH: 304, trimX: 43, trimY: 2 },
+			];
+
+			for (const f of frames) {
+				const region = buildTrimmedRegion({
+					...f,
+					sourceW: 187,
+					sourceH: 324,
+				});
+				sprite.setRegion(region);
+
+				// width/height should always be sourceSize, not frame size
+				expect(sprite.width).toBe(187);
+				expect(sprite.height).toBe(324);
+			}
+		});
+
+		it("should cache trim offset in current frame data", () => {
+			const sprite = new Sprite(0, 0, {
+				framewidth: 64,
+				frameheight: 64,
+				image: mockImage,
+			});
+			sprite.source = {
+				getTexture: () => {
+					return mockImage;
+				},
+			};
+
+			const region = buildTrimmedRegion({
+				frameW: 156,
+				frameH: 314,
+				trimX: 16,
+				trimY: 4,
+				sourceW: 187,
+				sourceH: 324,
+			});
+			sprite.setRegion(region);
+
+			expect(sprite.current.trim).toEqual({
+				x: 16,
+				y: 4,
+				w: 156,
+				h: 314,
+			});
+		});
+
+		it("should set trim to null for non-trimmed frames", () => {
+			const sprite = new Sprite(0, 0, {
+				framewidth: 64,
+				frameheight: 64,
+				image: mockImage,
+			});
+			sprite.source = {
+				getTexture: () => {
+					return mockImage;
+				},
+			};
+
+			const region = buildRegion({ w: 64, h: 64 });
+			sprite.setRegion(region);
+
+			expect(sprite.current.trim).toBeNull();
+		});
+	});
+
+	describe("Entity renderable anchor sync", () => {
+		it("should sync entity anchor to renderable anchor when entity anchor is at default (0, 0)", () => {
+			const entity = new Entity(0, 0, { width: 100, height: 100 });
+			expect(entity.anchorPoint.x).toBe(0);
+			expect(entity.anchorPoint.y).toBe(0);
+
+			// create a renderable with anchor (0.5, 0.5)
+			const renderable = new Renderable(0, 0, 50, 50);
+			// Renderable defaults to (0.5, 0.5)
+			expect(renderable.anchorPoint.x).toBe(0.5);
+			expect(renderable.anchorPoint.y).toBe(0.5);
+
+			entity.renderable = renderable;
+
+			// entity anchor should now match renderable
+			expect(entity.anchorPoint.x).toBe(0.5);
+			expect(entity.anchorPoint.y).toBe(0.5);
+		});
+
+		it("should not sync entity anchor when entity anchor has been explicitly set", () => {
+			const entity = new Entity(0, 0, {
+				width: 100,
+				height: 100,
+				anchorPoint: { x: 0.5, y: 1.0 },
+			});
+			expect(entity.anchorPoint.x).toBe(0.5);
+			expect(entity.anchorPoint.y).toBe(1.0);
+
+			const renderable = new Renderable(0, 0, 50, 50);
+			entity.renderable = renderable;
+
+			// entity anchor should NOT change — it was explicitly set
+			expect(entity.anchorPoint.x).toBe(0.5);
+			expect(entity.anchorPoint.y).toBe(1.0);
+		});
+
+		it("should sync entity anchor when renderable anchor is (0, 0)", () => {
+			const entity = new Entity(0, 0, { width: 100, height: 100 });
+
+			const renderable = new Renderable(0, 0, 50, 50);
+			renderable.anchorPoint.set(0, 0);
+			entity.renderable = renderable;
+
+			// entity and renderable both at (0, 0) — no visible change
+			expect(entity.anchorPoint.x).toBe(0);
+			expect(entity.anchorPoint.y).toBe(0);
+		});
+
+		it("should sync when setting a Sprite renderable with custom anchor", () => {
+			const entity = new Entity(0, 0, { width: 100, height: 300 });
+
+			const sprite = new Sprite(0, 0, {
+				framewidth: 32,
+				frameheight: 32,
+				image: mockImage,
+				anchorPoint: { x: 0.5, y: 0.5 },
+			});
+			entity.renderable = sprite;
+
+			expect(entity.anchorPoint.x).toBe(0.5);
+			expect(entity.anchorPoint.y).toBe(0.5);
+		});
+
+		it("should not sync for Tiled-style entities where both anchors are (0, 0)", () => {
+			// Simulate Tiled entity: explicit anchorPoint in settings
+			const entity = new Entity(0, 0, {
+				width: 32,
+				height: 64,
+				anchorPoint: { x: 0, y: 0 },
+			});
+
+			const sprite = new Sprite(0, 0, {
+				framewidth: 32,
+				frameheight: 64,
+				image: mockImage,
+				anchorPoint: { x: 0, y: 0 },
+			});
+			entity.renderable = sprite;
+
+			// Both should remain (0, 0) — Tiled compatibility
+			expect(entity.anchorPoint.x).toBe(0);
+			expect(entity.anchorPoint.y).toBe(0);
+		});
+	});
+
+	describe("Sprite draw trim positioning", () => {
+		it("should produce stable character center across trimmed frames", () => {
+			// This test verifies the mathematical invariant:
+			// For frames with pivot (0.5, 0.5) and the same sourceSize,
+			// (trim.x + frame.width * anchorPoint.x) / sourceSize.w === 0.5
+			// regardless of how the frame is trimmed.
+			const sourceW = 187;
+			const sourceH = 324;
+			const pivot = 0.5;
+
+			const testCases = [
+				{ trimX: 16, trimY: 4, frameW: 156, frameH: 314 },
+				{ trimX: 1, trimY: 9, frameW: 166, frameH: 301 },
+				{ trimX: 27, trimY: 3, frameW: 150, frameH: 305 },
+				{ trimX: 43, trimY: 2, frameW: 139, frameH: 304 },
+				{ trimX: 34, trimY: 4, frameW: 137, frameH: 309 },
+				{ trimX: 30, trimY: 9, frameW: 133, frameH: 309 },
+				{ trimX: 33, trimY: 3, frameW: 144, frameH: 312 },
+				{ trimX: 23, trimY: 2, frameW: 159, frameH: 317 },
+			];
+
+			for (const tc of testCases) {
+				// Compute anchorPoint as the TexturePacker parser does
+				const originX = sourceW * pivot - tc.trimX;
+				const originY = sourceH * pivot - tc.trimY;
+				const anchorX = originX / tc.frameW;
+				const anchorY = originY / tc.frameH;
+
+				// Recover pivot as setRegion does
+				const recoveredX = (tc.trimX + tc.frameW * anchorX) / sourceW;
+				const recoveredY = (tc.trimY + tc.frameH * anchorY) / sourceH;
+
+				expect(recoveredX).toBeCloseTo(0.5, 10);
+				expect(recoveredY).toBeCloseTo(0.5, 10);
+
+				// Verify the visual center is at sourceSize/2 from the sourceSize origin
+				// In the entity's local space (after preDraw translate(-anchor*sourceSize)):
+				// trim.x + frame center = trim.x + originX = sourceW * 0.5
+				const visualCenterX = tc.trimX + originX;
+				const visualCenterY = tc.trimY + originY;
+				expect(visualCenterX).toBeCloseTo(sourceW * 0.5, 10);
+				expect(visualCenterY).toBeCloseTo(sourceH * 0.5, 10);
+			}
+		});
+
+		it("should compute correct rotated trim offset", () => {
+			// For a -π/2 rotation, trim (tx, ty) maps to (-ty, +tx) in rotated space.
+			// The rotated draw position and a corner after rotation should give
+			// screen top-left at (trimX, trimY).
+			const trimX = 27;
+			const trimY = 3;
+			const frameH = 305;
+
+			// In the rotated draw space:
+			// xpos = -frameH - trimY, ypos = trimX
+			const drawX = -frameH - trimY;
+			const drawY = trimX;
+
+			// Corner (drawX + frameH, drawY) after -π/2 rotation: (x,y)→(y,-x)
+			const screenX = drawY; // trimX
+			const screenY = -(drawX + frameH); // trimY
+
+			expect(screenX).toBe(trimX);
+			expect(screenY).toBe(trimY);
+		});
+
+		it("should produce stable character center for rotated frames", () => {
+			const sourceW = 187;
+			const sourceH = 324;
+			const trimX = 27;
+			const trimY = 3;
+
+			// Character center in sourceSize coords = sourceSize / 2
+			const charCenterX = trimX + (sourceW * 0.5 - trimX);
+			const charCenterY = trimY + (sourceH * 0.5 - trimY);
+
+			expect(charCenterX).toBe(sourceW * 0.5);
+			expect(charCenterY).toBe(sourceH * 0.5);
+		});
+	});
+});

--- a/packages/melonjs/tests/texturepacker-parser.node-test.js
+++ b/packages/melonjs/tests/texturepacker-parser.node-test.js
@@ -1,0 +1,369 @@
+/**
+ * TexturePacker trimming math unit tests.
+ *
+ * Tests the mathematical invariants behind trimmed sprite handling:
+ * - Pivot recovery from trim offset and frame anchor
+ * - Stable character center across differently-trimmed frames
+ * - Correct trim offset transformation for rotated frames
+ *
+ * Run with: node --test tests/texturepacker-parser.node-test.js
+ */
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+/**
+ * Compute the anchorPoint the way the TexturePacker parser does:
+ * originX = sourceSize.w * pivot.x - (trimmed ? trim.x : 0)
+ * anchorPoint.x = originX / frame.w
+ */
+function computeAnchorPoint(
+	pivot,
+	frameW,
+	frameH,
+	trimX,
+	trimY,
+	sourceW,
+	sourceH,
+	trimmed,
+) {
+	const originX = sourceW * pivot.x - (trimmed ? trimX : 0);
+	const originY = sourceH * pivot.y - (trimmed ? trimY : 0);
+	return { x: originX / frameW, y: originY / frameH };
+}
+
+/**
+ * Recover the pivot from setRegion's formula:
+ * pivotX = (trim.x + frame.width * anchorPoint.x) / sourceSize.w
+ */
+function recoverPivot(
+	trimX,
+	trimY,
+	frameW,
+	frameH,
+	anchorX,
+	anchorY,
+	sourceW,
+	sourceH,
+) {
+	return {
+		x: (trimX + frameW * anchorX) / sourceW,
+		y: (trimY + frameH * anchorY) / sourceH,
+	};
+}
+
+describe("TexturePacker trim math", () => {
+	// Real walk animation data from cityscene.json
+	const WALK_FRAMES = [
+		{ name: "0001", frameW: 156, frameH: 314, trimX: 16, trimY: 4 },
+		{ name: "0002", frameW: 166, frameH: 301, trimX: 1, trimY: 9 },
+		{
+			name: "0003",
+			frameW: 150,
+			frameH: 305,
+			trimX: 27,
+			trimY: 3,
+			rotated: true,
+		},
+		{
+			name: "0004",
+			frameW: 139,
+			frameH: 304,
+			trimX: 43,
+			trimY: 2,
+			rotated: true,
+		},
+		{ name: "0005", frameW: 137, frameH: 309, trimX: 34, trimY: 4 },
+		{
+			name: "0006",
+			frameW: 133,
+			frameH: 309,
+			trimX: 30,
+			trimY: 9,
+			rotated: true,
+		},
+		{ name: "0007", frameW: 144, frameH: 312, trimX: 33, trimY: 3 },
+		{ name: "0008", frameW: 159, frameH: 317, trimX: 23, trimY: 2 },
+	];
+	const SOURCE_W = 187;
+	const SOURCE_H = 324;
+	const PIVOT = { x: 0.5, y: 0.5 };
+
+	describe("pivot recovery", () => {
+		it("should recover pivot (0.5, 0.5) for all walk frames", () => {
+			for (const f of WALK_FRAMES) {
+				const anchor = computeAnchorPoint(
+					PIVOT,
+					f.frameW,
+					f.frameH,
+					f.trimX,
+					f.trimY,
+					SOURCE_W,
+					SOURCE_H,
+					true,
+				);
+				const recovered = recoverPivot(
+					f.trimX,
+					f.trimY,
+					f.frameW,
+					f.frameH,
+					anchor.x,
+					anchor.y,
+					SOURCE_W,
+					SOURCE_H,
+				);
+
+				assert.ok(
+					Math.abs(recovered.x - 0.5) < 1e-10,
+					`frame ${f.name}: recovered pivotX = ${recovered.x}, expected 0.5`,
+				);
+				assert.ok(
+					Math.abs(recovered.y - 0.5) < 1e-10,
+					`frame ${f.name}: recovered pivotY = ${recovered.y}, expected 0.5`,
+				);
+			}
+		});
+
+		it("should recover non-centered pivots correctly", () => {
+			const pivot = { x: 0.3, y: 0.7 };
+			const trimX = 10;
+			const trimY = 5;
+			const frameW = 80;
+			const frameH = 90;
+			const sourceW = 100;
+			const sourceH = 100;
+
+			const anchor = computeAnchorPoint(
+				pivot,
+				frameW,
+				frameH,
+				trimX,
+				trimY,
+				sourceW,
+				sourceH,
+				true,
+			);
+			const recovered = recoverPivot(
+				trimX,
+				trimY,
+				frameW,
+				frameH,
+				anchor.x,
+				anchor.y,
+				sourceW,
+				sourceH,
+			);
+
+			assert.ok(Math.abs(recovered.x - 0.3) < 1e-10, `pivotX: ${recovered.x}`);
+			assert.ok(Math.abs(recovered.y - 0.7) < 1e-10, `pivotY: ${recovered.y}`);
+		});
+	});
+
+	describe("stable character center", () => {
+		it("should produce the same visual center for all walk frames", () => {
+			// The visual center in sourceSize coordinates should be at
+			// (sourceW * 0.5, sourceH * 0.5) for all frames with pivot (0.5, 0.5)
+			const expectedCenterX = SOURCE_W * 0.5;
+			const expectedCenterY = SOURCE_H * 0.5;
+
+			for (const f of WALK_FRAMES) {
+				const anchor = computeAnchorPoint(
+					PIVOT,
+					f.frameW,
+					f.frameH,
+					f.trimX,
+					f.trimY,
+					SOURCE_W,
+					SOURCE_H,
+					true,
+				);
+
+				// In the entity's local space, after preDraw translate(-anchor * sourceSize):
+				// - Frame draws at (trim.x, trim.y)
+				// - Character center within trimmed frame = anchor * frameSize
+				// - Character center in sourceSize coords = trim + anchor * frameSize
+				const centerX = f.trimX + f.frameW * anchor.x;
+				const centerY = f.trimY + f.frameH * anchor.y;
+
+				assert.ok(
+					Math.abs(centerX - expectedCenterX) < 1e-10,
+					`frame ${f.name}: centerX = ${centerX}, expected ${expectedCenterX}`,
+				);
+				assert.ok(
+					Math.abs(centerY - expectedCenterY) < 1e-10,
+					`frame ${f.name}: centerY = ${centerY}, expected ${expectedCenterY}`,
+				);
+			}
+		});
+
+		it("should maintain stable sourceSize dimensions across all frames", () => {
+			// All frames from the same animation should have the same sourceSize.
+			// setRegion uses sourceSize for this.width/this.height, so they stay constant.
+			for (const f of WALK_FRAMES) {
+				// The sprite's width/height = sourceSize (not frame dimensions)
+				assert.strictEqual(SOURCE_W, 187, `frame ${f.name}: sourceW`);
+				assert.strictEqual(SOURCE_H, 324, `frame ${f.name}: sourceH`);
+				// Frame dimensions vary
+				assert.notStrictEqual(
+					f.frameW,
+					SOURCE_W,
+					`frame ${f.name}: frameW should differ from sourceW`,
+				);
+			}
+		});
+	});
+
+	describe("rotated frame trim offset", () => {
+		it("should transform trim offset correctly for -π/2 rotation", () => {
+			// For a -π/2 rotation, the draw code computes:
+			//   xpos = pos.x - frameH - trim.y
+			//   ypos = pos.x + trim.x
+			// After the rotation transform (x,y) → (y,-x), the screen position becomes:
+			//   screen.x = ypos = trim.x
+			//   screen.y = -xpos = frameH + trim.y
+			// The image rect on screen has its TOP-LEFT at (trim.x, trim.y)
+
+			for (const f of WALK_FRAMES) {
+				if (!f.rotated) {
+					continue;
+				}
+
+				// In the rotated draw space (after rotate(-π/2)):
+				const drawX = -f.frameH - f.trimY;
+				const drawY = f.trimX;
+
+				// The rotation maps (x, y) → (y, -x):
+				// Top-left corner of the drawn rect:
+				//   (-frameH - trimY, trimX) → mapped through rotation
+				// But the full rect corners under rotation give screen top-left at (trimX, trimY)
+
+				// Verify: the bottom-left of the draw rect maps to the screen top-left
+				// Draw bottom-left = (drawX, drawY + frameW) - since after swap, the draw rect
+				// is (atlasW=frameH, atlasH=frameW), and the frame extends by frameW in Y
+				// But actually the key invariant is:
+				// After rotation, the visible frame's top-left on screen = (trimX, trimY)
+				//
+				// Corner (drawX + atlasW, drawY) where atlasW = frameH:
+				// = (-frameH - trimY + frameH, trimX) = (-trimY, trimX)
+				// After rotation: (trimX, trimY) ← This is the screen top-left!
+
+				const cornerX = drawX + f.frameH; // -trimY
+				const cornerY = drawY; // trimX
+
+				// After -π/2 rotation: (x, y) → (y, -x)
+				const screenX = cornerY; // trimX
+				const screenY = -cornerX; // trimY
+
+				assert.strictEqual(
+					screenX,
+					f.trimX,
+					`frame ${f.name}: screen top-left X should be trimX (${f.trimX}), got ${screenX}`,
+				);
+				assert.strictEqual(
+					screenY,
+					f.trimY,
+					`frame ${f.name}: screen top-left Y should be trimY (${f.trimY}), got ${screenY}`,
+				);
+			}
+		});
+
+		it("should produce the same character center for rotated and non-rotated frames", () => {
+			const expectedCenterX = SOURCE_W * 0.5;
+			const expectedCenterY = SOURCE_H * 0.5;
+
+			for (const f of WALK_FRAMES) {
+				const anchor = computeAnchorPoint(
+					PIVOT,
+					f.frameW,
+					f.frameH,
+					f.trimX,
+					f.trimY,
+					SOURCE_W,
+					SOURCE_H,
+					true,
+				);
+
+				// Whether rotated or not, the character center in sourceSize coords
+				// is at trim + anchor * frameSize
+				const centerX = f.trimX + f.frameW * anchor.x;
+				const centerY = f.trimY + f.frameH * anchor.y;
+
+				assert.ok(
+					Math.abs(centerX - expectedCenterX) < 1e-10,
+					`frame ${f.name} (rotated=${!!f.rotated}): centerX = ${centerX}`,
+				);
+				assert.ok(
+					Math.abs(centerY - expectedCenterY) < 1e-10,
+					`frame ${f.name} (rotated=${!!f.rotated}): centerY = ${centerY}`,
+				);
+			}
+		});
+	});
+
+	describe("entity anchor sync logic", () => {
+		it("should sync when entity anchor is at default (0, 0)", () => {
+			const entityAnchor = { x: 0, y: 0 };
+			const renderableAnchor = { x: 0.5, y: 0.5 };
+
+			// sync condition: entityAnchor === (0, 0)
+			if (entityAnchor.x === 0 && entityAnchor.y === 0) {
+				entityAnchor.x = renderableAnchor.x;
+				entityAnchor.y = renderableAnchor.y;
+			}
+
+			assert.strictEqual(entityAnchor.x, 0.5);
+			assert.strictEqual(entityAnchor.y, 0.5);
+		});
+
+		it("should not sync when entity anchor has been explicitly set", () => {
+			const entityAnchor = { x: 0.5, y: 1.0 };
+			const renderableAnchor = { x: 0.5, y: 0.5 };
+
+			if (entityAnchor.x === 0 && entityAnchor.y === 0) {
+				entityAnchor.x = renderableAnchor.x;
+				entityAnchor.y = renderableAnchor.y;
+			}
+
+			// Should remain at the explicit values
+			assert.strictEqual(entityAnchor.x, 0.5);
+			assert.strictEqual(entityAnchor.y, 1.0);
+		});
+
+		it("should preserve (0, 0) when renderable also has (0, 0)", () => {
+			const entityAnchor = { x: 0, y: 0 };
+			const renderableAnchor = { x: 0, y: 0 };
+
+			if (entityAnchor.x === 0 && entityAnchor.y === 0) {
+				entityAnchor.x = renderableAnchor.x;
+				entityAnchor.y = renderableAnchor.y;
+			}
+
+			assert.strictEqual(entityAnchor.x, 0);
+			assert.strictEqual(entityAnchor.y, 0);
+		});
+
+		it("should center body and renderable when both anchors match", () => {
+			// With entity anchor = renderable anchor = (0.5, 0.5):
+			// Entity.preDraw: translate(pos + bodyOffset + 0.5 * bodySize)
+			// Renderable.preDraw: translate(-0.5 * renderableSize)
+			// Body center = pos + bodyOffset + bodySize/2
+			// Visual center = pos + bodyOffset + 0.5*bodySize - 0.5*renderableSize + renderableSize/2
+			//               = pos + bodyOffset + 0.5*bodySize
+			// Both centers at the same point!
+
+			const bodyW = 100,
+				bodyH = 300;
+			const renderW = 187,
+				renderH = 324;
+			const anchor = 0.5;
+
+			const bodyCenterOffset = { x: anchor * bodyW, y: anchor * bodyH };
+			const visualCenterOffset = {
+				x: anchor * bodyW - anchor * renderW + renderW / 2,
+				y: anchor * bodyH - anchor * renderH + renderH / 2,
+			};
+
+			assert.strictEqual(bodyCenterOffset.x, visualCenterOffset.x);
+			assert.strictEqual(bodyCenterOffset.y, visualCenterOffset.y);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- **Sprite.setRegion**: use `sourceSize` for width/height on trimmed frames, recover stable anchorPoint from trim offset, cache trim data per frame
- **Sprite.draw**: apply trim offset after rotation handling, with coordinate transform `(-ty, +tx)` for -π/2 rotated atlas frames
- **Entity**: auto-inherit renderable's anchorPoint when entity is at default `(0,0)` — backward compatible with Tiled entities (TMX loader always passes explicit `anchorPoint: {x:0, y:0}`)
- **TexturePacker parser**: include `sourceSize` in parsed region data
- **atlas.createAnimationFromName**: use `sourceSize` for frame dimensions
- Added unit tests for trim math (`node:test`) and sprite/entity integration (`vitest`)

## Test plan
- [x] `node --test tests/texturepacker-parser.node-test.js` — 10 pure math tests pass
- [x] Sprite trimming vitest tests — 14 integration tests pass
- [x] TexturePacker example: sprite no longer jumps on rotated frames, body/renderable aligned
- [x] Platformer example: unchanged behavior (Tiled entities unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)