### PR TITLE
[#1261] Fix quadtree debug drawing not rendering

### DIFF
--- a/packages/debug-plugin/CHANGELOG.md
+++ b/packages/debug-plugin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 15.0.2
+
+### Bug Fixes
+- Fixed quadtree debug visualization not rendering — draw calls were issued after `renderer.flush()`, so the quadtree lines were never submitted to the GPU
+
 ## 15.0.1
 
 ### Bug Fixes

--- a/packages/debug-plugin/package.json
+++ b/packages/debug-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@melonjs/debug-plugin",
-	"version": "15.0.1",
+	"version": "15.0.2",
 	"description": "melonJS debug plugin",
 	"homepage": "https://github.com/melonjs/melonJS/tree/master/packages/debug-plugin#readme",
 	"type": "module",

--- a/packages/debug-plugin/src/debugPanel.js
+++ b/packages/debug-plugin/src/debugPanel.js
@@ -298,6 +298,9 @@ export class DebugPanel {
 		this._drawQuadTreeNode(renderer, game.world.broadphase);
 		renderer.translate(x, y);
 		renderer.restore();
+		// flush is needed because this runs after GAME_AFTER_DRAW,
+		// which is emitted after the main renderer.flush()
+		renderer.flush();
 	}
 
 	/** @private */


### PR DESCRIPTION
## Summary
Fix quadtree debug visualization not rendering. The `_drawQuadTree()` method runs in `GAME_AFTER_DRAW` which fires after `renderer.flush()`, so the draw calls were never submitted to the GPU.

Fix: add an explicit `renderer.flush()` after drawing the quadtree.

Also bumps debug plugin to 15.0.2 with changelog entry.

Closes #1261

## Test plan
- [x] Debug plugin builds
- [x] Quadtree visualization verified in platformer example

🤖 Generated with [Claude Code](https://claude.com/claude-code)