### PR TITLE
Fix: flush and rebatch when texture units are exhausted

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Physics: collision response is now mass-proportional — when two dynamic bodies collide, overlap and velocity correction are split based on relative mass
 - Entity: deprecated in favor of Sprite/Renderable + Body (#1008)
 - TMX: refactor TMXUtils into reusable `src/utils/decode.ts` and `src/utils/xml.ts` modules; modernize property coercion, XML normalization, and tileset iteration
+- WebGLRenderer: `Compositor`, `QuadCompositor`, and `PrimitiveCompositor` are now deprecated in favor of `Batcher`, `QuadBatcher`, and `PrimitiveBatcher`
+- Loader: modernize asset loading with Promise-based completion, improving parallel loading performance
+- Loader: `onload`, `onProgress`, and `onError` properties are now deprecated in favor of `LOADER_COMPLETE`, `LOADER_PROGRESS`, and `LOADER_ERROR` events
 
 ### Fixed
 - TMX: fix hexagonal renderer `pixelToTileCoords` mutating internal centers array on every call
@@ -37,6 +40,7 @@
 - Sprite: fix visual "vibration" on flip with trimmed atlas frames — stable dimensions and anchor across all frames (#1214)
 - Sprite: fix sprite jumping on rotated atlas frames — trim offset now applied after rotation with correct coordinate transform
 - Entity: auto-inherit renderable's anchorPoint when entity anchor is at default (0,0), aligning body and sprite centers
+- WebGL: flush and rebatch when texture units are exhausted instead of throwing (#1280)
 
 ### Performance
 - Path2D: replace `Math.pow()` with inline multiplication in quadratic/cubic Bézier and arc interpolation
@@ -57,10 +61,6 @@
 - WebGLRenderer: switch quad rendering from `gl.drawArrays` (6 vertices per quad) to `gl.drawElements` with a static index buffer (4 vertices + 6 indices per quad), reducing vertex data by 33%
 - WebGLRenderer: increase vertex batch size from 256 (64 quads) to 4096 (1024 quads), reducing draw calls for sprite-heavy and tile-heavy scenes
 
-### Changed
-- WebGLRenderer: `Compositor`, `QuadCompositor`, and `PrimitiveCompositor` are now deprecated in favor of `Batcher`, `QuadBatcher`, and `PrimitiveBatcher`
-- Loader: modernize asset loading with Promise-based completion, improving parallel loading performance
-- Loader: `onload`, `onProgress`, and `onError` properties are now deprecated in favor of `LOADER_COMPLETE`, `LOADER_PROGRESS`, and `LOADER_ERROR` events
 
 ## [18.0.0] (melonJS 2) - _2026-03-10_
 

--- a/packages/melonjs/src/video/texture/cache.js
+++ b/packages/melonjs/src/video/texture/cache.js
@@ -47,13 +47,17 @@ class TextureCache {
 			}
 		}
 
-		// No units available
+		// No units available — flush the current batch and reset assignments
 		// see https://github.com/melonjs/melonJS/issues/1280
-		throw new Error(
-			"Texture cache overflow: " +
-				this.max_size +
-				" texture units available for this GPU.",
-		);
+		if (renderer.currentCompositor) {
+			renderer.currentCompositor.flush();
+			renderer.currentCompositor.boundTextures.length = 0;
+			renderer.currentCompositor.currentTextureUnit = -1;
+		}
+		this.units.clear();
+		this.usedUnits.clear();
+		this.usedUnits.add(0);
+		return 0;
 	}
 
 	/**

--- a/packages/melonjs/tests/texture.spec.js
+++ b/packages/melonjs/tests/texture.spec.js
@@ -160,14 +160,16 @@ describe("Texture", () => {
 			expect(unit1).toEqual(1);
 		});
 
-		it("should throw when texture units are exhausted", () => {
+		it("should flush and reset when texture units are exhausted", () => {
 			cache.max_size = 2;
 			cache.allocateTextureUnit();
 			cache.allocateTextureUnit();
 
-			expect(() => {
-				return cache.allocateTextureUnit();
-			}).toThrow(/Texture cache overflow/);
+			// when all units are exhausted, it should flush, reset, and return unit 0
+			const unit = cache.allocateTextureUnit();
+			expect(unit).toEqual(0);
+			expect(cache.usedUnits.size).toEqual(1);
+			expect(cache.units.size).toEqual(0);
 		});
 
 		it("tint() should cache and return the same result for identical src+color", () => {


### PR DESCRIPTION
## Summary
- When all GPU texture units are occupied, the texture cache now flushes the current batch, resets texture unit assignments and GPU bindings, and continues with the new texture on unit 0 — instead of throwing a "Texture cache overflow" error
- Games with more unique textures than GPU texture units now work transparently (at the cost of additional draw calls)
- Updated test to verify the new flush-and-reset behavior

Closes #1280

## Test plan
- [x] All 1309 existing tests pass
- [x] Manually tested with texture unit cap forced to 2 — platformer example renders correctly without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)