### PR TITLE
Remove deprecated standalone draw for Text/BitmapText and UITextButton compat

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -33,6 +33,9 @@
 - WebGL context always created with `depth: true` for hardware depth buffer support
 - WebGL `clear()` now always clears depth + color + stencil buffers
 - WebGL renderer `setBatcher()` now syncs the projection matrix to the new batcher
+- **BREAKING**: `Text.draw()` and `BitmapText.draw()` no longer accept `text`, `x`, `y` parameters — standalone draw without a parent container is removed (deprecated since 10.6.0)
+- **BREAKING**: `Text.measureText()` no longer takes a `renderer` parameter (was unused)
+- **BREAKING**: `UITextButton` settings `backgroundColor` and `hoverColor` removed — use `hoverOffColor` and `hoverOnColor` instead
 
 ### Fixed
 - WebGL: depth buffer now correctly used for 3D mesh rendering with `gl.LESS` depth function

--- a/packages/melonjs/src/renderable/text/bitmaptext.js
+++ b/packages/melonjs/src/renderable/text/bitmaptext.js
@@ -288,31 +288,15 @@ export default class BitmapText extends Renderable {
 	/**
 	 * draw the bitmap font
 	 * @param {CanvasRenderer|WebGLRenderer} renderer - Reference to the destination renderer instance
-	 * @param {string} [text]
-	 * @param {number} [x]
-	 * @param {number} [y]
 	 */
-	draw(renderer, text, x, y) {
-		// save the previous global alpha value
-		const _alpha = renderer.globalAlpha();
-
-		// allows to provide backward compatibility when
-		// adding Bitmap Font to an object container
-		if (typeof this.ancestor === "undefined") {
-			// update cache
-			this.setText(text);
-			renderer.setGlobalAlpha(_alpha * this.getOpacity());
-		} else {
-			// added directly to an object container
-			x = this.pos.x;
-			y = this.pos.y;
-		}
+	draw(renderer) {
+		let x = this.pos.x;
+		let y = this.pos.y;
 
 		const lX = x;
 		const stringHeight = this.metrics.lineHeight();
 		const gy = this.metrics.glyphYOffset || 0;
 		const h = this.metrics.height;
-		let maxWidth = 0;
 
 		// apply baseline shift once for the entire text block
 		switch (this.textBaseline) {
@@ -346,17 +330,6 @@ export default class BitmapText extends Renderable {
 
 				default:
 					break;
-			}
-
-			// update initial position if required
-			if (this.isDirty === true && typeof this.ancestor === "undefined") {
-				if (i === 0) {
-					this.pos.y = y;
-				}
-				if (maxWidth < stringWidth) {
-					maxWidth = stringWidth;
-					this.pos.x = x;
-				}
 			}
 
 			// draw the string
@@ -402,15 +375,6 @@ export default class BitmapText extends Renderable {
 			// increment line
 			y += stringHeight;
 		}
-
-		if (typeof this.ancestor === "undefined") {
-			// restore the previous global alpha value
-			renderer.setGlobalAlpha(_alpha);
-		}
-
-		// clear the dirty flag here for
-		// backward compatibility
-		this.isDirty = false;
 	}
 
 	/**

--- a/packages/melonjs/src/renderable/text/text.js
+++ b/packages/melonjs/src/renderable/text/text.js
@@ -370,45 +370,21 @@ export default class Text extends Renderable {
 
 	/**
 	 * measure the given text size in pixels
-	 * @param {CanvasRenderer|WebGLRenderer} renderer - reference to the active renderer
 	 * @param {string} [text] - the text to be measured
 	 * @returns {TextMetrics} a TextMetrics object defining the dimensions of the given piece of text
 	 */
-	measureText(renderer, text = this._text) {
+	measureText(text = this._text) {
 		return this.metrics.measureText(text, this.canvasTexture.context);
 	}
 
 	/**
 	 * draw a text at the specified coord
 	 * @param {CanvasRenderer|WebGLRenderer} renderer - Reference to the destination renderer instance
-	 * @param {string} [text]
-	 * @param {number} [x]
-	 * @param {number} [y]
 	 */
-	draw(renderer, text, x = this.pos.x, y = this.pos.y) {
-		// @deprecated since 10.6.0 — standalone draw without a parent container
-		// TODO: remove in 19.0.0
-		if (typeof this.ancestor === "undefined") {
-			// update position if changed
-			if (this.pos.x !== x || this.pos.y !== y) {
-				this.pos.x = x;
-				this.pos.y = y;
-				this.isDirty = true;
-			}
-
-			// update text cache
-			this.setText(text);
-
-			// save the previous context
-			renderer.save();
-
-			// apply the defined alpha value
-			renderer.setGlobalAlpha(renderer.globalAlpha() * this.getOpacity());
-		}
-
+	draw(renderer) {
 		// adjust x,y position based on the bounding box
-		x = this.metrics.x;
-		y = this.metrics.y;
+		let x = this.metrics.x;
+		let y = this.metrics.y;
 
 		// clamp to pixel grid if required
 		if (renderer.settings.subPixel === false) {
@@ -418,12 +394,6 @@ export default class Text extends Renderable {
 
 		// draw the text
 		renderer.drawImage(this.canvasTexture.canvas, x, y);
-
-		// @deprecated since 10.6.0 — TODO: remove in 19.0.0
-		if (typeof this.ancestor === "undefined") {
-			// restore previous context
-			renderer.restore();
-		}
 	}
 
 	/**

--- a/packages/melonjs/src/renderable/ui/uitextbutton.ts
+++ b/packages/melonjs/src/renderable/ui/uitextbutton.ts
@@ -17,10 +17,6 @@ interface UITextButtonSettings {
 	textBaseline?: string;
 	borderWidth?: number;
 	borderHeight?: number;
-	/** @deprecated use hoverOffColor */
-	backgroundColor?: string;
-	/** @deprecated use hoverOnColor */
-	hoverColor?: string;
 	[key: string]: any;
 }
 
@@ -96,8 +92,8 @@ export default class UITextButton extends UIBaseElement {
 	 *              // if you omit the next two, size is calculated by the size of the text
 	 *              borderWidth: 200,
 	 *              borderHeight: 20,
-	 *              backgroundColor: '#00aa0080',
-	 *              hoverColor: '#00ff00ff'
+	 *              hoverOffColor: '#00aa0080',
+	 *              hoverOnColor: '#00ff00ff'
 	 *          });
 	 *      }
 	 *
@@ -113,15 +109,8 @@ export default class UITextButton extends UIBaseElement {
 
 		this.bindKey = settings.bindKey || -1;
 
-		/* eslint-disable @typescript-eslint/no-deprecated */
-		// keep settings.backgroundColor for backward compatibility
-		this.hoverOffColor =
-			settings.hoverOffColor || settings.backgroundColor || "#00aa0080";
-
-		// keep settings.hoverColor for backward compatibility
-		this.hoverOnColor =
-			settings.hoverOnColor || settings.hoverColor || "#00ff00ff";
-		/* eslint-enable @typescript-eslint/no-deprecated */
+		this.hoverOffColor = settings.hoverOffColor || "#00aa0080";
+		this.hoverOnColor = settings.hoverOnColor || "#00ff00ff";
 
 		this.borderStrokeColor = settings.borderStrokeColor || "#000000";
 


### PR DESCRIPTION
## Summary

- **Text.draw()** / **BitmapText.draw()** — remove deprecated `text`, `x`, `y` parameters and standalone ancestor checks (deprecated since 10.6.0, marked for removal in 19.0.0)
- **BitmapText.draw()** — remove redundant `isDirty = false` (handled by `postDraw`) and manual alpha save/restore
- **Text.measureText()** — remove unused `renderer` parameter
- **UITextButton** — remove deprecated `backgroundColor` and `hoverColor` settings, use `hoverOffColor` and `hoverOnColor`

## Test plan

- [ ] All 2304 unit tests pass
- [ ] Text example renders correctly
- [ ] UI example renders correctly (buttons with hover colors)
- [ ] BitmapText in platformer/other examples renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)