### PR TITLE
Clean up root configs and add CI caching

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,16 +1,12 @@
-; EditorConfig file format for defining coding styles
-; enabling editors to adhere to the project defined style.
-; Visit http://editorconfig.org for more details.
-
 root = true
 
-[**]
+[*]
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+indent_style = tab
 
-[**.{html,json,yml,css}]
+[*.{yml,yaml,css,html,md}]
 indent_style = space
 indent_size = 2
-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,13 @@ jobs:
         with:
           node-version: 22
       - uses: pnpm/action-setup@v4
+      - name: Get pnpm store directory
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm i
       - name: Build melonjs
         run: pnpm -F melonjs build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,14 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm i
       - run: pnpm lint
       - run: pnpm biome check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,12 @@ jobs:
         with:
           node-version: 22
       - uses: pnpm/action-setup@v4
+      - name: Get pnpm store directory
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm i
       - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,17 @@
-# Eclipse files
-.project
-.settings
+# IDE
 .idea
+*.sw*
 
-# Temp files
+# OS
 .DS_Store
 Thumbs.db
 Desktop.ini
 
-# Vim swap files
-*.sw*
-
-# Sublime project and workspace
-*.sublime-project
-*.sublime-workspace
-
-# Project specific ignore
-add-on/
+# Project
 node_modules/
 **/build/
 dist/*
 !.placeholder
-/_SpecRunner.html
 package-lock.json
 docs/
 .turbo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,5 @@
 		"quickfix.biome": "explicit",
 		"source.organizeImports.biome": "explicit"
 	},
-	"typescript.tsdk": "node_modules\\typescript\\lib"
+	"typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## Summary
- `.gitignore`: remove stale entries (Eclipse, Sublime, add-on/, _SpecRunner.html)
- `.editorconfig`: add tab indent for JS/TS, simplify
- `.vscode/settings.json`: fix Windows path separator in typescript.tsdk
- Add pnpm store caching to all CI workflows (main, test, docs) via `actions/cache@v4` — should save ~20-30s per run on cache hits

## Test plan
- [x] CI will validate the caching works on first run (cache miss) and subsequent runs (cache hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)