### PR TITLE
Address review feedback from PR #1257 and #1258

### DIFF
--- a/packages/melonjs/src/level/tiled/TMXLayer.js
+++ b/packages/melonjs/src/level/tiled/TMXLayer.js
@@ -248,9 +248,8 @@ export default class TMXLayer extends Renderable {
 	onDeactivateEvent() {
 		// clear all allocated objects
 		this.animatedTilesets = undefined;
-		if (this.canvasRenderer) {
-			this.canvasRenderer = null;
-		}
+		// keep canvasRenderer for reuse — dropping the reference would leak
+		// event listeners registered by CanvasRenderer's constructor
 	}
 
 	/**

--- a/packages/melonjs/src/level/tiled/renderer/TMXRenderer.js
+++ b/packages/melonjs/src/level/tiled/renderer/TMXRenderer.js
@@ -84,7 +84,7 @@ export default class TMXRenderer {
 		// only adjust position if obj.gid is defined
 		if (typeof obj.gid === "number") {
 			// Tiled objects origin point is "bottom-left" in Tiled,
-			// "top-left" in melonJS)
+			// "top-left" in melonJS
 			obj.y -= obj.height;
 		}
 	}

--- a/packages/melonjs/src/renderable/entity/entity.js
+++ b/packages/melonjs/src/renderable/entity/entity.js
@@ -157,6 +157,8 @@ import Sprite from "../sprite.js";
  * @see Body
  */
 export default class Entity extends Renderable {
+	static _deprecationWarned = false;
+
 	/**
 	 * @param {number} x - the x coordinates of the entity object
 	 * @param {number} y - the y coordinates of the entity object
@@ -176,8 +178,11 @@ export default class Entity extends Renderable {
 	 * @deprecated since 18.1.0 — see the class-level documentation for migration examples
 	 */
 	constructor(x, y, settings) {
-		// deprecation warning
-		warning("me.Entity", "me.Sprite combined with me.Body", "18.1.0");
+		// deprecation warning (once per session)
+		if (!Entity._deprecationWarned) {
+			warning("me.Entity", "me.Sprite combined with me.Body", "18.1.0");
+			Entity._deprecationWarned = true;
+		}
 
 		// call the super constructor
 		super(x, y, settings.width, settings.height);

--- a/packages/melonjs/src/video/texture/atlas.js
+++ b/packages/melonjs/src/video/texture/atlas.js
@@ -517,8 +517,12 @@ export class TextureAtlas {
 		for (const i in names) {
 			const name = Array.isArray(names) ? names[i] : i;
 			const region = this.getRegion(name);
+			// skip non-region keys (e.g. "anims" added by Aseprite parser)
 			if (region == null) {
-				throw new Error("Texture - region for " + name + " not found");
+				if (Array.isArray(names)) {
+					throw new Error("Texture - region for " + name + " not found");
+				}
+				continue;
 			}
 			regions.push({ name, region });
 			const frameW = region.sourceSize ? region.sourceSize.w : region.width;

--- a/packages/melonjs/tests/tmxrenderer.spec.js
+++ b/packages/melonjs/tests/tmxrenderer.spec.js
@@ -123,16 +123,22 @@ describe("TMX Renderers", () => {
 			// This verifies the critical bug fix:
 			// previously this.centers[i].sub(rel) mutated the centers
 
-			// Call pixelToTileCoords multiple times with the same input
-			const result1 = renderer.pixelToTileCoords(50, 50);
-			const result2 = renderer.pixelToTileCoords(50, 50);
-			const result3 = renderer.pixelToTileCoords(50, 50);
+			// Call pixelToTileCoords to trigger center calculations
+			renderer.pixelToTileCoords(50, 50);
 
-			// Results should be identical since centers are not mutated
-			expect(result1.x).toEqual(result2.x);
-			expect(result1.y).toEqual(result2.y);
-			expect(result2.x).toEqual(result3.x);
-			expect(result2.y).toEqual(result3.y);
+			// Save centers values after first call
+			const centersAfterFirst = renderer.centers.map((c) => {
+				return { x: c.x, y: c.y };
+			});
+
+			// Call again — centers should be re-set to the same values
+			renderer.pixelToTileCoords(50, 50);
+
+			// Verify centers were not mutated by the distance calculation
+			for (let i = 0; i < 4; i++) {
+				expect(renderer.centers[i].x).toEqual(centersAfterFirst[i].x);
+				expect(renderer.centers[i].y).toEqual(centersAfterFirst[i].y);
+			}
 		});
 
 		it("pixelToTileCoords should return consistent results (staggerX)", () => {


### PR DESCRIPTION
## Summary
Follow-up fixes from Copilot review comments on the Entity deprecation (#1257) and TMX renderer cleanup (#1258) PRs:

- `getAnimationSettings()`: skip non-region keys like `anims` (from Aseprite parser) when iterating atlas without explicit names — avoids throwing on Aseprite atlases
- Entity deprecation warning: emit only once per session via static flag instead of on every `new Entity()`
- TMXRenderer: fix comment typo (unmatched parenthesis)
- TMXLayer: revert canvasRenderer nulling to avoid leaking CanvasRenderer event listeners
- Hex renderer test: verify actual center values aren't mutated, not just that repeated calls return the same result

## Test plan
- [x] All 1301 tests pass
- [x] Build passes (lint + types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)