### PR TITLE
[#1008] Deprecate Entity in favor of Sprite/Renderable + Body

### DIFF
--- a/packages/examples/src/examples/platformer/entities/enemies.ts
+++ b/packages/examples/src/examples/platformer/entities/enemies.ts
@@ -1,45 +1,51 @@
-import { audio, collision, Entity, game, ParticleEmitter, Rect } from "melonjs";
+import {
+	audio,
+	Body,
+	collision,
+	game,
+	ParticleEmitter,
+	Rect,
+	Sprite,
+} from "melonjs";
 import { gameState } from "../gameState";
 
 /**
- * An enemy entity
+ * A base enemy entity using Sprite + Body
  * follow a horizontal path defined by the box size in Tiled
  */
-class PathEnemyEntity extends Entity {
+class PathEnemyEntity extends Sprite {
+	alive: boolean;
+	startX: number;
+	endX: number;
+	walkLeft: boolean;
+	isMovingEnemy: boolean;
+	particleTint: string;
+
 	/**
 	 * constructor
 	 */
-	constructor(x, y, settings) {
+	constructor(x, y, settings, frameNames: string[]) {
 		// save the area size defined in Tiled
 		const width = settings.width || settings.framewidth;
 
-		// adjust the setting size to the sprite one
-		settings.width = settings.framewidth;
-		settings.height = settings.frameheight;
+		// create the sprite from texture atlas animation frames
+		super(x, y, {
+			...gameState.texture.getAnimationSettings(frameNames),
+			anchorPoint: { x: 0, y: 0 },
+		});
 
-		// redefine the default shape (used to define path) with a shape matching the renderable
-		settings.shapes[0] = new Rect(
-			0,
-			0,
-			settings.framewidth,
-			settings.frameheight,
-		);
-
-		// call the super constructor
-		super(x, y, settings);
+		// add a physic body matching the sprite max frame dimensions
+		this.body = new Body(this, new Rect(0, 0, this.width, this.height));
 
 		// set start/end position based on the initial area size
-		this.startX = this.pos.x;
-		this.endX = this.pos.x + width - settings.framewidth;
-		this.pos.x = this.pos.x + width - settings.framewidth;
-
-		// enemies are not impacted by gravity
-		this.body.gravityScale = 0;
+		this.startX = x;
+		this.endX = x + width - settings.framewidth;
+		this.pos.x = x + width - settings.framewidth;
 
 		this.walkLeft = false;
 
 		// body walking & flying speed
-		this.body.setMaxVelocity(settings.velX || 1, settings.velY || 0);
+		this.body.setMaxVelocity(settings.velX || 1, settings.velY || 15);
 
 		// set a "enemyObject" type
 		this.body.collisionType = collision.types.ENEMY_OBJECT;
@@ -55,6 +61,9 @@ class PathEnemyEntity extends Entity {
 		// a specific flag to recognize these enemies
 		this.isMovingEnemy = true;
 
+		// living state
+		this.alive = true;
+
 		// default tint for particles
 		this.particleTint = "#FFF";
 	}
@@ -68,7 +77,7 @@ class PathEnemyEntity extends Entity {
 				if (this.pos.x <= this.startX) {
 					// if reach start position
 					this.walkLeft = false;
-					this.renderable.flipX(true);
+					this.flipX(true);
 				} else {
 					this.body.force.x = -this.body.maxVel.x;
 				}
@@ -78,7 +87,7 @@ class PathEnemyEntity extends Entity {
 			if (this.pos.x >= this.endX) {
 				// if reach the end position
 				this.walkLeft = true;
-				this.renderable.flipX(false);
+				this.flipX(false);
 			} else {
 				this.body.force.x = this.body.maxVel.x;
 			}
@@ -91,7 +100,12 @@ class PathEnemyEntity extends Entity {
 	/**
 	 * collision handle
 	 */
-	onCollision(response) {
+	onCollision(response, other) {
+		if (other.body.collisionType === collision.types.WORLD_SHAPE) {
+			// solid against world shapes (platforms, ground)
+			return true;
+		}
+
 		// res.y >0 means touched by something on the bottom
 		// which mean at top position for this one
 		if (this.alive && response.overlapV.y > 0 && response.a.body.falling) {
@@ -102,7 +116,7 @@ class PathEnemyEntity extends Entity {
 			// make the body static
 			this.body.setStatic(true);
 			// set dead animation
-			this.renderable.setCurrentAnimation("dead");
+			this.setCurrentAnimation("dead");
 
 			const emitter = new ParticleEmitter(this.centerX, this.centerY, {
 				width: this.width / 4,
@@ -129,7 +143,7 @@ class PathEnemyEntity extends Entity {
 }
 
 /**
- * An Slime enemy entity
+ * A Slime enemy entity
  * follow a horizontal path defined by the box size in Tiled
  */
 export class SlimeEnemyEntity extends PathEnemyEntity {
@@ -137,11 +151,8 @@ export class SlimeEnemyEntity extends PathEnemyEntity {
 	 * constructor
 	 */
 	constructor(x, y, settings) {
-		// super constructor
-		super(x, y, settings);
-
-		// set a renderable
-		this.renderable = gameState.texture.createAnimationFromName([
+		// super constructor with slime frame names
+		super(x, y, settings, [
 			"slime_normal.png",
 			"slime_walk.png",
 			"slime_dead.png",
@@ -149,22 +160,16 @@ export class SlimeEnemyEntity extends PathEnemyEntity {
 
 		// custom animation speed ?
 		if (settings.animationspeed) {
-			this.renderable.animationspeed = settings.animationspeed;
+			this.animationspeed = settings.animationspeed;
 		}
 
-		// walking animatin
-		this.renderable.addAnimation("walk", [
-			"slime_normal.png",
-			"slime_walk.png",
-		]);
-		// dead animatin
-		this.renderable.addAnimation("dead", ["slime_dead.png"]);
+		// walking animation
+		this.addAnimation("walk", ["slime_normal.png", "slime_walk.png"]);
+		// dead animation
+		this.addAnimation("dead", ["slime_dead.png"]);
 
 		// set default one
-		this.renderable.setCurrentAnimation("walk");
-
-		// set the renderable position to bottom center
-		this.anchorPoint.set(0.5, 1.0);
+		this.setCurrentAnimation("walk");
 
 		// particle tint matching the sprite color
 		this.particleTint = "#FF35B8";
@@ -172,41 +177,68 @@ export class SlimeEnemyEntity extends PathEnemyEntity {
 }
 
 /**
- * An Fly enemy entity
+ * A Fly enemy entity
  * follow a horizontal path defined by the box size in Tiled
  */
 export class FlyEnemyEntity extends PathEnemyEntity {
+	startY: number;
+	endY: number;
+	flyUp: boolean;
+
 	/**
 	 * constructor
 	 */
 	constructor(x, y, settings) {
-		// super constructor
-		super(x, y, settings);
+		// super constructor with fly frame names
+		super(x, y, settings, ["fly_normal.png", "fly_fly.png", "fly_dead.png"]);
 
-		// set a renderable
-		this.renderable = gameState.texture.createAnimationFromName([
-			"fly_normal.png",
-			"fly_fly.png",
-			"fly_dead.png",
-		]);
+		// set vertical patrol range (bob up and down by half height)
+		const bobRange = settings.height || this.height;
+		this.startY = y;
+		this.endY = y + bobRange;
+		this.flyUp = true;
+
+		// allow vertical movement
+		this.body.setMaxVelocity(settings.velX || 1, settings.velY || 1);
 
 		// custom animation speed ?
 		if (settings.animationspeed) {
-			this.renderable.animationspeed = settings.animationspeed;
+			this.animationspeed = settings.animationspeed;
 		}
 
-		// walking animatin
-		this.renderable.addAnimation("walk", ["fly_normal.png", "fly_fly.png"]);
-		// dead animatin
-		this.renderable.addAnimation("dead", ["fly_dead.png"]);
+		// walking animation
+		this.addAnimation("walk", ["fly_normal.png", "fly_fly.png"]);
+		// dead animation
+		this.addAnimation("dead", ["fly_dead.png"]);
 
 		// set default one
-		this.renderable.setCurrentAnimation("walk");
-
-		// set the renderable position to bottom center
-		this.anchorPoint.set(0.5, 1.0);
+		this.setCurrentAnimation("walk");
 
 		// particle tint matching the sprite color
 		this.particleTint = "#000000";
+	}
+
+	/**
+	 * manage the fly movement (horizontal + vertical bobbing)
+	 */
+	update(dt) {
+		if (this.alive) {
+			// vertical bobbing — apply force against gravity to fly
+			if (this.flyUp) {
+				if (this.pos.y <= this.startY) {
+					this.flyUp = false;
+				} else {
+					this.body.force.y = -this.body.maxVel.y;
+				}
+			} else {
+				if (this.pos.y >= this.endY) {
+					this.flyUp = true;
+				} else {
+					this.body.force.y = this.body.maxVel.y;
+				}
+			}
+		}
+
+		return super.update(dt);
 	}
 }

--- a/packages/examples/src/examples/platformer/entities/player.ts
+++ b/packages/examples/src/examples/platformer/entities/player.ts
@@ -1,19 +1,51 @@
 import {
 	audio,
+	Body,
 	collision,
-	Entity,
 	game,
 	input,
 	level,
+	Rect,
+	Sprite,
 	timer,
 	video,
 } from "melonjs";
 import { gameState } from "../gameState";
 
-export class PlayerEntity extends Entity {
+export class PlayerEntity extends Sprite {
+	dying: boolean;
+	multipleJump: number;
+
 	constructor(x, y, settings) {
-		// call the constructor
-		super(x, y, settings);
+		// create the sprite using atlas animation frames
+		super(x, y, {
+			...gameState.texture.getAnimationSettings([
+				"walk0001.png",
+				"walk0002.png",
+				"walk0003.png",
+				"walk0004.png",
+				"walk0005.png",
+				"walk0006.png",
+				"walk0007.png",
+				"walk0008.png",
+				"walk0009.png",
+				"walk0010.png",
+				"walk0011.png",
+			]),
+			anchorPoint: { x: 0, y: 0 },
+		});
+
+		// add a physic body using the Tiled object dimensions,
+		// centered horizontally and bottom-aligned within the sprite frame
+		this.body = new Body(
+			this,
+			new Rect(
+				(this.width - settings.width) / 2,
+				this.height - settings.height,
+				settings.width,
+				settings.height,
+			),
+		);
 
 		// set a "player object" type
 		this.body.collisionType = collision.types.PLAYER_OBJECT;
@@ -44,9 +76,6 @@ export class PlayerEntity extends Entity {
 		input.bindKey(input.KEY.D, "right");
 		input.bindKey(input.KEY.W, "jump", true);
 		input.bindKey(input.KEY.S, "down");
-
-		//me.input.registerPointerEvent("pointerdown", this, this.onCollision.bind(this));
-		//me.input.bindPointer(me.input.pointer.RIGHT, me.input.KEY.LEFT);
 
 		input.bindGamepad(
 			0,
@@ -101,31 +130,14 @@ export class PlayerEntity extends Entity {
 			input.KEY.UP,
 		);
 
-		// set a renderable
-		this.renderable = gameState.texture.createAnimationFromName([
-			"walk0001.png",
-			"walk0002.png",
-			"walk0003.png",
-			"walk0004.png",
-			"walk0005.png",
-			"walk0006.png",
-			"walk0007.png",
-			"walk0008.png",
-			"walk0009.png",
-			"walk0010.png",
-			"walk0011.png",
-		]);
-
-		// define a basic walking animatin
-		this.renderable.addAnimation("stand", [
-			{ name: "walk0001.png", delay: 100 },
-		]);
-		this.renderable.addAnimation("walk", [
+		// define a basic walking animation
+		this.addAnimation("stand", [{ name: "walk0001.png", delay: 100 }]);
+		this.addAnimation("walk", [
 			{ name: "walk0001.png", delay: 100 },
 			{ name: "walk0002.png", delay: 100 },
 			{ name: "walk0003.png", delay: 100 },
 		]);
-		this.renderable.addAnimation("jump", [
+		this.addAnimation("jump", [
 			{ name: "walk0004.png", delay: 150 },
 			{ name: "walk0005.png", delay: 150 },
 			{ name: "walk0006.png", delay: 150 },
@@ -134,10 +146,7 @@ export class PlayerEntity extends Entity {
 		]);
 
 		// set as default
-		this.renderable.setCurrentAnimation("walk");
-
-		// set the renderable position to bottom center
-		this.anchorPoint.set(0.5, 1.0);
+		this.setCurrentAnimation("walk");
 	}
 
 	/**
@@ -146,20 +155,20 @@ export class PlayerEntity extends Entity {
 	update(dt) {
 		if (input.isKeyPressed("left")) {
 			if (this.body.vel.y === 0) {
-				this.renderable.setCurrentAnimation("walk");
+				this.setCurrentAnimation("walk");
 			}
 			this.body.force.x = -this.body.maxVel.x;
-			this.renderable.flipX(true);
+			this.flipX(true);
 		} else if (input.isKeyPressed("right")) {
 			if (this.body.vel.y === 0) {
-				this.renderable.setCurrentAnimation("walk");
+				this.setCurrentAnimation("walk");
 			}
 			this.body.force.x = this.body.maxVel.x;
-			this.renderable.flipX(false);
+			this.flipX(false);
 		}
 
 		if (input.isKeyPressed("jump")) {
-			this.renderable.setCurrentAnimation("jump");
+			this.setCurrentAnimation("jump");
 			this.body.jumping = true;
 			if (this.multipleJump <= 2) {
 				// easy "math" for double jump
@@ -178,7 +187,7 @@ export class PlayerEntity extends Entity {
 		}
 
 		if (this.body.force.x === 0 && this.body.force.y === 0) {
-			this.renderable.setCurrentAnimation("stand");
+			this.setCurrentAnimation("stand");
 		}
 
 		// check if we fell into a hole
@@ -194,11 +203,7 @@ export class PlayerEntity extends Entity {
 		}
 
 		// check if we moved (an "idle" animation would definitely be cleaner)
-		if (
-			this.body.vel.x !== 0 ||
-			this.body.vel.y !== 0 ||
-			this.renderable?.isFlickering()
-		) {
+		if (this.body.vel.x !== 0 || this.body.vel.y !== 0 || this.isFlickering()) {
 			super.update(dt);
 			return true;
 		}
@@ -272,14 +277,12 @@ export class PlayerEntity extends Entity {
 	 * ouch
 	 */
 	hurt() {
-		const sprite = this.renderable;
-
-		if (!sprite.isFlickering()) {
+		if (!this.isFlickering()) {
 			// tint to red and flicker
-			sprite.tint.setColor(255, 192, 192);
-			sprite.flicker(750, () => {
+			this.tint.setColor(255, 192, 192);
+			this.flicker(750, () => {
 				// clear the tint once the flickering effect is over
-				sprite.tint.setColor(255, 255, 255);
+				this.tint.setColor(255, 255, 255);
 			});
 
 			// flash the screen

--- a/packages/melonjs/src/renderable/entity/entity.js
+++ b/packages/melonjs/src/renderable/entity/entity.js
@@ -1,4 +1,5 @@
 import { polygonPool } from "../../geometries/polygon.ts";
+import { warning } from "../../lang/console.js";
 import { vector2dPool } from "../../math/vector2d.ts";
 import Body from "../../physics/body.js";
 import Renderable from "../renderable.js";
@@ -16,6 +17,144 @@ import Sprite from "../sprite.js";
 
 /**
  * a Generic Object Entity
+ * @deprecated since 18.1.0 — use {@link Sprite} or {@link Renderable} combined with {@link Body} instead.
+ *
+ * ### Why Entity is deprecated
+ *
+ * `Entity` introduced an unnecessary extra layer: it wrapped a child {@link Renderable} (typically a {@link Sprite})
+ * inside a parent object that also held a {@link Body}. This design led to a number of long-standing issues:
+ *
+ * - **Anchor point confusion** — Entity used its own anchor point to position the child renderable relative to the
+ *   body bounds, which behaved differently from the standard {@link Renderable} anchor point. This caused
+ *   persistent alignment bugs with bounds and rendering (see issues #848, #834, #754, #580, #922).
+ * - **Indirect API** — animations, flipping, tinting, and other visual operations had to go through
+ *   `this.renderable` instead of being called directly, making the API more verbose and error-prone.
+ * - **Custom rendering pipeline** — Entity overrode `preDraw`/`draw` with a custom coordinate system that
+ *   differed from the rest of the engine, making it harder to reason about positioning and transforms.
+ *
+ * ### The Sprite + Body approach
+ *
+ * The recommended replacement is to extend {@link Sprite} (for animated/image-based objects) or
+ * {@link Renderable} (for custom-drawn objects) directly, and attach a {@link Body} in the constructor.
+ * This approach:
+ *
+ * - Uses the **standard rendering pipeline** — no custom `preDraw` or coordinate system surprises.
+ * - Provides a **direct API** — call `this.flipX()`, `this.setCurrentAnimation()`, `this.tint` directly.
+ * - Aligns with **industry conventions** — attaching a physics body to a renderable is the standard pattern
+ *   used by other game engines.
+ * - Gives **full control** over body shape and position within the sprite frame.
+ *
+ * ### Migration Guide
+ *
+ * #### Example 1 — Animated Sprite with physics (using a texture atlas)
+ * ```js
+ * class PlayerSprite extends me.Sprite {
+ *     constructor(x, y, settings) {
+ *         // create the Sprite using atlas animation frames
+ *         super(x, y, {
+ *             ...game.texture.getAnimationSettings([
+ *                 "walk0001.png", "walk0002.png", "walk0003.png"
+ *             ]),
+ *             anchorPoint: { x: 0.5, y: 1.0 }
+ *         });
+ *
+ *         // add a physic body (use Tiled shapes if available, or define your own)
+ *         this.body = new me.Body(this,
+ *             settings.shapes || new me.Rect(0, 0, settings.width, settings.height)
+ *         );
+ *         this.body.collisionType = me.collision.types.PLAYER_OBJECT;
+ *         this.body.setMaxVelocity(3, 15);
+ *         this.body.setFriction(0.4, 0);
+ *
+ *         // define animations (called directly on the sprite, not on this.renderable)
+ *         this.addAnimation("walk", ["walk0001.png", "walk0002.png", "walk0003.png"]);
+ *         this.setCurrentAnimation("walk");
+ *     }
+ *
+ *     update(dt) {
+ *         // input handling, animations, etc. — all directly on `this`
+ *         if (me.input.isKeyPressed("right")) {
+ *             this.body.force.x = this.body.maxVel.x;
+ *             this.flipX(false);
+ *         }
+ *         return super.update(dt);
+ *     }
+ *
+ *     onCollision(response, other) {
+ *         return true; // solid
+ *     }
+ * }
+ * ```
+ *
+ * #### Example 2 — Sprite with physics (using a standalone spritesheet image)
+ * ```js
+ * class EnemySprite extends me.Sprite {
+ *     constructor(x, y, settings) {
+ *         super(x, y, Object.assign({
+ *             image: "enemy_spritesheet",
+ *             framewidth: 32,
+ *             frameheight: 32,
+ *         }, settings));
+ *
+ *         // add a physic body
+ *         this.body = new me.Body(this, new me.Rect(0, 0, this.width, this.height));
+ *         this.body.collisionType = me.collision.types.ENEMY_OBJECT;
+ *         this.body.setMaxVelocity(1, 1);
+ *         this.body.gravityScale = 0;
+ *
+ *         this.addAnimation("walk", [0, 1, 2, 3]);
+ *         this.addAnimation("dead", [4]);
+ *         this.setCurrentAnimation("walk");
+ *     }
+ *
+ *     onCollision(response, other) {
+ *         return false;
+ *     }
+ * }
+ * ```
+ *
+ * #### Example 3 — Custom-drawn Renderable with physics
+ * ```js
+ * class CustomBall extends me.Renderable {
+ *     constructor(x, y, radius) {
+ *         super(x, y, radius * 2, radius * 2);
+ *         this.radius = radius;
+ *
+ *         // add a physic body with a circular shape
+ *         this.body = new me.Body(this, new me.Ellipse(radius, radius, radius * 2, radius * 2));
+ *         this.body.collisionType = me.collision.types.ENEMY_OBJECT;
+ *         this.body.setMaxVelocity(4, 4);
+ *         this.body.gravityScale = 0;
+ *         this.body.force.set(
+ *             me.Math.randomFloat(-4, 4),
+ *             me.Math.randomFloat(-4, 4)
+ *         );
+ *     }
+ *
+ *     update(dt) {
+ *         return super.update(dt);
+ *     }
+ *
+ *     draw(renderer) {
+ *         renderer.setColor("#FF0000");
+ *         renderer.fillEllipse(
+ *             this.width / 2, this.height / 2,
+ *             this.radius, this.radius
+ *         );
+ *     }
+ *
+ *     onCollision(response, other) {
+ *         // bounce off on collision
+ *         this.body.force.x = -this.body.force.x;
+ *         this.body.force.y = -this.body.force.y;
+ *         return false;
+ *     }
+ * }
+ * ```
+ *
+ * @see Sprite
+ * @see Renderable
+ * @see Body
  */
 export default class Entity extends Renderable {
 	/**
@@ -34,8 +173,12 @@ export default class Entity extends Renderable {
 	 * @param {string} [settings.type] - object type
 	 * @param {number} [settings.collisionMask] - Mask collision detection for this object
 	 * @param {Rect[]|Polygon[]|Line[]|Ellipse[]} [settings.shapes] - the initial list of collision shapes (usually populated through Tiled)
+	 * @deprecated since 18.1.0 — see the class-level documentation for migration examples
 	 */
 	constructor(x, y, settings) {
+		// deprecation warning
+		warning("me.Entity", "me.Sprite combined with me.Body", "18.1.0");
+
 		// call the super constructor
 		super(x, y, settings.width, settings.height);
 

--- a/packages/melonjs/src/video/texture/atlas.js
+++ b/packages/melonjs/src/video/texture/atlas.js
@@ -478,14 +478,90 @@ export class TextureAtlas {
 	 * // set the renderable position to bottom center
 	 * sprite.anchorPoint.set(0.5, 1.0);
 	 */
+	/**
+	 * Return the Sprite settings object (framewidth, frameheight, atlas, atlasIndices, etc.)
+	 * for the given set of atlas frame names. This is useful when extending {@link Sprite}
+	 * and you need to pass atlas animation data to the parent constructor.
+	 * @param {string[]|number[]} [names] - list of names for each sprite
+	 * (when manually creating a Texture out of a spritesheet, only numeric values are authorized).
+	 * If not specified, all defined names/entries in the atlas will be added.
+	 * @returns {object} A settings object suitable for passing to the {@link Sprite} constructor
+	 * @example
+	 * // extend Sprite directly with texture atlas animation frames
+	 * class MyPlayer extends me.Sprite {
+	 *     constructor(x, y, settings) {
+	 *         super(x, y, {
+	 *             ...game.texture.getAnimationSettings([
+	 *                 "walk0001.png", "walk0002.png", "walk0003.png"
+	 *             ]),
+	 *             anchorPoint: { x: 0.5, y: 1.0 }
+	 *         });
+	 *         // add a physic body
+	 *         this.body = new me.Body(this, new me.Rect(0, 0, this.width, this.height));
+	 *     }
+	 * }
+	 */
+	getAnimationSettings(names) {
+		const tpAtlas = [];
+		const indices = {};
+		let width = 0;
+		let height = 0;
+		const textureAtlas = this.getAtlas();
+
+		if (typeof names === "undefined") {
+			names = textureAtlas;
+		}
+
+		// first pass: collect regions and compute max dimensions
+		const regions = [];
+		for (const i in names) {
+			const name = Array.isArray(names) ? names[i] : i;
+			const region = this.getRegion(name);
+			if (region == null) {
+				throw new Error("Texture - region for " + name + " not found");
+			}
+			regions.push({ name, region });
+			const frameW = region.sourceSize ? region.sourceSize.w : region.width;
+			const frameH = region.sourceSize ? region.sourceSize.h : region.height;
+			width = Math.max(frameW, width);
+			height = Math.max(frameH, height);
+		}
+
+		// second pass: clone regions, strip anchorPoint,
+		// and add trim offset to bottom-align smaller frames
+		for (const { name, region } of regions) {
+			const regionCopy = Object.assign({}, region);
+			delete regionCopy.anchorPoint;
+
+			const frameH = region.sourceSize ? region.sourceSize.h : region.height;
+			if (frameH < height) {
+				// bottom-align by offsetting the y draw position
+				regionCopy.trim = Object.assign({}, region.trim || { x: 0, y: 0 });
+				regionCopy.trim.y += height - frameH;
+			}
+
+			tpAtlas.push(regionCopy);
+			indices[name] = tpAtlas.length - 1;
+		}
+
+		return {
+			image: this,
+			framewidth: width,
+			frameheight: height,
+			margin: 0,
+			spacing: 0,
+			atlas: tpAtlas,
+			anims: textureAtlas.anims,
+			atlasIndices: indices,
+		};
+	}
+
 	createAnimationFromName(names, settings) {
 		const tpAtlas = [];
 		const indices = {};
 		let width = 0;
 		let height = 0;
 		const textureAtlas = this.getAtlas();
-		// iterate through the given names
-		// and create a "normalized" atlas
 
 		if (typeof names === "undefined") {
 			names = textureAtlas;
@@ -495,16 +571,12 @@ export class TextureAtlas {
 			const name = Array.isArray(names) ? names[i] : i;
 			const region = this.getRegion(name);
 			if (region == null) {
-				// throw an error
 				throw new Error("Texture - region for " + name + " not found");
 			}
 			tpAtlas.push(region);
-			// save the corresponding index
 			indices[name] = tpAtlas.length - 1;
-			// use sourceSize (original untrimmed size) if available for stable bounds
 			const frameW = region.sourceSize ? region.sourceSize.w : region.width;
 			const frameH = region.sourceSize ? region.sourceSize.h : region.height;
-			// calculate the max size of a frame
 			width = Math.max(frameW, width);
 			height = Math.max(frameH, height);
 		}

--- a/packages/melonjs/tests/texture.spec.js
+++ b/packages/melonjs/tests/texture.spec.js
@@ -1,5 +1,11 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { boot, CanvasTexture, video } from "../src/index.js";
+import {
+	boot,
+	CanvasTexture,
+	Sprite,
+	TextureAtlas,
+	video,
+} from "../src/index.js";
 
 describe("Texture", () => {
 	beforeAll(() => {
@@ -222,6 +228,288 @@ describe("Texture", () => {
 			// get should return the first one stored
 			const retrieved = cache.get(canvas.canvas);
 			expect(retrieved).toBe(atlas1);
+		});
+	});
+
+	describe("TextureAtlas.getAnimationSettings", () => {
+		let atlas;
+
+		beforeAll(() => {
+			// create a mock texture atlas using TexturePacker JSON format
+			const mockImage = video.createCanvas(256, 256);
+			const atlasJSON = {
+				meta: {
+					app: "https://www.codeandweb.com/texturepacker",
+					size: { w: 256, h: 256 },
+					image: "default",
+				},
+				frames: [
+					{
+						filename: "walk0001.png",
+						frame: { x: 0, y: 0, w: 32, h: 48 },
+						rotated: false,
+						trimmed: false,
+						spriteSourceSize: { x: 0, y: 0, w: 32, h: 48 },
+						sourceSize: { w: 32, h: 48 },
+					},
+					{
+						filename: "walk0002.png",
+						frame: { x: 32, y: 0, w: 32, h: 48 },
+						rotated: false,
+						trimmed: false,
+						spriteSourceSize: { x: 0, y: 0, w: 32, h: 48 },
+						sourceSize: { w: 32, h: 48 },
+					},
+					{
+						filename: "walk0003.png",
+						frame: { x: 64, y: 0, w: 32, h: 48 },
+						rotated: false,
+						trimmed: false,
+						spriteSourceSize: { x: 0, y: 0, w: 32, h: 48 },
+						sourceSize: { w: 32, h: 48 },
+					},
+					{
+						filename: "idle0001.png",
+						frame: { x: 96, y: 0, w: 40, h: 52 },
+						rotated: false,
+						trimmed: false,
+						spriteSourceSize: { x: 0, y: 0, w: 40, h: 52 },
+						sourceSize: { w: 40, h: 52 },
+					},
+				],
+			};
+			atlas = new TextureAtlas(atlasJSON, mockImage);
+		});
+
+		it("should return a valid settings object with expected properties", () => {
+			const settings = atlas.getAnimationSettings([
+				"walk0001.png",
+				"walk0002.png",
+				"walk0003.png",
+			]);
+
+			expect(settings).toBeDefined();
+			expect(settings.image).toBe(atlas);
+			expect(settings.framewidth).toEqual(32);
+			expect(settings.frameheight).toEqual(48);
+			expect(settings.margin).toEqual(0);
+			expect(settings.spacing).toEqual(0);
+			expect(settings.atlas).toBeInstanceOf(Array);
+			expect(settings.atlas.length).toEqual(3);
+			expect(settings.atlasIndices).toBeDefined();
+			expect(settings.atlasIndices["walk0001.png"]).toEqual(0);
+			expect(settings.atlasIndices["walk0002.png"]).toEqual(1);
+			expect(settings.atlasIndices["walk0003.png"]).toEqual(2);
+		});
+
+		it("should compute framewidth/frameheight as the max across all requested frames", () => {
+			const settings = atlas.getAnimationSettings([
+				"walk0001.png",
+				"idle0001.png",
+			]);
+
+			// walk is 32x48, idle is 40x52 — max should be 40x52
+			expect(settings.framewidth).toEqual(40);
+			expect(settings.frameheight).toEqual(52);
+		});
+
+		it("should use all atlas entries when names is undefined", () => {
+			const settings = atlas.getAnimationSettings();
+
+			expect(settings.atlas.length).toEqual(4);
+			expect(settings.atlasIndices["walk0001.png"]).toBeDefined();
+			expect(settings.atlasIndices["walk0002.png"]).toBeDefined();
+			expect(settings.atlasIndices["walk0003.png"]).toBeDefined();
+			expect(settings.atlasIndices["idle0001.png"]).toBeDefined();
+		});
+
+		it("should throw when a requested frame name does not exist", () => {
+			expect(() => {
+				atlas.getAnimationSettings(["nonexistent.png"]);
+			}).toThrow(/region for nonexistent.png not found/);
+		});
+
+		it("should produce settings compatible with Sprite constructor", () => {
+			const settings = atlas.getAnimationSettings([
+				"walk0001.png",
+				"walk0002.png",
+				"walk0003.png",
+			]);
+
+			const sprite = new Sprite(0, 0, settings);
+			expect(sprite).toBeInstanceOf(Sprite);
+			expect(sprite.width).toEqual(32);
+			expect(sprite.height).toEqual(48);
+		});
+
+		it("should produce settings that enable addAnimation with frame names", () => {
+			const settings = atlas.getAnimationSettings([
+				"walk0001.png",
+				"walk0002.png",
+				"walk0003.png",
+			]);
+
+			const sprite = new Sprite(0, 0, settings);
+			const count = sprite.addAnimation("walk", [
+				"walk0001.png",
+				"walk0002.png",
+			]);
+			expect(count).toEqual(2);
+			sprite.setCurrentAnimation("walk");
+			expect(sprite.isCurrentAnimation("walk")).toEqual(true);
+		});
+
+		it("should produce identical results to createAnimationFromName", () => {
+			const settings = atlas.getAnimationSettings([
+				"walk0001.png",
+				"walk0002.png",
+				"walk0003.png",
+			]);
+			const spriteFromSettings = new Sprite(0, 0, settings);
+
+			const spriteFromFactory = atlas.createAnimationFromName([
+				"walk0001.png",
+				"walk0002.png",
+				"walk0003.png",
+			]);
+
+			// same dimensions
+			expect(spriteFromSettings.width).toEqual(spriteFromFactory.width);
+			expect(spriteFromSettings.height).toEqual(spriteFromFactory.height);
+
+			// same atlas data
+			expect(spriteFromSettings.textureAtlas.length).toEqual(
+				spriteFromFactory.textureAtlas.length,
+			);
+			expect(Object.keys(spriteFromSettings.atlasIndices).length).toEqual(
+				Object.keys(spriteFromFactory.atlasIndices).length,
+			);
+		});
+
+		it("should strip anchorPoint from atlas regions", () => {
+			// create an atlas with pivot/anchorPoint data (as TexturePacker exports)
+			const mockImage = video.createCanvas(256, 256);
+			const atlasWithPivot = new TextureAtlas(
+				{
+					meta: {
+						app: "https://www.codeandweb.com/texturepacker",
+						size: { w: 256, h: 256 },
+						image: "default",
+					},
+					frames: [
+						{
+							filename: "char0001.png",
+							frame: { x: 0, y: 0, w: 32, h: 48 },
+							rotated: false,
+							trimmed: false,
+							spriteSourceSize: { x: 0, y: 0, w: 32, h: 48 },
+							sourceSize: { w: 32, h: 48 },
+							pivot: { x: 0.5, y: 1.0 },
+						},
+						{
+							filename: "char0002.png",
+							frame: { x: 32, y: 0, w: 32, h: 48 },
+							rotated: false,
+							trimmed: false,
+							spriteSourceSize: { x: 0, y: 0, w: 32, h: 48 },
+							sourceSize: { w: 32, h: 48 },
+							pivot: { x: 0.5, y: 1.0 },
+						},
+					],
+				},
+				mockImage,
+			);
+
+			// verify the original regions have anchorPoint
+			const originalRegion = atlasWithPivot.getRegion("char0001.png");
+			expect(originalRegion.anchorPoint).toBeDefined();
+
+			// getAnimationSettings should strip it
+			const settings = atlasWithPivot.getAnimationSettings([
+				"char0001.png",
+				"char0002.png",
+			]);
+			for (const region of settings.atlas) {
+				expect(region.anchorPoint).toBeUndefined();
+			}
+
+			// Sprite created from these settings should keep its own anchor
+			const sprite = new Sprite(10, 20, {
+				...settings,
+				anchorPoint: { x: 0, y: 0 },
+			});
+			sprite.addAnimation("walk", ["char0001.png", "char0002.png"]);
+			sprite.setCurrentAnimation("walk");
+			// anchor should remain (0, 0), not overridden by the region
+			expect(sprite.anchorPoint.x).toEqual(0);
+			expect(sprite.anchorPoint.y).toEqual(0);
+		});
+
+		it("createAnimationFromName should preserve anchorPoint in regions", () => {
+			// create an atlas with pivot data
+			const mockImage = video.createCanvas(256, 256);
+			const atlasWithPivot = new TextureAtlas(
+				{
+					meta: {
+						app: "https://www.codeandweb.com/texturepacker",
+						size: { w: 256, h: 256 },
+						image: "default",
+					},
+					frames: [
+						{
+							filename: "hero0001.png",
+							frame: { x: 0, y: 0, w: 32, h: 48 },
+							rotated: false,
+							trimmed: false,
+							spriteSourceSize: { x: 0, y: 0, w: 32, h: 48 },
+							sourceSize: { w: 32, h: 48 },
+							pivot: { x: 0.5, y: 1.0 },
+						},
+					],
+				},
+				mockImage,
+			);
+
+			// createAnimationFromName should NOT strip anchorPoint (backward compat)
+			const sprite = atlasWithPivot.createAnimationFromName(["hero0001.png"]);
+			// the sprite's anchor should be set from the region's pivot
+			expect(sprite.anchorPoint.x).toEqual(0.5);
+			expect(sprite.anchorPoint.y).toEqual(1.0);
+		});
+
+		it("should bottom-align smaller frames via trim offset", () => {
+			// walk frames are 32x48, idle is 40x52 — max height is 52
+			const settings = atlas.getAnimationSettings([
+				"walk0001.png",
+				"idle0001.png",
+			]);
+
+			// walk frame (height 48) should get a trim.y offset of 52 - 48 = 4
+			const walkRegion = settings.atlas[settings.atlasIndices["walk0001.png"]];
+			expect(walkRegion.trim).toBeDefined();
+			expect(walkRegion.trim.y).toEqual(4);
+
+			// idle frame (height 52 = max) should NOT get a trim offset
+			const idleRegion = settings.atlas[settings.atlasIndices["idle0001.png"]];
+			// trim should be null/undefined or have y=0
+			if (idleRegion.trim) {
+				expect(idleRegion.trim.y).toEqual(0);
+			}
+		});
+
+		it("should not add trim when all frames have the same height", () => {
+			const settings = atlas.getAnimationSettings([
+				"walk0001.png",
+				"walk0002.png",
+				"walk0003.png",
+			]);
+
+			// all walk frames are 32x48 — no trim needed
+			for (const region of settings.atlas) {
+				if (region.trim) {
+					expect(region.trim.y).toEqual(0);
+				}
+			}
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Deprecate `Entity` with console warning and detailed migration guide explaining why (anchor point confusion, indirect API, custom rendering pipeline) and how to migrate (3 examples)
- New `TextureAtlas.getAnimationSettings()` method for extending `Sprite` with texture atlas animations — strips per-frame anchors and bottom-aligns smaller frames
- Platformer example fully migrated from Entity to Sprite + Body (player, slime with gravity, fly with physics-based flight)
- `createAnimationFromName()` unchanged for backward compatibility
- 11 new unit tests for `getAnimationSettings()`

## Test plan
- [x] All 1286 existing + new tests pass
- [x] Platformer example visually verified (player, slime, fly, coins, collision, death)
- [x] `createAnimationFromName()` backward compatibility verified by test
- [x] melonjs and examples packages build successfully

Closes #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)