### PR TITLE
Refactor Tween to use event-based lifecycle instead of world container

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"lefthook": "^2.1.5",
 		"tsconfig": "workspace:^",
 		"tsx": "^4.21.0",
-		"turbo": "^2.9.4",
+		"turbo": "^2.9.5",
 		"typescript": "^6.0.2",
 		"typescript-eslint": "^8.58.0",
 		"vitest": "^4.1.2"

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -36,7 +36,7 @@
 - **BREAKING**: `Text.draw()` and `BitmapText.draw()` no longer accept `text`, `x`, `y` parameters — standalone draw without a parent container is removed (deprecated since 10.6.0)
 - **BREAKING**: `Text.measureText()` no longer takes a `renderer` parameter (was unused)
 - **BREAKING**: `UITextButton` settings `backgroundColor` and `hoverColor` removed — use `hoverOffColor` and `hoverOnColor` instead
-- **BREAKING**: `Tween` no longer adds itself to `game.world` — uses event-based lifecycle (`TICK`, `STATE_PAUSE`, `STATE_RESUME`, `GAME_RESET`) instead. Public API unchanged. `isPersistent` and `updateWhenPaused` properties still supported.
+- **BREAKING**: `Tween` no longer adds itself to `game.world` — uses event-based lifecycle (`TICK`, `GAME_AFTER_UPDATE`, `STATE_PAUSE`, `STATE_RESUME`, `GAME_RESET`) instead. Public API unchanged. `isPersistent` and `updateWhenPaused` properties still supported.
 
 ### Fixed
 - WebGL: depth buffer now correctly used for 3D mesh rendering with `gl.LESS` depth function

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -36,6 +36,7 @@
 - **BREAKING**: `Text.draw()` and `BitmapText.draw()` no longer accept `text`, `x`, `y` parameters — standalone draw without a parent container is removed (deprecated since 10.6.0)
 - **BREAKING**: `Text.measureText()` no longer takes a `renderer` parameter (was unused)
 - **BREAKING**: `UITextButton` settings `backgroundColor` and `hoverColor` removed — use `hoverOffColor` and `hoverOnColor` instead
+- **BREAKING**: `Tween` no longer adds itself to `game.world` — uses event-based lifecycle (`TICK`, `STATE_PAUSE`, `STATE_RESUME`, `GAME_RESET`) instead. Public API unchanged. `isPersistent` and `updateWhenPaused` properties still supported.
 
 ### Fixed
 - WebGL: depth buffer now correctly used for 3D mesh rendering with `gl.LESS` depth function

--- a/packages/melonjs/src/system/eventEmitter.ts
+++ b/packages/melonjs/src/system/eventEmitter.ts
@@ -90,17 +90,20 @@ export class EventEmitter<Events extends EventsMap = DefaultEvents> {
 	emit<E extends keyof Events>(event: E, ...args: Parameters<Events[E]>) {
 		const listeners = this.eventListeners[event];
 		if (listeners) {
-			for (const entry of listeners) {
+			// iterate over a copy so that removeListener during emit is safe
+			const snapshot = listeners.slice();
+			for (const entry of snapshot) {
 				entry.fn.apply(entry.ctx, args);
 			}
 		}
 
 		const listenersOnce = this.eventListenersOnce[event];
 		if (listenersOnce) {
+			// clear before invoking so re-entrant addListenerOnce is safe
+			this.eventListenersOnce[event] = [];
 			for (const entry of listenersOnce) {
 				entry.fn.apply(entry.ctx, args);
 			}
-			this.eventListenersOnce[event] = [];
 		}
 	}
 

--- a/packages/melonjs/src/tweens/easing.ts
+++ b/packages/melonjs/src/tweens/easing.ts
@@ -4,40 +4,29 @@
  */
 
 /**
- * Easing Function :<br>
- * <p>
- * Easing.Linear.None<br>
- * Easing.Quadratic.In<br>
- * Easing.Quadratic.Out<br>
- * Easing.Quadratic.InOut<br>
- * Easing.Cubic.In<br>
- * Easing.Cubic.Out<br>
- * Easing.Cubic.InOut<br>
- * Easing.Quartic.In<br>
- * Easing.Quartic.Out<br>
- * Easing.Quartic.InOut<br>
- * Easing.Quintic.In<br>
- * Easing.Quintic.Out<br>
- * Easing.Quintic.InOut<br>
- * Easing.Sinusoidal.In<br>
- * Easing.Sinusoidal.Out<br>
- * Easing.Sinusoidal.InOut<br>
- * Easing.Exponential.In<br>
- * Easing.Exponential.Out<br>
- * Easing.Exponential.InOut<br>
- * Easing.Circular.In<br>
- * Easing.Circular.Out<br>
- * Easing.Circular.InOut<br>
- * Easing.Elastic.In<br>
- * Easing.Elastic.Out<br>
- * Easing.Elastic.InOut<br>
- * Easing.Back.In<br>
- * Easing.Back.Out<br>
- * Easing.Back.InOut<br>
- * Easing.Bounce.In<br>
- * Easing.Bounce.Out<br>
- * Easing.Bounce.InOut
- * </p>
+ * Easing functions for use with {@link Tween}.
+ * Each family provides `In` (accelerate), `Out` (decelerate), and `InOut` (both) variants.
+ *
+ * Available families:
+ * - `Linear.None` — constant speed
+ * - `Quadratic` — power of 2
+ * - `Cubic` — power of 3
+ * - `Quartic` — power of 4
+ * - `Quintic` — power of 5
+ * - `Sinusoidal` — sine wave
+ * - `Exponential` — base-2 exponential
+ * - `Circular` — circular arc
+ * - `Elastic` — spring overshoot
+ * - `Back` — slight overshoot before settling
+ * - `Bounce` — bouncing ball effect
+ * @example
+ * // use with Tween
+ * new me.Tween(obj).to({ x: 100 }, {
+ *     duration: 1000,
+ *     easing: me.Tween.Easing.Bounce.Out,
+ * }).start();
+ * @see https://easings.net/ for visual reference
+ * @category Tweens
  */
 
 export type EasingFunction = (t: number) => number;

--- a/packages/melonjs/src/tweens/interpolation.ts
+++ b/packages/melonjs/src/tweens/interpolation.ts
@@ -46,7 +46,29 @@ const catmullRom = (
 
 export type InterpolationFunction = (v: number[], k: number) => number;
 
+/**
+ * Interpolation functions for tweening through arrays of values.
+ * Used when a tween target property is an array (e.g. a path of waypoints).
+ *
+ * Available functions:
+ * - `Linear` — straight-line interpolation between consecutive values
+ * - `Bezier` — smooth Bezier curve through all values
+ * - `CatmullRom` — smooth Catmull-Rom spline through all values (best for paths)
+ * @example
+ * // tween through waypoints using CatmullRom spline
+ * new me.Tween(obj).to({ x: [100, 200, 300, 400] }, {
+ *     duration: 2000,
+ *     interpolation: me.Tween.Interpolation.CatmullRom,
+ * }).start();
+ * @see {@link Tween}
+ * @category Tweens
+ */
 export const Interpolation = {
+	/**
+	 * Piecewise linear interpolation between consecutive array values.
+	 * @param v - array of values
+	 * @param k - interpolation factor (0 to 1)
+	 */
 	Linear: (v: number[], k: number) => {
 		const m = v.length - 1;
 		const f = m * k;
@@ -61,6 +83,11 @@ export const Interpolation = {
 
 		return linear(v[i], v[i + 1 > m ? m : i + 1], f - i);
 	},
+	/**
+	 * Smooth Bezier curve interpolation through all array values.
+	 * @param v - array of values
+	 * @param k - interpolation factor (0 to 1)
+	 */
 	Bezier: (v: number[], k: number) => {
 		let b = 0;
 		const n = v.length - 1;
@@ -71,6 +98,11 @@ export const Interpolation = {
 
 		return b;
 	},
+	/**
+	 * Smooth Catmull-Rom spline interpolation — best for path-following tweens.
+	 * @param v - array of values
+	 * @param k - interpolation factor (0 to 1)
+	 */
 	CatmullRom: (v: number[], k: number) => {
 		const m = v.length - 1;
 		let f = m * k;

--- a/packages/melonjs/src/tweens/tween.ts
+++ b/packages/melonjs/src/tweens/tween.ts
@@ -30,7 +30,7 @@ type OnCompleteCallback<T> = (this: T) => void;
  * optimised Robert Penner's equations.
  *
  * Tweens use an event-based lifecycle — on `start()` the tween subscribes to
- * the game loop events (`TICK`, `STATE_PAUSE`, `STATE_RESUME`, `GAME_RESET`)
+ * the game loop events (`TICK`, `GAME_AFTER_UPDATE`, `STATE_PAUSE`, `STATE_RESUME`, `GAME_RESET`)
  * and automatically unsubscribes on completion or `stop()`.
  * They do not need to be added to a container.
  * @example
@@ -139,7 +139,7 @@ export default class Tween {
 	 */
 	_resumeCallback(elapsed: number) {
 		this._isPaused = false;
-		if (this._startTime && !this.updateWhenPaused) {
+		if (this._startTime !== null && !this.updateWhenPaused) {
 			this._startTime += elapsed;
 		}
 	}

--- a/packages/melonjs/src/tweens/tween.ts
+++ b/packages/melonjs/src/tweens/tween.ts
@@ -243,25 +243,25 @@ export default class Tween {
 		this._valuesEnd = properties;
 
 		if (typeof options !== "undefined") {
-			if (options.duration) {
+			if (options.duration !== undefined) {
 				this._duration = options.duration;
 			}
-			if (options.yoyo) {
+			if (options.yoyo !== undefined) {
 				this.yoyo(options.yoyo);
 			}
-			if (options.easing) {
+			if (options.easing !== undefined) {
 				this.easing(options.easing);
 			}
-			if (options.repeat) {
+			if (options.repeat !== undefined) {
 				this.repeat(options.repeat);
 			}
-			if (options.delay) {
+			if (options.delay !== undefined) {
 				this.delay(options.delay);
 			}
-			if (options.interpolation) {
+			if (options.interpolation !== undefined) {
 				this.interpolation(options.interpolation);
 			}
-			if (options.autoStart) {
+			if (options.autoStart === true) {
 				this.start();
 			}
 		}
@@ -280,6 +280,10 @@ export default class Tween {
 		this._unsubscribe();
 
 		this._onStartCallbackFired = false;
+
+		// sync internal time tracker to the provided start time
+		this._tweenTimeTracker = time;
+		this._lastUpdate = time;
 
 		// subscribe to game loop events
 		this._lastTick = globalThis.performance.now();

--- a/packages/melonjs/src/tweens/tween.ts
+++ b/packages/melonjs/src/tweens/tween.ts
@@ -1,5 +1,12 @@
-import { game } from "../application/application.ts";
-import { GAME_AFTER_UPDATE, off, on, STATE_RESUME } from "../system/event.js";
+import {
+	GAME_AFTER_UPDATE,
+	GAME_RESET,
+	off,
+	on,
+	STATE_PAUSE,
+	STATE_RESUME,
+	TICK,
+} from "../system/event.js";
 import { createPool } from "../system/pool.ts";
 import timer from "../system/timer.js";
 import { Easing, EasingFunction } from "./easing.js";
@@ -18,17 +25,29 @@ type OnUpdateCallback<T> = (this: T, value: number) => void;
 type OnCompleteCallback<T> = (this: T) => void;
 
 /**
- * Javascript Tweening Engine<p>
- * Super simple, fast and easy to use tweening engine which incorporates optimised Robert Penner's equation<p>
- * <a href="https://github.com/sole/Tween.js">https://github.com/sole/Tween.js</a><p>
- * author sole / http://soledadpenades.com<br>
- * author mr.doob / http://mrdoob.com<br>
- * author Robert Eisele / http://www.xarg.org<br>
- * author Philippe / http://philippe.elsass.me<br>
- * author Robert Penner / http://www.robertpenner.com/easing_terms_of_use.html<br>
- * author Paul Lewis / http://www.aerotwist.com/<br>
- * author lechecacharro<br>
- * author Josh Faul / http://jocafa.com/
+ * A tweening engine for smoothly interpolating object properties over time.
+ * Based on <a href="https://github.com/sole/Tween.js">tween.js</a> with
+ * optimised Robert Penner's equations.
+ *
+ * Tweens use an event-based lifecycle — on `start()` the tween subscribes to
+ * the game loop events (`TICK`, `STATE_PAUSE`, `STATE_RESUME`, `GAME_RESET`)
+ * and automatically unsubscribes on completion or `stop()`.
+ * They do not need to be added to a container.
+ * @example
+ * // basic usage
+ * new me.Tween(myObject.pos)
+ *     .to({ x: 200, y: 200 }, { duration: 3000, easing: me.Tween.Easing.Bounce.Out })
+ *     .onComplete(() => console.log("done!"))
+ *     .start();
+ * @example
+ * // auto-start with options
+ * new me.Tween(myObject.pos).to({ x: 200 }, {
+ *     duration: 1000,
+ *     easing: me.Tween.Easing.Quadratic.InOut,
+ *     yoyo: true,
+ *     repeat: Infinity,
+ *     autoStart: true,
+ * });
  * @category Tweens
  */
 export default class Tween {
@@ -51,22 +70,24 @@ export default class Tween {
 	_onCompleteCallback: OnCompleteCallback<object> | null;
 	_tweenTimeTracker: number;
 	_lastUpdate: number;
-	isPersistent: boolean;
-	updateWhenPaused: boolean;
-	isRenderable: boolean;
+	_isRunning: boolean;
+	_isPaused: boolean;
+	_lastTick: number;
 
 	/**
-	 * @param object - object on which to apply the tween
-	 * @example
-	 * // add a tween to change the object pos.x and pos.y variable to 200 in 3 seconds
-	 * tween = new me.Tween(myObject.pos).to({
-	 *       x: 200,
-	 *       y: 200,
-	 *    }, {
-	 *       duration: 3000,
-	 *       easing: me.Tween.Easing.Bounce.Out,
-	 *       autoStart : true
-	 * }).onComplete(myFunc);
+	 * whether the tween should persist across state changes (not auto-stopped on game reset)
+	 * @default false
+	 */
+	isPersistent: boolean;
+
+	/**
+	 * whether the tween should keep running when the game is paused
+	 * @default false
+	 */
+	updateWhenPaused: boolean;
+
+	/**
+	 * @param object - the object whose properties will be tweened
 	 */
 	constructor(object: object) {
 		this.setProperties(object);
@@ -83,6 +104,9 @@ export default class Tween {
 	 * @ignore
 	 */
 	setProperties(object: object) {
+		// ensure any running tween is stopped before resetting (e.g., pool reuse)
+		this._unsubscribe();
+
 		this._object = object;
 		this._valuesStart = {};
 		this._valuesEnd = {};
@@ -103,27 +127,19 @@ export default class Tween {
 		// track the last update timestamp from the game loop
 		this._lastUpdate = globalThis.performance.now();
 		this._tweenTimeTracker = this._lastUpdate;
-
-		// reset flags to default value
+		this._isRunning = false;
+		this._isPaused = false;
+		this._lastTick = globalThis.performance.now();
 		this.isPersistent = false;
-		// this is not really supported
 		this.updateWhenPaused = false;
-		// comply with the container contract
-		this.isRenderable = false;
-
-		// Set all starting values present on the target object
-		for (const field in object) {
-			if (typeof object !== "object") {
-				this._valuesStart[field] = parseFloat(object[field]);
-			}
-		}
 	}
 
 	/**
 	 * @ignore
 	 */
 	_resumeCallback(elapsed: number) {
-		if (this._startTime) {
+		this._isPaused = false;
+		if (this._startTime && !this.updateWhenPaused) {
 			this._startTime += elapsed;
 		}
 	}
@@ -133,39 +149,82 @@ export default class Tween {
 		this._lastUpdate = lastUpdate;
 	}
 
-	/**
-	 * subscribe to events when added
-	 * @ignore
-	 */
-	onActivateEvent() {
-		// eslint-disable-next-line @typescript-eslint/unbound-method
-		on(STATE_RESUME, this._resumeCallback, this);
-		// eslint-disable-next-line @typescript-eslint/unbound-method
-		on(GAME_AFTER_UPDATE, this._onAfterUpdate, this);
+	/** @ignore */
+	_onTick(timestamp: number) {
+		if (!this._isPaused || this.updateWhenPaused) {
+			// compute delta from the raw RAF timestamp
+			const dt = timestamp - this._lastTick;
+			this._lastTick = timestamp;
+			if (dt > 0 && dt < 1000) {
+				this.update(dt);
+			}
+		}
+	}
+
+	/** @ignore */
+	_onPause() {
+		this._isPaused = true;
+	}
+
+	/** @ignore */
+	_onReset() {
+		if (!this.isPersistent) {
+			this.stop();
+		}
 	}
 
 	/**
-	 * Unsubscribe when tween is removed
+	 * Subscribe to the game loop events
 	 * @ignore
 	 */
-	onDeactivateEvent() {
-		// eslint-disable-next-line @typescript-eslint/unbound-method
-		off(STATE_RESUME, this._resumeCallback, this);
-		// eslint-disable-next-line @typescript-eslint/unbound-method
-		off(GAME_AFTER_UPDATE, this._onAfterUpdate, this);
+	_subscribe() {
+		if (!this._isRunning) {
+			this._isRunning = true;
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			on(TICK, this._onTick, this);
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			on(STATE_PAUSE, this._onPause, this);
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			on(STATE_RESUME, this._resumeCallback, this);
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			on(GAME_AFTER_UPDATE, this._onAfterUpdate, this);
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			on(GAME_RESET, this._onReset, this);
+		}
 	}
 
 	/**
-	 * object properties to be updated and duration
-	 * @param properties - hash of properties
-	 * @param [options] - object of tween properties, or a duration if a numeric value is passed
-	 * @param [options.duration] - tween duration
-	 * @param [options.easing] - easing function
-	 * @param [options.delay] - delay amount expressed in milliseconds
-	 * @param [options.yoyo] - allows the tween to bounce back to their original value when finished. To be used together with repeat to create endless loops.
-	 * @param [options.repeat] - amount of times the tween should be repeated
-	 * @param [options.interpolation] - interpolation function
-	 * @param [options.autoStart] - allow this tween to start automatically. Otherwise call me.Tween.start().
+	 * Unsubscribe from the game loop events
+	 * @ignore
+	 */
+	_unsubscribe() {
+		if (this._isRunning) {
+			this._isRunning = false;
+			this._isPaused = false;
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			off(TICK, this._onTick, this);
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			off(STATE_PAUSE, this._onPause, this);
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			off(STATE_RESUME, this._resumeCallback, this);
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			off(GAME_AFTER_UPDATE, this._onAfterUpdate, this);
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			off(GAME_RESET, this._onReset, this);
+		}
+	}
+
+	/**
+	 * Define the target property values and tween options.
+	 * @param properties - target property values to tween to (e.g. `{ x: 200, y: 100 }`)
+	 * @param [options] - tween configuration
+	 * @param [options.duration] - tween duration in milliseconds
+	 * @param [options.easing] - easing function (e.g. `Tween.Easing.Quadratic.InOut`)
+	 * @param [options.delay] - delay before starting, in milliseconds
+	 * @param [options.yoyo] - bounce back to original values when finished (use with `repeat`)
+	 * @param [options.repeat] - number of times to repeat (use `Infinity` for endless loops)
+	 * @param [options.interpolation] - interpolation function for array values
+	 * @param [options.autoStart] - start the tween immediately without calling `start()`
 	 * @returns this instance for object chaining
 	 */
 	to(
@@ -210,15 +269,16 @@ export default class Tween {
 	}
 
 	/**
-	 * start the tween
-	 * @param [time] - the current time when the tween was started
+	 * Start the tween. Subscribes to game loop events and begins interpolation.
+	 * @param [time] - the start time (defaults to current game time)
 	 * @returns this instance for object chaining
 	 */
 	start(time = timer.getTime()) {
 		this._onStartCallbackFired = false;
 
-		// add the tween to the object pool on start
-		game.world.addChild(this);
+		// subscribe to game loop events
+		this._lastTick = globalThis.performance.now();
+		this._subscribe();
 
 		this._startTime = time + this._delayTime;
 
@@ -250,12 +310,11 @@ export default class Tween {
 		return this;
 	}
 	/**
-	 * stop the tween
+	 * Stop the tween. Unsubscribes from all game loop events.
 	 * @returns this instance for object chaining
 	 */
 	stop() {
-		// remove the tween from the world container
-		game.world.removeChildNow(this);
+		this._unsubscribe();
 		return this;
 	}
 
@@ -438,8 +497,8 @@ export default class Tween {
 
 				return true;
 			} else {
-				// remove the tween from the world container
-				game.world.removeChildNow(this);
+				// unsubscribe from events on completion
+				this._unsubscribe();
 
 				if (this._onCompleteCallback !== null) {
 					this._onCompleteCallback.call(this._object);
@@ -459,10 +518,27 @@ export default class Tween {
 		return true;
 	}
 
-	// export easing function as static class property
+	/**
+	 * Available easing functions, accessed via `Tween.Easing`.
+	 * Each family provides `In`, `Out`, and `InOut` variants.
+	 * @see {@link Easing} for the full list
+	 * @example
+	 * me.Tween.Easing.Quadratic.InOut
+	 * me.Tween.Easing.Bounce.Out
+	 * me.Tween.Easing.Elastic.In
+	 */
 	static get Easing() {
 		return Easing;
 	}
+
+	/**
+	 * Available interpolation functions for tweening array values.
+	 * @see {@link Interpolation}
+	 * @example
+	 * me.Tween.Interpolation.Linear
+	 * me.Tween.Interpolation.Bezier
+	 * me.Tween.Interpolation.CatmullRom
+	 */
 	static get Interpolation() {
 		return Interpolation;
 	}

--- a/packages/melonjs/src/tweens/tween.ts
+++ b/packages/melonjs/src/tweens/tween.ts
@@ -431,7 +431,8 @@ export default class Tween {
 			this._onStartCallbackFired = true;
 		}
 
-		let elapsed = (time - this._startTime) / this._duration;
+		let elapsed =
+			this._duration > 0 ? (time - this._startTime) / this._duration : 1;
 		elapsed = elapsed > 1 ? 1 : elapsed;
 
 		const value = this._easingFunction(elapsed);
@@ -446,9 +447,13 @@ export default class Tween {
 			} else {
 				// Parses relative end values with start as base (e.g.: +10, -3)
 				if (typeof end === "string") {
+					const parsed = parseFloat(end);
+					if (isNaN(parsed)) {
+						continue; // skip non-numeric string properties
+					}
 					// @ts-expect-error todo
 					// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-					end = start + parseFloat(end);
+					end = start + parsed;
 				}
 
 				// protect against non numeric properties.

--- a/packages/melonjs/src/tweens/tween.ts
+++ b/packages/melonjs/src/tweens/tween.ts
@@ -30,7 +30,8 @@ type OnCompleteCallback<T> = (this: T) => void;
  * optimised Robert Penner's equations.
  *
  * Tweens use an event-based lifecycle — on `start()` the tween subscribes to
- * the game loop events (`TICK`, `GAME_AFTER_UPDATE`, `STATE_PAUSE`, `STATE_RESUME`, `GAME_RESET`)
+ * the game loop events (`TICK`, `GAME_AFTER_UPDATE`, `STATE_PAUSE`,
+ * `STATE_RESUME`, `GAME_RESET`)
  * and automatically unsubscribes on completion or `stop()`.
  * They do not need to be added to a container.
  * @example
@@ -274,6 +275,10 @@ export default class Tween {
 	 * @returns this instance for object chaining
 	 */
 	start(time = timer.getTime()) {
+		// stop any running tween before restarting (prevents listener leaks
+		// and array value corruption from repeated start() calls)
+		this._unsubscribe();
+
 		this._onStartCallbackFired = false;
 
 		// subscribe to game loop events

--- a/packages/melonjs/tests/bitmapfontdata.spec.ts
+++ b/packages/melonjs/tests/bitmapfontdata.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { getPool } from "../src/pool.ts";
+import { bitmapTextDataPool } from "../src/renderable/text/bitmaptextdata.ts";
 
 const bitmapTextDataFixture =
 	'info face="Arial" size=18 bold=0 italic=0 charset="" unicode=0 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=0,0\n' +
@@ -145,7 +145,7 @@ describe("BitmapTextData", () => {
 	describe("parse", () => {
 		let bitmapTextData: any = null;
 		beforeEach(() => {
-			bitmapTextData = getPool("bitmapTextData").get(bitmapTextDataFixture);
+			bitmapTextData = bitmapTextDataPool.get(bitmapTextDataFixture);
 		});
 
 		it("should have 95 glyphs", () => {

--- a/packages/melonjs/tests/bitmapfontdata.spec.ts
+++ b/packages/melonjs/tests/bitmapfontdata.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { bitmapTextDataPool } from "../src/renderable/text/bitmaptextdata.ts";
 
 const bitmapTextDataFixture =
@@ -146,6 +146,12 @@ describe("BitmapTextData", () => {
 		let bitmapTextData: any = null;
 		beforeEach(() => {
 			bitmapTextData = bitmapTextDataPool.get(bitmapTextDataFixture);
+		});
+		afterEach(() => {
+			if (bitmapTextData) {
+				bitmapTextDataPool.release(bitmapTextData);
+				bitmapTextData = null;
+			}
 		});
 
 		it("should have 95 glyphs", () => {

--- a/packages/melonjs/tests/pool.test.ts
+++ b/packages/melonjs/tests/pool.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from "vitest";
-import { createPool } from "../src/pool";
+import { createPool } from "../src/system/pool";
 
 class GameObject {
 	destroyCalled = false;

--- a/packages/melonjs/tests/tween.spec.ts
+++ b/packages/melonjs/tests/tween.spec.ts
@@ -1,0 +1,466 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Tween } from "../src/index.js";
+import { Easing } from "../src/tweens/easing.js";
+import { Interpolation } from "../src/tweens/interpolation.js";
+
+describe("Tween", () => {
+	let obj: { x: number; y: number };
+	let tween: Tween;
+
+	beforeEach(() => {
+		obj = { x: 0, y: 0 };
+		tween = new Tween(obj);
+	});
+
+	// --- construction ---
+
+	describe("constructor", () => {
+		it("creates a tween with default properties", () => {
+			expect(tween).toBeDefined();
+			expect(tween._object).toBe(obj);
+			expect(tween._duration).toEqual(1000);
+			expect(tween._repeat).toEqual(0);
+			expect(tween._yoyo).toBe(false);
+			expect(tween._delayTime).toEqual(0);
+			expect(tween._isRunning).toBe(false);
+			expect(tween._isPaused).toBe(false);
+			expect(tween.isPersistent).toBe(false);
+			expect(tween.updateWhenPaused).toBe(false);
+		});
+	});
+
+	// --- to() ---
+
+	describe("to()", () => {
+		it("sets target values", () => {
+			tween.to({ x: 100, y: 200 });
+			expect(tween._valuesEnd).toEqual({ x: 100, y: 200 });
+		});
+
+		it("sets duration from options", () => {
+			tween.to({ x: 100 }, { duration: 2000 });
+			expect(tween._duration).toEqual(2000);
+		});
+
+		it("sets easing from options", () => {
+			tween.to({ x: 100 }, { easing: Easing.Quadratic.In });
+			expect(tween._easingFunction).toBe(Easing.Quadratic.In);
+		});
+
+		it("sets delay from options", () => {
+			tween.to({ x: 100 }, { delay: 500 });
+			expect(tween._delayTime).toEqual(500);
+		});
+
+		it("sets repeat from options", () => {
+			tween.to({ x: 100 }, { repeat: 3 });
+			expect(tween._repeat).toEqual(3);
+		});
+
+		it("sets yoyo from options", () => {
+			tween.to({ x: 100 }, { yoyo: true });
+			expect(tween._yoyo).toBe(true);
+		});
+
+		it("sets interpolation from options", () => {
+			tween.to(
+				{ x: [0, 50, 100] },
+				{ interpolation: Interpolation.CatmullRom },
+			);
+			expect(tween._interpolationFunction).toBe(Interpolation.CatmullRom);
+		});
+
+		it("returns this for chaining", () => {
+			expect(tween.to({ x: 100 })).toBe(tween);
+		});
+	});
+
+	// --- start / stop ---
+
+	describe("start() / stop()", () => {
+		it("start sets _isRunning to true", () => {
+			tween.to({ x: 100 });
+			tween.start();
+			expect(tween._isRunning).toBe(true);
+		});
+
+		it("stop sets _isRunning to false", () => {
+			tween.to({ x: 100 });
+			tween.start();
+			tween.stop();
+			expect(tween._isRunning).toBe(false);
+		});
+
+		it("start initializes _valuesStart from the object", () => {
+			obj.x = 50;
+			tween.to({ x: 200 });
+			tween.start();
+			expect(tween._valuesStart.x).toEqual(50);
+		});
+
+		it("start returns this for chaining", () => {
+			tween.to({ x: 100 });
+			expect(tween.start()).toBe(tween);
+		});
+
+		it("stop returns this for chaining", () => {
+			tween.to({ x: 100 });
+			tween.start();
+			expect(tween.stop()).toBe(tween);
+		});
+
+		it("double start does not double-subscribe", () => {
+			tween.to({ x: 100 });
+			tween.start();
+			tween.start();
+			expect(tween._isRunning).toBe(true);
+			tween.stop();
+			expect(tween._isRunning).toBe(false);
+		});
+
+		it("stop without start is safe", () => {
+			expect(() => {
+				tween.stop();
+			}).not.toThrow();
+		});
+	});
+
+	// --- update ---
+
+	describe("update()", () => {
+		it("interpolates values over time", () => {
+			tween.to({ x: 100 }, { duration: 1000 });
+			tween.start(0);
+
+			tween.update(500);
+			expect(obj.x).toBeGreaterThan(0);
+
+			tween.update(500);
+			expect(obj.x).toBeCloseTo(100, 0);
+		});
+
+		it("fires onStart callback once", () => {
+			let callCount = 0;
+			tween.to({ x: 100 }, { duration: 1000 }).onStart(() => {
+				callCount++;
+			});
+			tween.start(0);
+
+			tween.update(100);
+			tween.update(100);
+			tween.update(100);
+			expect(callCount).toEqual(1);
+		});
+
+		it("fires onUpdate callback each frame", () => {
+			let callCount = 0;
+			tween.to({ x: 100 }, { duration: 1000 }).onUpdate(() => {
+				callCount++;
+			});
+			tween.start(0);
+
+			tween.update(100);
+			tween.update(100);
+			tween.update(100);
+			expect(callCount).toEqual(3);
+		});
+
+		it("fires onComplete callback when finished", () => {
+			let completed = false;
+			tween.to({ x: 100 }, { duration: 100 }).onComplete(() => {
+				completed = true;
+			});
+			tween.start(0);
+
+			tween.update(100);
+			expect(completed).toBe(true);
+		});
+
+		it("returns false when complete", () => {
+			tween.to({ x: 100 }, { duration: 100 });
+			tween.start(0);
+
+			const result = tween.update(100);
+			expect(result).toBe(false);
+		});
+
+		it("returns true while in progress", () => {
+			tween.to({ x: 100 }, { duration: 1000 });
+			tween.start(0);
+
+			const result = tween.update(500);
+			expect(result).toBe(true);
+		});
+
+		it("unsubscribes on completion", () => {
+			tween.to({ x: 100 }, { duration: 100 });
+			tween.start(0);
+
+			tween.update(100);
+			expect(tween._isRunning).toBe(false);
+		});
+	});
+
+	// --- delay ---
+
+	describe("delay()", () => {
+		it("delays the start of interpolation", () => {
+			tween.to({ x: 100 }, { duration: 1000, delay: 500 });
+			tween.start(0);
+
+			// during delay, value should not change
+			tween.update(16);
+			const xDuringDelay = obj.x;
+
+			// after enough updates to pass delay + some duration
+			for (let i = 0; i < 100; i++) {
+				tween.update(16);
+			}
+			expect(obj.x).toBeGreaterThan(xDuringDelay);
+		});
+
+		it("returns this for chaining", () => {
+			expect(tween.delay(100)).toBe(tween);
+		});
+	});
+
+	// --- repeat ---
+
+	describe("repeat()", () => {
+		it("repeats the tween", () => {
+			let completeCount = 0;
+			tween.to({ x: 100 }, { duration: 100, repeat: 2 }).onComplete(() => {
+				completeCount++;
+			});
+			tween.start(0);
+
+			// first pass
+			tween.update(100);
+			expect(obj.x).toBeCloseTo(100, 0);
+			expect(completeCount).toEqual(0); // not complete yet, still repeating
+
+			// second pass
+			tween.update(100);
+			expect(completeCount).toEqual(0);
+
+			// third pass (final)
+			tween.update(100);
+			expect(completeCount).toEqual(1);
+		});
+
+		it("returns this for chaining", () => {
+			expect(tween.repeat(3)).toBe(tween);
+		});
+	});
+
+	// --- yoyo ---
+
+	describe("yoyo()", () => {
+		it("reverses direction on repeat", () => {
+			tween.to({ x: 100 }, { duration: 100, repeat: 1, yoyo: true });
+			tween.start(0);
+
+			// forward pass
+			tween.update(100);
+			expect(obj.x).toBeCloseTo(100, 0);
+
+			// yoyo back
+			tween.update(100);
+			expect(obj.x).toBeCloseTo(0, 0);
+		});
+
+		it("returns this for chaining", () => {
+			expect(tween.yoyo(true)).toBe(tween);
+		});
+	});
+
+	// --- easing ---
+
+	describe("easing()", () => {
+		it("applies the easing function", () => {
+			// Quadratic.In produces slower start than Linear
+			const linearObj = { x: 0 };
+			const quadObj = { x: 0 };
+
+			const linearTween = new Tween(linearObj).to(
+				{ x: 100 },
+				{ duration: 1000, easing: Easing.Linear.None },
+			);
+			const quadTween = new Tween(quadObj).to(
+				{ x: 100 },
+				{ duration: 1000, easing: Easing.Quadratic.In },
+			);
+
+			linearTween.start(0);
+			quadTween.start(0);
+
+			// run both for the same number of frames
+			for (let i = 0; i < 20; i++) {
+				linearTween.update(16);
+				quadTween.update(16);
+			}
+
+			// Quadratic.In should be behind Linear at the midpoint
+			expect(quadObj.x).toBeLessThan(linearObj.x);
+			expect(quadObj.x).toBeGreaterThan(0);
+		});
+
+		it("returns this for chaining", () => {
+			expect(tween.easing(Easing.Linear.None)).toBe(tween);
+		});
+	});
+
+	// --- chain ---
+
+	describe("chain()", () => {
+		it("starts chained tweens on completion", () => {
+			const obj2 = { x: 0 };
+			const chained = new Tween(obj2).to({ x: 100 }, { duration: 100 });
+
+			tween.to({ x: 100 }, { duration: 100 }).chain(chained);
+			tween.start(0);
+
+			tween.update(100);
+			// chained tween should have started
+			expect(chained._isRunning).toBe(true);
+		});
+
+		it("returns this for chaining", () => {
+			expect(tween.chain(new Tween({}))).toBe(tween);
+		});
+	});
+
+	// --- callbacks ---
+
+	describe("callbacks", () => {
+		it("onStart returns this for chaining", () => {
+			expect(tween.onStart(() => {})).toBe(tween);
+		});
+
+		it("onUpdate returns this for chaining", () => {
+			expect(tween.onUpdate(() => {})).toBe(tween);
+		});
+
+		it("onComplete returns this for chaining", () => {
+			expect(tween.onComplete(() => {})).toBe(tween);
+		});
+
+		it("onUpdate receives the easing value", () => {
+			let receivedValue = -1;
+			tween.to({ x: 100 }, { duration: 1000 }).onUpdate(function (value) {
+				receivedValue = value;
+			});
+			tween.start(0);
+
+			tween.update(500);
+			expect(receivedValue).toBeGreaterThan(0);
+			expect(receivedValue).toBeLessThanOrEqual(1);
+		});
+	});
+
+	// --- setProperties / reset ---
+
+	describe("setProperties()", () => {
+		it("resets all tween state", () => {
+			tween.to({ x: 100 }, { duration: 2000, delay: 500 });
+			tween.start(0);
+			tween.update(100);
+
+			const newObj = { x: 0, y: 0 };
+			tween.setProperties(newObj);
+
+			expect(tween._object).toBe(newObj);
+			expect(tween._duration).toEqual(1000); // default
+			expect(tween._delayTime).toEqual(0);
+			expect(tween._isRunning).toBe(false);
+			expect(tween._onStartCallback).toBeNull();
+			expect(tween._onUpdateCallback).toBeNull();
+			expect(tween._onCompleteCallback).toBeNull();
+		});
+
+		it("unsubscribes a running tween", () => {
+			tween.to({ x: 100 });
+			tween.start();
+			expect(tween._isRunning).toBe(true);
+
+			tween.setProperties({ x: 0 });
+			expect(tween._isRunning).toBe(false);
+		});
+	});
+
+	// --- isPersistent ---
+
+	describe("isPersistent", () => {
+		it("defaults to false", () => {
+			expect(tween.isPersistent).toBe(false);
+		});
+
+		it("can be set to true", () => {
+			tween.isPersistent = true;
+			expect(tween.isPersistent).toBe(true);
+		});
+	});
+
+	// --- updateWhenPaused ---
+
+	describe("updateWhenPaused", () => {
+		it("defaults to false", () => {
+			expect(tween.updateWhenPaused).toBe(false);
+		});
+
+		it("can be set to true", () => {
+			tween.updateWhenPaused = true;
+			expect(tween.updateWhenPaused).toBe(true);
+		});
+	});
+
+	// --- static accessors ---
+
+	describe("static Easing / Interpolation", () => {
+		it("Tween.Easing is accessible", () => {
+			expect(Tween.Easing).toBeDefined();
+			expect(Tween.Easing.Linear.None).toBeTypeOf("function");
+			expect(Tween.Easing.Bounce.Out).toBeTypeOf("function");
+		});
+
+		it("Tween.Interpolation is accessible", () => {
+			expect(Tween.Interpolation).toBeDefined();
+			expect(Tween.Interpolation.Linear).toBeTypeOf("function");
+			expect(Tween.Interpolation.CatmullRom).toBeTypeOf("function");
+		});
+	});
+
+	// --- interpolation with arrays ---
+
+	describe("array interpolation", () => {
+		it("interpolates through array values", () => {
+			tween.to({ x: [50, 100] }, { duration: 1000 });
+			tween.start(0);
+
+			// after a few frames, should be between start and end
+			for (let i = 0; i < 10; i++) {
+				tween.update(16);
+			}
+			expect(obj.x).toBeGreaterThan(0);
+
+			// run to completion
+			for (let i = 0; i < 100; i++) {
+				tween.update(16);
+			}
+			expect(obj.x).toBeCloseTo(100, 0);
+		});
+	});
+
+	// --- relative values ---
+
+	describe("relative string values", () => {
+		it("supports relative +/- string values", () => {
+			obj.x = 50;
+			tween.to({ x: "+100" }, { duration: 100 });
+			tween.start(0);
+
+			tween.update(100);
+			expect(obj.x).toBeCloseTo(150, 0);
+		});
+	});
+});

--- a/packages/melonjs/tests/tween.spec.ts
+++ b/packages/melonjs/tests/tween.spec.ts
@@ -308,6 +308,9 @@ describe("Tween", () => {
 			// Quadratic.In should be behind Linear at the midpoint
 			expect(quadObj.x).toBeLessThan(linearObj.x);
 			expect(quadObj.x).toBeGreaterThan(0);
+
+			linearTween.stop();
+			quadTween.stop();
 		});
 
 		it("returns this for chaining", () => {
@@ -328,6 +331,7 @@ describe("Tween", () => {
 			tween.update(100);
 			// chained tween should have started
 			expect(chained._isRunning).toBe(true);
+			chained.stop();
 		});
 
 		it("returns this for chaining", () => {
@@ -535,9 +539,10 @@ describe("Tween", () => {
 		it("onComplete callback can start a new tween", () => {
 			const obj2 = { x: 0 };
 			let secondStarted = false;
+			let t2: InstanceType<typeof Tween> | null = null;
 
 			tween.to({ x: 100 }, { duration: 100 }).onComplete(() => {
-				const t2 = new Tween(obj2).to({ x: 50 }, { duration: 100 });
+				t2 = new Tween(obj2).to({ x: 50 }, { duration: 100 });
 				t2.start(0);
 				secondStarted = t2._isRunning;
 			});
@@ -545,6 +550,7 @@ describe("Tween", () => {
 
 			tween.update(100);
 			expect(secondStarted).toBe(true);
+			t2?.stop();
 		});
 
 		it("multiple tweens on same object both run", () => {

--- a/packages/melonjs/tests/tween.spec.ts
+++ b/packages/melonjs/tests/tween.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Tween } from "../src/index.js";
 import { Easing } from "../src/tweens/easing.js";
 import { Interpolation } from "../src/tweens/interpolation.js";
@@ -10,6 +10,11 @@ describe("Tween", () => {
 	beforeEach(() => {
 		obj = { x: 0, y: 0 };
 		tween = new Tween(obj);
+	});
+
+	afterEach(() => {
+		// ensure event listeners are cleaned up between tests
+		tween.stop();
 	});
 
 	// --- construction ---

--- a/packages/melonjs/tests/tween.spec.ts
+++ b/packages/melonjs/tests/tween.spec.ts
@@ -463,4 +463,182 @@ describe("Tween", () => {
 			expect(obj.x).toBeCloseTo(150, 0);
 		});
 	});
+
+	// --- edge cases ---
+
+	describe("edge cases", () => {
+		it("restart after completion works", () => {
+			tween.to({ x: 100 }, { duration: 100 });
+			tween.start(0);
+			tween.update(100);
+			expect(tween._isRunning).toBe(false);
+			expect(obj.x).toBeCloseTo(100, 0);
+
+			// reset object and restart
+			obj.x = 0;
+			tween.to({ x: 200 }, { duration: 100 });
+			tween.start(0);
+			expect(tween._isRunning).toBe(true);
+
+			tween.update(100);
+			expect(obj.x).toBeCloseTo(200, 0);
+		});
+
+		it("duration of 0 does not divide by zero", () => {
+			// duration 0 should not cause Infinity/NaN in elapsed calculation
+			tween.to({ x: 100 }, { duration: 0 });
+			tween.start(0);
+
+			// should not throw or produce NaN
+			expect(() => {
+				tween.update(16);
+			}).not.toThrow();
+			expect(isNaN(obj.x)).toBe(false);
+		});
+
+		it("empty properties to({}) completes after duration", () => {
+			let completed = false;
+			tween.to({}, { duration: 100 }).onComplete(() => {
+				completed = true;
+			});
+			tween.start(0);
+
+			tween.update(100);
+			expect(completed).toBe(true);
+			// object unchanged
+			expect(obj.x).toEqual(0);
+			expect(obj.y).toEqual(0);
+		});
+
+		it("infinite repeat never completes", () => {
+			let completeCount = 0;
+			tween
+				.to({ x: 100 }, { duration: 100, repeat: Infinity })
+				.onComplete(() => {
+					completeCount++;
+				});
+			tween.start(0);
+
+			// run many cycles
+			for (let i = 0; i < 100; i++) {
+				tween.update(100);
+			}
+			expect(completeCount).toEqual(0);
+			expect(tween._isRunning).toBe(true);
+		});
+
+		it("onComplete callback can start a new tween", () => {
+			const obj2 = { x: 0 };
+			let secondStarted = false;
+
+			tween.to({ x: 100 }, { duration: 100 }).onComplete(() => {
+				const t2 = new Tween(obj2).to({ x: 50 }, { duration: 100 });
+				t2.start(0);
+				secondStarted = t2._isRunning;
+			});
+			tween.start(0);
+
+			tween.update(100);
+			expect(secondStarted).toBe(true);
+		});
+
+		it("multiple tweens on same object both run", () => {
+			const tweenX = new Tween(obj).to({ x: 100 }, { duration: 100 });
+			const tweenY = new Tween(obj).to({ y: 200 }, { duration: 100 });
+
+			tweenX.start(0);
+			tweenY.start(0);
+
+			tweenX.update(100);
+			tweenY.update(100);
+
+			expect(obj.x).toBeCloseTo(100, 0);
+			expect(obj.y).toBeCloseTo(200, 0);
+		});
+
+		it("stop during onUpdate callback is safe", () => {
+			let updateCount = 0;
+			tween.to({ x: 100 }, { duration: 1000 }).onUpdate(() => {
+				updateCount++;
+				if (updateCount >= 2) {
+					tween.stop();
+				}
+			});
+			tween.start(0);
+
+			tween.update(100);
+			tween.update(100);
+			expect(tween._isRunning).toBe(false);
+		});
+
+		it("start with negative delay is treated as no delay", () => {
+			tween.to({ x: 100 }, { duration: 100 });
+			tween.delay(-500);
+			tween.start(0);
+
+			tween.update(100);
+			// should have completed (negative delay doesn't block)
+			expect(obj.x).toBeGreaterThan(0);
+		});
+
+		it("tweening a non-numeric property is ignored", () => {
+			const strObj = { name: "hello", x: 0 } as Record<string, unknown>;
+			const t = new Tween(strObj).to(
+				{ name: "world", x: 100 },
+				{ duration: 100 },
+			);
+			t.start(0);
+
+			expect(() => {
+				t.update(100);
+			}).not.toThrow();
+			// numeric property should be tweened
+			expect(strObj.x).toBeCloseTo(100, 0);
+			// string property should be unchanged (not corrupted to NaN)
+			expect(strObj.name).toEqual("hello");
+		});
+
+		it("very large dt does not break the tween", () => {
+			tween.to({ x: 100 }, { duration: 1000 });
+			tween.start(0);
+
+			// simulate a huge frame skip
+			tween.update(999999);
+			expect(obj.x).toBeCloseTo(100, 0);
+			expect(tween._isRunning).toBe(false);
+		});
+
+		it("update with dt=0 does not crash", () => {
+			tween.to({ x: 100 }, { duration: 1000 });
+			tween.start(0);
+
+			expect(() => {
+				tween.update(0);
+				tween.update(0);
+				tween.update(0);
+			}).not.toThrow();
+		});
+
+		it("yoyo without repeat behaves like no yoyo", () => {
+			tween.to({ x: 100 }, { duration: 100, yoyo: true });
+			tween.start(0);
+
+			tween.update(100);
+			// completes normally (yoyo only matters with repeat)
+			expect(obj.x).toBeCloseTo(100, 0);
+			expect(tween._isRunning).toBe(false);
+		});
+
+		it("chained tween on a stopped parent never starts", () => {
+			const obj2 = { x: 0 };
+			const chained = new Tween(obj2).to({ x: 100 }, { duration: 100 });
+
+			tween.to({ x: 100 }, { duration: 1000 }).chain(chained);
+			tween.start(0);
+			tween.stop();
+
+			// parent was stopped, chained should not have started
+			expect(chained._isRunning).toBe(false);
+		});
+	});
 });

--- a/packages/melonjs/tests/tween.spec.ts
+++ b/packages/melonjs/tests/tween.spec.ts
@@ -539,18 +539,21 @@ describe("Tween", () => {
 		it("onComplete callback can start a new tween", () => {
 			const obj2 = { x: 0 };
 			let secondStarted = false;
-			let t2: InstanceType<typeof Tween> | null = null;
+			const tweensToCleanup: Tween[] = [];
 
 			tween.to({ x: 100 }, { duration: 100 }).onComplete(() => {
-				t2 = new Tween(obj2).to({ x: 50 }, { duration: 100 });
+				const t2 = new Tween(obj2).to({ x: 50 }, { duration: 100 });
 				t2.start(0);
 				secondStarted = t2._isRunning;
+				tweensToCleanup.push(t2);
 			});
 			tween.start(0);
 
 			tween.update(100);
 			expect(secondStarted).toBe(true);
-			t2?.stop();
+			tweensToCleanup.forEach((t) => {
+				t.stop();
+			});
 		});
 
 		it("multiple tweens on same object both run", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       turbo:
-        specifier: ^2.9.4
-        version: 2.9.4
+        specifier: ^2.9.5
+        version: 2.9.5
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -699,33 +699,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@turbo/darwin-64@2.9.4':
-    resolution: {integrity: sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g==}
+  '@turbo/darwin-64@2.9.5':
+    resolution: {integrity: sha512-qPxhKsLMQP+9+dsmPgAGidi5uNifD4AoAOnEnljab3Qgn0QZRR31Hp+/CgW3Ia5AanWj6JuLLTBYvuQj4mqTWg==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.4':
-    resolution: {integrity: sha512-9cjTWe4OiNlFMSRggPNh+TJlRs7MS5FWrHc96MOzft5vESWjjpvaadYPv5ykDW7b45mVHOF2U/W+48LoX9USWw==}
+  '@turbo/darwin-arm64@2.9.5':
+    resolution: {integrity: sha512-vkF/9F/l3aWd4bHxTui5Hh0F5xrTZ4e3rbBsc57zA6O8gNbmHN3B6eZ5psAIP2CnJRZ8ZxRjV3WZHeNXMXkPBw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.4':
-    resolution: {integrity: sha512-Cl1GjxqBXQ+r9KKowmXG+lhD1gclLp48/SE7NxL//66iaMytRw0uiphWGOkccD92iPiRjHLRUaA9lOTtgr5OCA==}
+  '@turbo/linux-64@2.9.5':
+    resolution: {integrity: sha512-z/Get5NUaUxm5HSGFqVMICDRjFNsCUhSc4wnFa/PP1QD0NXCjr7bu9a2EM6md/KMCBW0Qe393Ac+UM7/ryDDTw==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.4':
-    resolution: {integrity: sha512-j2hPAKVmGNN2EsKigEWD+43y9m7zaPhNAs6ptsyfq0u7evHHBAXAwOfv86OEMg/gvC+pwGip0i1CIm1bR1vYug==}
+  '@turbo/linux-arm64@2.9.5':
+    resolution: {integrity: sha512-jyBifaNoI5/NheyswomiZXJvjdAdvT7hDRYzQ4meP0DKGvpXUjnqsD+4/J2YSDQ34OHxFkL30FnSCUIVOh2PHw==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.4':
-    resolution: {integrity: sha512-1jWPjCe9ZRmsDTXE7uzqfySNQspnUx0g6caqvwps+k/sc+fm9hC/4zRQKlXZLbVmP3Xxp601Ju71boegHdnYGw==}
+  '@turbo/windows-64@2.9.5':
+    resolution: {integrity: sha512-ph24K5uPtvo7UfuyDXnBiB/8XvrO+RQWbbw5zkA/bVNoy9HDiNoIJJj3s62MxT9tjEb6DnPje5PXSz1UR7QAyg==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.4':
-    resolution: {integrity: sha512-dlko15TQVu/BFYmIY018Y3covWMRQlUgAkD+OOk+Rokcfj6VY02Vv4mCfT/Zns6B4q8jGbOd6IZhnCFYsE8Viw==}
+  '@turbo/windows-arm64@2.9.5':
+    resolution: {integrity: sha512-6c5RccT/+iR39SdT1G5HyZaD2n57W77o+l0TTfxG/cVlhV94Acyg2gTQW7zUOhW1BeQpBjHzu9x8yVBZwrHh7g==}
     cpu: [arm64]
     os: [win32]
 
@@ -1913,8 +1913,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo@2.9.4:
-    resolution: {integrity: sha512-wZ/kMcZCuK5oEp7sXSSo/5fzKjP9I2EhoiarZjyCm2Ixk0WxFrC/h0gF3686eHHINoFQOOSWgB/pGfvkR8rkgQ==}
+  turbo@2.9.5:
+    resolution: {integrity: sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA==}
     hasBin: true
 
   type-check@0.4.0:
@@ -2426,22 +2426,22 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@turbo/darwin-64@2.9.4':
+  '@turbo/darwin-64@2.9.5':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.4':
+  '@turbo/darwin-arm64@2.9.5':
     optional: true
 
-  '@turbo/linux-64@2.9.4':
+  '@turbo/linux-64@2.9.5':
     optional: true
 
-  '@turbo/linux-arm64@2.9.4':
+  '@turbo/linux-arm64@2.9.5':
     optional: true
 
-  '@turbo/windows-64@2.9.4':
+  '@turbo/windows-64@2.9.5':
     optional: true
 
-  '@turbo/windows-arm64@2.9.4':
+  '@turbo/windows-arm64@2.9.5':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -3599,14 +3599,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.9.4:
+  turbo@2.9.5:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.4
-      '@turbo/darwin-arm64': 2.9.4
-      '@turbo/linux-64': 2.9.4
-      '@turbo/linux-arm64': 2.9.4
-      '@turbo/windows-64': 2.9.4
-      '@turbo/windows-arm64': 2.9.4
+      '@turbo/darwin-64': 2.9.5
+      '@turbo/darwin-arm64': 2.9.5
+      '@turbo/linux-64': 2.9.5
+      '@turbo/linux-arm64': 2.9.5
+      '@turbo/windows-64': 2.9.5
+      '@turbo/windows-arm64': 2.9.5
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://turbo.build/schema.json",
+	"$schema": "https://v2-9-5.turborepo.dev/schema.json",
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],


### PR DESCRIPTION
Closes #1347

## Summary

- Tween no longer adds itself to `game.world` — subscribes to game loop events (`TICK`, `STATE_PAUSE`, `STATE_RESUME`, `GAME_AFTER_UPDATE`, `GAME_RESET`) on `start()` and unsubscribes on `stop()` or completion
- Removes `game.world` dependency — no more `addChild`/`removeChildNow`
- Removes container-compat flags (`isRenderable`)
- `isPersistent` controls whether `GAME_RESET` auto-stops the tween
- `updateWhenPaused` controls whether the tween pauses with the game state
- Removed dead code in `setProperties` (always-false `typeof` check)
- `setProperties` calls `_unsubscribe()` to prevent leaked event listeners on pool reuse
- Updated JSDoc for Tween, Easing, and Interpolation with cross-references and examples

## Breaking Changes

- Tween no longer appears in `game.world.children` — code that iterated the world container to find tweens will no longer see them
- `isRenderable` property removed from Tween

## Test plan

- [ ] All 2304 unit tests pass
- [ ] Whack-a-mole example: moles animate correctly (tween timing)
- [ ] Platformer example: camera fade in/out works (isPersistent tweens)
- [ ] Graphics example: animated shapes still work
- [ ] Pausing/resuming the game correctly pauses/resumes active tweens

🤖 Generated with [Claude Code](https://claude.com/claude-code)