### PR TITLE
Add version logging to tiled-inflate-plugin and use workspace dependency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ jobs:
         run: pnpm -F melonjs build
       - name: Build debug plugin
         run: pnpm -F @melonjs/debug-plugin build
+      - name: Build tiled-inflate-plugin
+        run: pnpm -F @melonjs/tiled-inflate-plugin build
       - name: Build API docs
         run: pnpm doc
       - name: Build examples

--- a/packages/debug-plugin/CHANGELOG.md
+++ b/packages/debug-plugin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 15.0.3
+
+### Improvements
+- Console log now links to the npm package page instead of the GitHub readme
+
 ## 15.0.2
 
 ### Bug Fixes

--- a/packages/debug-plugin/package.json
+++ b/packages/debug-plugin/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "@melonjs/debug-plugin",
-	"version": "15.0.2",
+	"version": "15.0.3",
 	"description": "melonJS debug plugin",
-	"homepage": "https://github.com/melonjs/melonJS/tree/master/packages/debug-plugin#readme",
+	"homepage": "https://www.npmjs.com/package/@melonjs/debug-plugin",
 	"type": "module",
 	"keywords": [
 		"2D",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"@melonjs/debug-plugin": "workspace:*",
-		"@melonjs/tiled-inflate-plugin": "^1.1.2",
+		"@melonjs/tiled-inflate-plugin": "workspace:*",
 		"@types/react": "^19.2.13",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^5.1.3",

--- a/packages/tiled-inflate-plugin/CHANGELOG.md
+++ b/packages/tiled-inflate-plugin/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Replaced rollup build with esbuild (matching other monorepo packages)
 
 ### Improvements
+- Log plugin name, version and homepage to console on registration
 - Fixed Uint32Array construction to account for byteOffset/byteLength
 - Set esbuild target to es2022
 - Updated Node.js engine requirement to >= 20

--- a/packages/tiled-inflate-plugin/package.json
+++ b/packages/tiled-inflate-plugin/package.json
@@ -2,7 +2,7 @@
 	"name": "@melonjs/tiled-inflate-plugin",
 	"version": "1.2.0",
 	"description": "a melonJS plugin to enable loading and parsing of compressed Tiled maps",
-	"homepage": "https://github.com/melonjs/melonJS/tree/master/packages/tiled-inflate-plugin#readme",
+	"homepage": "https://www.npmjs.com/package/@melonjs/tiled-inflate-plugin",
 	"type": "module",
 	"keywords": [
 		"2D",

--- a/packages/tiled-inflate-plugin/src/index.js
+++ b/packages/tiled-inflate-plugin/src/index.js
@@ -2,6 +2,7 @@ import { decompress as zstdDecompress } from "fzstd";
 import { Base64 } from "js-base64";
 import { plugin, TMXUtils } from "melonjs";
 import pako from "pako";
+import { homepage, name, version } from "../package.json";
 
 /**
  * @classdesc
@@ -22,6 +23,8 @@ export class TiledInflatePlugin extends plugin.BasePlugin {
 
 		// minimum melonJS version expected to run this plugin
 		this.version = "15.2.1";
+
+		console.log(`${name} ${version} | ${homepage}`);
 
 		/**
 		 * decompress and decode zlib/gzip/zstd data

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: workspace:*
         version: link:../debug-plugin
       '@melonjs/tiled-inflate-plugin':
-        specifier: ^1.1.2
-        version: 1.1.2(melonjs@packages+melonjs)
+        specifier: workspace:*
+        version: link:../tiled-inflate-plugin
       '@types/react':
         specifier: ^19.2.13
         version: 19.2.14
@@ -756,12 +756,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@melonjs/tiled-inflate-plugin@1.1.2':
-    resolution: {integrity: sha512-XuUP/cwF+RWUqZXtGMM/9k5UGFxfOVkEOaWqZGLJ3C7D3l9VKI2auNFzxRIsaTIGQ/2W9iHHyC3twO+QdzG47Q==}
-    engines: {node: '>= 19'}
-    peerDependencies:
-      melonjs: '>=15.2.1'
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2774,12 +2768,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@melonjs/tiled-inflate-plugin@1.1.2(melonjs@packages+melonjs)':
-    dependencies:
-      js-base64: 3.7.8
-      melonjs: link:packages/melonjs
-      pako: 2.1.0
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary
- Log plugin name, version and homepage to console on registration (matching debug-plugin pattern)
- Update examples to use `workspace:*` for `@melonjs/tiled-inflate-plugin` instead of npm version

## Test plan
- [x] Plugin builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)