### PR TITLE
Fix ace-builds import for production build

### DIFF
--- a/packages/examples/src/main.tsx
+++ b/packages/examples/src/main.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
-import ace from "ace-builds";
+import * as ace from "ace-builds/src-noconflict/ace";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 import "ace-builds/src-noconflict/mode-javascript";
 import "ace-builds/src-noconflict/mode-typescript";


### PR DESCRIPTION
## Summary
Fix `ReferenceError: Can't find variable: ace` on the deployed examples page.

The `ace-builds` default export doesn't work with Vite production builds. Changed to import directly from `ace-builds/src-noconflict/ace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)