### PR TITLE
Fix JSDoc typos and grammar across codebase

### DIFF
--- a/packages/melonjs/src/application/application.js
+++ b/packages/melonjs/src/application/application.js
@@ -56,7 +56,7 @@ export default class Application {
 		this.parentElement = undefined;
 
 		/**
-		 * a reference to the active Canvas or WebGL active renderer renderer
+		 * a reference to the active Canvas or WebGL renderer
 		 * @type {CanvasRenderer|WebGLRenderer}
 		 */
 		this.renderer = undefined;
@@ -109,7 +109,7 @@ export default class Application {
 		 * @type {boolean}
 		 * @default true
 		 * @example
-		 *  // keep the default game instance running even when loosing focus
+		 *  // keep the default game instance running even when losing focus
 		 *  me.game.pauseOnBlur = false;
 		 */
 		this.pauseOnBlur = true;
@@ -353,7 +353,7 @@ export default class Application {
 
 	/**
 	 * Fired when a level is fully loaded and all renderable instantiated. <br>
-	 * Additionnaly the level id will also be passed to the called function.
+	 * Additionally the level id will also be passed to the called function.
 	 * @example
 	 * // call myFunction () everytime a level is loaded
 	 * me.game.onLevelLoaded = this.myFunction.bind(this);

--- a/packages/melonjs/src/audio/audio.js
+++ b/packages/melonjs/src/audio/audio.js
@@ -135,7 +135,7 @@ export function disable() {
  * @param {Function} [onloadcb] - function to be called when the resource is loaded
  * @param {Function} [onerrorcb] - function to be called in case of error
  * @param {Object} [settings] - custom settings to apply to the request (@link https://developer.mozilla.org/en-US/docs/Web/API/fetch#options)
- * @returns {number} the amount of asset loaded (always 1 if successfull)
+ * @returns {number} the amount of asset loaded (always 1 if successful)
  * @category Audio
  */
 export function load(sound, onloadcb, onerrorcb, settings = {}) {
@@ -218,7 +218,7 @@ export function play(sound_name, loop = false, onend, volume) {
 }
 
 /**
- * Fade a currently playing sound between two volumee.
+ * Fade a currently playing sound between two volumes.
  * @param {string} sound_name - audio clip name - case sensitive
  * @param {number} from - Volume to fade from (0.0 to 1.0).
  * @param {number} to - Volume to fade to (0.0 to 1.0).
@@ -416,7 +416,7 @@ export function pause(sound_name, id) {
  * @param {string} sound_name - audio clip name - case sensitive
  * @param {number} [id] - the sound instance ID. If none is passed, all sounds in group will resume.
  * @example
- * // play a audio clip
+ * // play an audio clip
  * let id = me.audio.play("myClip");
  * ...
  * // pause it
@@ -455,7 +455,7 @@ export function playTrack(sound_name, volume) {
  * stop the current audio track
  * @see {@link playTrack}
  * @example
- * // play a awesome music
+ * // play an awesome music
  * me.audio.playTrack("awesome_music");
  * // stop the current music
  * me.audio.stopTrack();

--- a/packages/melonjs/src/camera/camera2d.js
+++ b/packages/melonjs/src/camera/camera2d.js
@@ -151,7 +151,7 @@ export default class Camera2d extends Renderable {
 		// set a default deadzone
 		this.setDeadzone(this.width / 6, this.height / 6);
 
-		// for backward "compatiblity" (in terms of behavior)
+		// for backward "compatibility" (in terms of behavior)
 		this.anchorPoint.set(0, 0);
 
 		// enable event detection on the camera
@@ -653,7 +653,7 @@ export default class Camera2d extends Renderable {
 	}
 
 	/**
-	 * draw all object visibile in this viewport
+	 * draw all objects visible in this viewport
 	 * @ignore
 	 */
 	draw(renderer, container) {

--- a/packages/melonjs/src/geometries/ellipse.ts
+++ b/packages/melonjs/src/geometries/ellipse.ts
@@ -103,7 +103,7 @@ export class Ellipse {
 	 * @param y - the center y coordinate of the ellipse
 	 * @param w - width (diameter) of the ellipse
 	 * @param h - height (diameter) of the ellipse
-	 * @returns this instance for objecf chaining
+	 * @returns this instance for object chaining
 	 */
 	setShape(x: number, y: number, w: number, h: number) {
 		const hW = w / 2;

--- a/packages/melonjs/src/geometries/line.ts
+++ b/packages/melonjs/src/geometries/line.ts
@@ -53,7 +53,7 @@ export class Line extends Polygon {
 	/**
 	 * Computes the calculated collision edges and normals.
 	 * This **must** be called if the `points` array, `angle`, or `offset` is modified manually.
-	 * @returns this instance for objecf chaining
+	 * @returns this instance for object chaining
 	 */
 	override recalc() {
 		const edges = this.edges;

--- a/packages/melonjs/src/geometries/polygon.ts
+++ b/packages/melonjs/src/geometries/polygon.ts
@@ -86,8 +86,8 @@ export class Polygon {
 	 * set new value to the Polygon
 	 * @param x - position of the Polygon
 	 * @param y - position of the Polygon
-	 * @param points - array of vector or vertice defining the Polygon
-	 * @returns this instance for objecf chaining
+	 * @param points - array of vector or vertices defining the Polygon
+	 * @returns this instance for object chaining
 	 */
 	setShape(x: number, y: number, points: PolygonVertices | LineVertices) {
 		this.pos.set(x, y);
@@ -97,8 +97,8 @@ export class Polygon {
 
 	/**
 	 * set the vertices defining this Polygon
-	 * @param vertices - array of vector or vertice defining the Polygon
-	 * @returns this instance for objecf chaining
+	 * @param vertices - array of vector or vertices defining the Polygon
+	 * @returns this instance for object chaining
 	 */
 	setVertices(vertices: PolygonVertices | LineVertices) {
 		if (!Array.isArray(vertices)) {
@@ -158,7 +158,7 @@ export class Polygon {
 	}
 
 	/**
-	 * apply a 2d projection to this shapen
+	 * apply a 2d projection to this shape
 	 * @returns Reference to this object for method chaining
 	 */
 	to2d() {

--- a/packages/melonjs/src/level/level.js
+++ b/packages/melonjs/src/level/level.js
@@ -75,7 +75,7 @@ function loadTMXLevel(levelId, container, flatten, setViewportBounds) {
 }
 
 /**
- * a level manager. once ressources loaded, the level manager contains all references of defined levels.
+ * a level manager. once resources loaded, the level manager contains all references of defined levels.
  * @namespace level
  */
 

--- a/packages/melonjs/src/loader/loader.js
+++ b/packages/melonjs/src/loader/loader.js
@@ -52,7 +52,7 @@ export const baseURL = {};
  *  // allow for cross-origin texture loading
  * me.loader.crossOrigin = "anonymous";
  *
- * // set all ressources to be loaded
+ * // set all resources to be loaded
  * me.loader.preload(game.resources, () => this.loaded());
  */
 export let crossOrigin;
@@ -71,7 +71,7 @@ export let crossOrigin;
  *  // enable withCredentials
  * me.loader.withCredentials = true;
  *
- * // set all ressources to be loaded
+ * // set all resources to be loaded
  * me.loader.preload(game.resources, () => this.loaded());
  */
 export let withCredentials = false;

--- a/packages/melonjs/src/math/color.ts
+++ b/packages/melonjs/src/math/color.ts
@@ -648,7 +648,7 @@ export class Color {
 	}
 
 	/**
-	 * return an Float Array representation of this object
+	 * return a Float Array representation of this object
 	 * @returns A Float Array representation of this color
 	 */
 	toArray() {

--- a/packages/melonjs/src/math/observableVector2d.ts
+++ b/packages/melonjs/src/math/observableVector2d.ts
@@ -148,7 +148,7 @@ export class ObservableVector2d {
 	}
 
 	/**
-	 * Substract the passed vector to this vector
+	 * Subtract the passed vector from this vector
 	 * @param v other vector
 	 * @returns Reference to this object for method chaining
 	 */

--- a/packages/melonjs/src/math/observableVector3d.ts
+++ b/packages/melonjs/src/math/observableVector3d.ts
@@ -168,7 +168,7 @@ export class ObservableVector3d {
 	}
 
 	/**
-	 * Substract the passed vector to this vector
+	 * Subtract the passed vector from this vector
 	 * @param v other vector
 	 * @returns Reference to this object for method chaining
 	 */

--- a/packages/melonjs/src/math/vector2d.ts
+++ b/packages/melonjs/src/math/vector2d.ts
@@ -74,7 +74,7 @@ export class Vector2d {
 	}
 
 	/**
-	 * Substract the passed vector to this vector
+	 * Subtract the passed vector from this vector
 	 * @param v other vector
 	 * @returns Reference to this object for method chaining
 	 */

--- a/packages/melonjs/src/math/vector3d.ts
+++ b/packages/melonjs/src/math/vector3d.ts
@@ -68,7 +68,7 @@ export class Vector3d {
 	}
 
 	/**
-	 * Substract the passed vector to this vector
+	 * Subtract the passed vector from this vector
 	 * @param v other vector
 	 * @returns Reference to this object for method chaining
 	 */

--- a/packages/melonjs/src/particles/emitter.js
+++ b/packages/melonjs/src/particles/emitter.js
@@ -43,7 +43,7 @@ export default class ParticleEmitter extends Container {
 	 * // Add the emitter to the game world
 	 * me.game.world.addChild(emitter);
 	 *
-	 * // Launch all particles one time and stop, like a explosion
+	 * // Launch all particles one time and stop, like an explosion
 	 * emitter.burstParticles();
 	 *
 	 * // Launch constantly the particles, like a fountain

--- a/packages/melonjs/src/particles/settings.js
+++ b/packages/melonjs/src/particles/settings.js
@@ -20,7 +20,7 @@ const ParticleEmitterSettings = {
 
 	/**
 	 * image used for particles texture
-	 * (by default melonJS will create an white 8x8 texture image)
+	 * (by default melonJS will create a white 8x8 texture image)
 	 * @type {HTMLCanvasElement}
 	 * @default undefined
 	 * @see {@link textureSize}
@@ -29,7 +29,7 @@ const ParticleEmitterSettings = {
 
 	/**
 	 * default texture size used for particles if no image is specified
-	 * (by default melonJS will create an white 8x8 texture image)
+	 * (by default melonJS will create a white 8x8 texture image)
 	 * @type {number}
 	 * @default 8
 	 * @see {@link image}

--- a/packages/melonjs/src/physics/body.js
+++ b/packages/melonjs/src/physics/body.js
@@ -44,7 +44,7 @@ export default class Body {
 
 		if (typeof this.bounds === "undefined") {
 			/**
-			 * The AABB bounds box reprensenting this body
+			 * The AABB bounds box representing this body
 			 * @public
 			 * @type {Bounds}
 			 */
@@ -109,7 +109,7 @@ export default class Body {
 			 * this.body.friction.set(0.4, 0);
 			 * this.body.setMaxVelocity(3, 15);
 			 *
-			 * // apply a postive or negative force when pressing left of right key
+			 * // apply a positive or negative force when pressing left of right key
 			 * update(dt) {
 			 *     if (me.input.isKeyPressed("left"))    {
 			 *          this.body.force.x = -this.body.maxVel.x;
@@ -134,7 +134,7 @@ export default class Body {
 		this.friction.set(0, 0);
 
 		/**
-		 * the body bouciness level when colliding with other solid bodies :
+		 * the body bounciness level when colliding with other solid bodies :
 		 * a value of 0 will not bounce, a value of 1 will fully rebound.
 		 * @public
 		 * @type {number}
@@ -234,7 +234,7 @@ export default class Body {
 
 	/**
 	 * set the body as a static body
-	 * static body do not move automatically and do not check againt collision with others
+	 * static body do not move automatically and do not check against collision with others
 	 * @param {boolean} [isStatic=true]
 	 */
 	setStatic(isStatic = true) {
@@ -509,7 +509,7 @@ export default class Body {
 	 *    - The current element being processed in the array <br>
 	 *    - The index of element in the array. <br>
 	 *    - The array forEach() was called upon. <br>
-	 * @param {Function} callback - fnction to execute on each element
+	 * @param {Function} callback - function to execute on each element
 	 * @param {object} [thisArg] - value to use as this(i.e reference Object) when executing callback.
 	 * @example
 	 * // iterate through all shapes of the physic body
@@ -624,10 +624,10 @@ export default class Body {
 
 	/**
 	 * Updates the parent's position as well as computes the new body's velocity based
-	 * on the values of force/friction.  Velocity chages are proportional to the
+	 * on the values of force/friction.  Velocity changes are proportional to the
 	 * me.timer.tick value (which can be used to scale velocities).  The approach to moving the
 	 * parent renderable is to compute new values of the Body.vel property then add them to
-	 * the parent.pos value thus changing the postion the amount of Body.vel each time the
+	 * the parent.pos value thus changing the position by the amount of Body.vel each time the
 	 * update call is made. <br>
 	 * Updates to Body.vel are bounded by maxVel (which defaults to viewport size if not set) <br>
 	 * At this time a call to Body.Update does not call the onBodyUpdate callback that is listed in the constructor arguments.

--- a/packages/melonjs/src/physics/quadtree.js
+++ b/packages/melonjs/src/physics/quadtree.js
@@ -217,7 +217,7 @@ export default class QuadTree {
 					if (child.name !== "rootContainer") {
 						this.insert(child);
 					}
-					// recursivly insert all childs
+					// recursively insert all children
 					this.insertContainer(child);
 				} else {
 					// only insert object with a bounding box

--- a/packages/melonjs/src/physics/world.js
+++ b/packages/melonjs/src/physics/world.js
@@ -18,7 +18,7 @@ import QuadTree from "./quadtree.js";
  */
 
 /**
- * an object representing the physic world, and responsible for managing and updating all childs and physics
+ * an object representing the physic world, and responsible for managing and updating all children and physics
  * @category Container
  */
 export default class World extends Container {

--- a/packages/melonjs/src/plugin/plugin.js
+++ b/packages/melonjs/src/plugin/plugin.js
@@ -137,7 +137,7 @@ export function register(plugin, name = plugin.toString().match(/ (\w+)/)[1]) {
  * returns the the plugin instance with the specified class type or registered name
  * @name get
  * @memberof plugin
- * @param {object|string} classType - the Class Object or registered name of the plugin to retreive
+ * @param {object|string} classType - the Class Object or registered name of the plugin to retrieve
  * @returns {plugin.BasePlugin} a plugin instance or undefined
  */
 export function get(classType) {

--- a/packages/melonjs/src/renderable/container.js
+++ b/packages/melonjs/src/renderable/container.js
@@ -111,7 +111,7 @@ export default class Container extends Renderable {
 		this.autoDepth = true;
 
 		/**
-		 * Specify if the container draw operation should clip his children to its own bounds
+		 * Specify if the container draw operation should clip its children to its own bounds
 		 * @type {boolean}
 		 * @default false
 		 */
@@ -172,7 +172,7 @@ export default class Container extends Renderable {
 	}
 
 	/**
-	 * reset the container, removing all childrens, and reseting transforms.
+	 * reset the container, removing all children, and resetting transforms.
 	 */
 	reset() {
 		// cancel any sort operation
@@ -200,13 +200,13 @@ export default class Container extends Renderable {
 
 	/**
 	 * Add a child to the container <br>
-	 * if auto-sort is disable, the object will be appended at the bottom of the list.
+	 * if auto-sort is disabled, the object will be appended at the bottom of the list.
 	 * Adding a child to the container will automatically remove it from its other container.
 	 * Meaning a child can only have one parent. This is important if you add a renderable
 	 * to a container then add it to the World container it will move it out of the
-	 * orginal container. Then when the World container reset() method is called the renderable
+	 * original container. Then when the World container reset() method is called the renderable
 	 * will not be in any container. <br>
-	 * if the given child implements a onActivateEvent method, that method will be called
+	 * if the given child implements an onActivateEvent method, that method will be called
 	 * once the child is added to this container.
 	 * @param {Renderable|Entity|Sprite|Collectable|Trigger|Draggable|DropTarget|NineSliceSprite|ImageLayer|ColorLayer|Light2d|UIBaseElement|UISpriteElement|UITextButton|Text|BitmapText|Tween} child - Child to be added
 	 * @param {number} [z] - forces the z index of the child to the specified value
@@ -262,7 +262,7 @@ export default class Container extends Renderable {
 			this.updateBounds();
 		}
 
-		// if a physic body(ies) to the game world
+		// add a physic body(ies) to the game world
 		if (this.isAttachedToRoot()) {
 			const worldContainer = this.getRootAncestor();
 			if (child.body instanceof Body) {
@@ -333,7 +333,7 @@ export default class Container extends Renderable {
 				this.updateBounds();
 			}
 
-			// if a physic body(ies) to the game world
+			// add a physic body(ies) to the game world
 			if (this.isAttachedToRoot()) {
 				const worldContainer = this.getRootAncestor();
 				if (child.body instanceof Body) {
@@ -368,7 +368,7 @@ export default class Container extends Renderable {
 	 *    - The current element being processed in the array <br>
 	 *    - The index of element in the array. <br>
 	 *    - The array forEach() was called upon. <br>
-	 * @param {Function} callback - fnction to execute on each element
+	 * @param {Function} callback - function to execute on each element
 	 * @param {object} [thisArg] - value to use as this(i.e reference Object) when executing callback.
 	 * @example
 	 * // iterate through all children of this container
@@ -418,7 +418,7 @@ export default class Container extends Renderable {
 		} else {
 			throw new Error(
 				child +
-					" Both the supplied childs must be a child of the caller " +
+					" Both the supplied children must be a child of the caller " +
 					this,
 			);
 		}
@@ -474,7 +474,7 @@ export default class Container extends Renderable {
 	 * it parses the whole object tree each time
 	 * @param {string} prop - Property name
 	 * @param {string|RegExp|number|boolean} value - Value of the property
-	 * @returns {Renderable[]} Array of childs
+	 * @returns {Renderable[]} Array of children
 	 * @example
 	 * // get the first child object called "mainPlayer" in a specific container :
 	 * let ent = myContainer.getChildByProp("name", "mainPlayer");
@@ -509,7 +509,7 @@ export default class Container extends Renderable {
 	}
 
 	/**
-	 * returns the list of childs with the specified class type
+	 * returns the list of children with the specified class type
 	 * @param {object} classType - Class type
 	 * @returns {Renderable[]} Array of children
 	 */
@@ -527,7 +527,7 @@ export default class Container extends Renderable {
 	}
 
 	/**
-	 * returns the list of childs with the specified name<br>
+	 * returns the list of children with the specified name<br>
 	 * as defined in Tiled (Name field of the Object Properties)<br>
 	 * note : avoid calling this function every frame since
 	 * it parses the whole object list each time
@@ -637,7 +637,7 @@ export default class Container extends Renderable {
 
 	/**
 	 * Invokes the removeChildNow in a defer, to ensure the child is removed safely after the update & draw stack has completed. <br>
-	 * if the given child implements a onDeactivateEvent() method, that method will be called once the child is removed from this container.
+	 * if the given child implements an onDeactivateEvent() method, that method will be called once the child is removed from this container.
 	 * @param {Renderable|Sprite|Collectable|Trigger|Draggable|DropTarget|NineSliceSprite|ImageLayer|ColorLayer|Light2d|UIBaseElement|UISpriteElement|UITextButton|Text|BitmapText} child - Child to be removed
 	 * @param {boolean} [keepalive=false] - true to prevent calling child.destroy()
 	 */
@@ -793,7 +793,7 @@ export default class Container extends Renderable {
 			if (recursive === true) {
 				this.forEach((child) => {
 					if (child instanceof Container) {
-						// note : this will generate one defered sorting function
+						// note : this will generate one deferred sorting function
 						// for each existing containe
 						child.sort(recursive);
 					}
@@ -936,7 +936,7 @@ export default class Container extends Renderable {
 
 		this.drawCount = 0;
 
-		// clip the containter children to the container bounds
+		// clip the container children to the container bounds
 		if (
 			this.root === false &&
 			this.clipping === true &&

--- a/packages/melonjs/src/renderable/imagelayer.js
+++ b/packages/melonjs/src/renderable/imagelayer.js
@@ -61,7 +61,7 @@ export default class ImageLayer extends Sprite {
 		this.ratio = vector2dPool.get(1.0, 1.0);
 
 		if (typeof settings.ratio !== "undefined") {
-			// little hack for backward compatiblity
+			// little hack for backward compatibility
 			if (stringUtil.isNumeric(settings.ratio)) {
 				this.ratio.set(settings.ratio, +settings.ratio);
 			} /* vector */ else {

--- a/packages/melonjs/src/renderable/nineslicesprite.js
+++ b/packages/melonjs/src/renderable/nineslicesprite.js
@@ -7,7 +7,7 @@ import Sprite from "./sprite.js";
  */
 
 /**
- * A NineSliceSprite is similar to a Sprite, but it uses 9-slice scaling to strech its inner area to fit the size of the Renderable,
+ * A NineSliceSprite is similar to a Sprite, but it uses 9-slice scaling to stretch its inner area to fit the size of the Renderable,
  * by proportionally scaling a sprite by splitting it in a grid of nine parts (with only parts 1, 3, 7, 9 not being scaled). <br>
  * <img src="images/9-slice-scaling.png"/><br>
  * @category Game Objects

--- a/packages/melonjs/src/renderable/renderable.js
+++ b/packages/melonjs/src/renderable/renderable.js
@@ -632,7 +632,7 @@ export default class Renderable extends Rect {
 
 			bounds.clear();
 			if (this.autoTransform === true && !this.currentTransform.isIdentity()) {
-				// temporarly translate the matrix based on the anchor point
+				// temporarily translate the matrix based on the anchor point
 				this.currentTransform.translate(
 					-this.width * this.anchorPoint.x,
 					-this.height * this.anchorPoint.y,
@@ -796,7 +796,7 @@ export default class Renderable extends Rect {
 	 * @param {Renderable} other - the other renderable touching this one (a reference to response.a or response.b)
 	 * @returns {boolean} true if the object should respond to the collision (its position and velocity will be corrected)
 	 * @example
-	 * // colision handler
+	 * // collision handler
 	 * onCollision(response) {
 	 *     if (response.b.body.collisionType === me.collision.types.ENEMY_OBJECT) {
 	 *         // makes the other object solid, by substracting the overlap vector to the current position

--- a/packages/melonjs/src/renderable/sprite.js
+++ b/packages/melonjs/src/renderable/sprite.js
@@ -364,7 +364,7 @@ export default class Sprite extends Renderable {
 	 * this.addAnimation("turn", [{ name: 0, delay: 200 }, { name: 1, delay: 100 }])
 	 * // can do this with atlas values as well:
 	 * this.addAnimation("turn", [{ name: "turnone", delay: 200 }, { name: "turntwo", delay: 100 }])
-	 * // define an dying animation that stop on the last frame
+	 * // define a dying animation that stop on the last frame
 	 * this.addAnimation("die", [{ name: 3, delay: 200 }, { name: 4, delay: 100 }, { name: 5, delay: Infinity }])
 	 * // set the standing animation as default
 	 * this.setCurrentAnimation("stand");
@@ -694,7 +694,7 @@ export default class Sprite extends Renderable {
 	}
 
 	/**
-	 * draw this srite (automatically called by melonJS)
+	 * draw this sprite (automatically called by melonJS)
 	 * @param {CanvasRenderer|WebGLRenderer} renderer - a renderer instance
 	 * @param {Camera2d} [viewport] - the viewport to (re)draw
 	 */

--- a/packages/melonjs/src/renderable/text/bitmaptext.js
+++ b/packages/melonjs/src/renderable/text/bitmaptext.js
@@ -36,7 +36,7 @@ export default class BitmapText extends Renderable {
 	 * // two possibilities for using "myFont"
 	 * // either call the draw function from your Renderable draw function
 	 * myFont.draw(renderer, "Hello!", 0, 0);
-	 * // or just add it to the word container
+	 * // or just add it to the world container
 	 * me.game.world.addChild(myFont);
 	 */
 	constructor(x, y, settings) {
@@ -54,7 +54,7 @@ export default class BitmapText extends Renderable {
 
 		/**
 		 * Set the text baseline (e.g. the Y-coordinate for the draw operation), <br>
-		 * possible values are "top", "hanging, "middle, "alphabetic, "ideographic, "bottom"<br>
+		 * possible values are "top", "hanging", "middle", "alphabetic", "ideographic", "bottom"<br>
 		 * @public
 		 * @type {string}
 		 * @default "top"
@@ -105,7 +105,7 @@ export default class BitmapText extends Renderable {
 			 * font data
 			 * @private
 			 */
-			// use settings.font to retreive the data from the loader
+			// use settings.font to retrieve the data from the loader
 			this.fontData = bitmapTextDataPool.get(getBinary(settings.font));
 		} else {
 			this.fontData = bitmapTextDataPool.get(

--- a/packages/melonjs/src/renderable/text/text.js
+++ b/packages/melonjs/src/renderable/text/text.js
@@ -76,7 +76,7 @@ export default class Text extends Renderable {
 
 		/**
 		 * Set the text baseline (e.g. the Y-coordinate for the draw operation), <br>
-		 * possible values are "top", "hanging, "middle, "alphabetic, "ideographic, "bottom"<br>
+		 * possible values are "top", "hanging", "middle", "alphabetic", "ideographic", "bottom"<br>
 		 * @type {string}
 		 * @default "top"
 		 */
@@ -111,7 +111,7 @@ export default class Text extends Renderable {
 		 */
 		this._text = [];
 
-		// initalize the object based on the given settings
+		// initialize the object based on the given settings
 		this.onResetEvent(x, y, settings);
 	}
 

--- a/packages/melonjs/src/renderable/ui/uitextbutton.js
+++ b/packages/melonjs/src/renderable/ui/uitextbutton.js
@@ -91,7 +91,7 @@ export default class UITextButton extends UIBaseElement {
 
 		/**
 		 * Set the text baseline (e.g. the Y-coordinate for the draw operation), <br>
-		 * possible values are "top", "hanging, "middle, "alphabetic, "ideographic, "bottom"<br>
+		 * possible values are "top", "hanging", "middle", "alphabetic", "ideographic", "bottom"<br>
 		 * @public
 		 * @type {string}
 		 * @default "middle"

--- a/packages/melonjs/src/system/device.js
+++ b/packages/melonjs/src/system/device.js
@@ -364,10 +364,10 @@ export let autoFocus = true;
  *       // initialize the "audio"
  *       me.audio.init("mp3,ogg");
  *
- *       // set callback for ressources loaded event
+ *       // set callback for resources loaded event
  *       me.loader.onload = this.loaded.bind(this);
  *
- *       // set all ressources to be loaded
+ *       // set all resources to be loaded
  *       me.loader.preload(game.assets);
  *
  *       // load everything & display a loading screen
@@ -807,7 +807,7 @@ export function watchAccelerometer() {
 }
 
 /**
- * unwatch Accelerometor event
+ * unwatch Accelerometer event
  * @memberof device
  * @category Application
  */

--- a/packages/melonjs/src/utils/array.ts
+++ b/packages/melonjs/src/utils/array.ts
@@ -26,7 +26,7 @@ export function remove<T>(arr: T[], obj: T): T[] {
 
 /**
  * return a random array element
- * @param arr - array to pick a element
+ * @param arr - array to pick an element
  * @returns random member of array
  * @example
  * // Select a random array element
@@ -39,7 +39,7 @@ export function random<T>(arr: T[]) {
 
 /**
  * return a weighted random array element, favoring the earlier entries
- * @param arr - array to pick a element
+ * @param arr - array to pick an element
  * @returns random member of array
  */
 export function weightedRandom<T>(arr: T[]) {

--- a/packages/melonjs/src/video/canvas/canvas_renderer.js
+++ b/packages/melonjs/src/video/canvas/canvas_renderer.js
@@ -89,7 +89,7 @@ export default class CanvasRenderer extends Renderer {
 
 	/**
 	 * set a blend mode for the given context. <br>
-	 * Supported blend mode between Canvas and WebGL remderer : <br>
+	 * Supported blend mode between Canvas and WebGL renderer : <br>
 	 * - "normal" : this is the default mode and draws new content on top of the existing content <br>
 	 * <img src="../images/normal-blendmode.png" width="510"/> <br>
 	 * - "multiply" : the pixels of the top layer are multiplied with the corresponding pixel of the bottom layer. A darker picture is the result. <br>
@@ -600,7 +600,7 @@ export default class CanvasRenderer extends Renderer {
 	}
 
 	/**
-	 * Draw a a point at the specified coordinates
+	 * Draw a point at the specified coordinates
 	 * @param {number} x
 	 * @param {number} y
 	 * @param {number} width

--- a/packages/melonjs/src/video/webgl/batchers/quad_batcher.js
+++ b/packages/melonjs/src/video/webgl/batchers/quad_batcher.js
@@ -223,7 +223,7 @@ export default class QuadBatcher extends Batcher {
 			typeof globalThis.OffscreenCanvas !== "undefined" &&
 			pixels instanceof globalThis.OffscreenCanvas
 		) {
-			// convert to ImageBitmap first (else Safari 16.4 and higher will throw an TypeError exception)
+			// convert to ImageBitmap first (else Safari 16.4 and higher will throw a TypeError exception)
 			const imageBitmap = pixels.transferToImageBitmap();
 			gl.texImage2D(
 				gl.TEXTURE_2D,

--- a/packages/melonjs/src/video/webgl/webgl_renderer.js
+++ b/packages/melonjs/src/video/webgl/webgl_renderer.js
@@ -723,7 +723,7 @@ export default class WebGLRenderer extends Renderer {
 
 	/**
 	 * set a blend mode for the given context. <br>
-	 * Supported blend mode between Canvas and WebGL remderer : <br>
+	 * Supported blend mode between Canvas and WebGL renderer : <br>
 	 * - "normal" : this is the default mode and draws new content on top of the existing content <br>
 	 * <img src="../images/normal-blendmode.png" width="510"/> <br>
 	 * - "multiply" : the pixels of the top layer are multiplied with the corresponding pixel of the bottom layer. A darker picture is the result. <br>
@@ -1271,7 +1271,7 @@ export default class WebGLRenderer extends Renderer {
 	}
 
 	/**
-	 * Draw a a point at the specified coordinates
+	 * Draw a point at the specified coordinates
 	 * @param {number} x - x axis of the coordinate for the point.
 	 * @param {number} y - y axis of the coordinate for the point.
 	 */


### PR DESCRIPTION
## Summary
Fix 74 typos and grammar issues across 32 source files.

Includes:
- Misspelled words: `objecf`, `reprensenting`, `bouciness`, `successfull`, `volumee`, `compatiblity`, `temporarly`, `recursivly`, `remderer`, `srite`, `ressources`, `Substract`, `initalize`, `retreive`, `strech`, `Accelerometor`, and more
- Grammar fixes: "a/an" misuse, "childs" → "children", "his" → "its", missing verbs, doubled words
- Missing closing quotes in textBaseline JSDoc values

## Test plan
- [x] All 1314 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)