### PR TITLE
Update tiled-inflate-plugin README with logo and badges

### DIFF
--- a/packages/tiled-inflate-plugin/README.md
+++ b/packages/tiled-inflate-plugin/README.md
@@ -1,4 +1,9 @@
-# @melonjs/tiled-inflate-plugin
+# melonJS Tiled Inflate Plugin
+![melonJS Logo](https://github.com/melonjs/melonJS/raw/master/media/Banner/Banner%20-%20Billboard%20-%20Original%20Logo%20-%20horizontal.png)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/melonjs/melonJS/blob/master/LICENSE)
+[![NPM Package](https://img.shields.io/npm/v/@melonjs/tiled-inflate-plugin)](https://www.npmjs.com/package/@melonjs/tiled-inflate-plugin)
+[![jsDeliver](https://data.jsdelivr.com/v1/package/npm/@melonjs/tiled-inflate-plugin/badge?style=rounded)](https://www.jsdelivr.com/package/npm/@melonjs/tiled-inflate-plugin)
 
 A [melonJS](https://github.com/melonjs/melonJS) plugin to enable loading and parsing of compressed [Tiled](https://www.mapeditor.org/) maps.
 


### PR DESCRIPTION
Add melonJS logo and npm/license/jsdelivr badges to match debug-plugin README style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)