### PR TITLE
Refresh whack-a-mole example for v19 API

### DIFF
--- a/packages/examples/src/examples/whac-a-mole/ExampleWhacAMole.ts
+++ b/packages/examples/src/examples/whac-a-mole/ExampleWhacAMole.ts
@@ -1,15 +1,15 @@
-import { audio, loader, save, state, video } from "melonjs";
+import { Application, audio, loader, save, state } from "melonjs";
 import { createExampleComponent } from "../utils";
 import { data } from "./data";
 import { PlayScreen } from "./play";
 import { resources } from "./resources";
 
 const createGame = () => {
-	// Initialize the video.
-	if (!video.init(1024, 768, { parent: "screen", scale: "auto" })) {
-		alert("Your browser does not support HTML5 canvas.");
-		return;
-	}
+	// create a new melonJS Application
+	const _app = new Application(1024, 768, {
+		parent: "screen",
+		scale: "auto",
+	});
 
 	// initialize the "sound engine"
 	audio.init("mp3,ogg");
@@ -20,7 +20,7 @@ const createGame = () => {
 	// set the local hiscore value
 	data.hiscore = save.hiscore as number;
 
-	// set all ressources to be loaded
+	// set all resources to be loaded
 	loader.preload(resources, () => {
 		// set the "Play/Ingame" Screen Object
 		state.set(state.PLAY, new PlayScreen());

--- a/packages/examples/src/examples/whac-a-mole/HUD.ts
+++ b/packages/examples/src/examples/whac-a-mole/HUD.ts
@@ -1,63 +1,15 @@
-import {
-	BitmapText,
-	type CanvasRenderer,
-	Container,
-	Renderable,
-	video,
-	type WebGLRenderer,
-} from "melonjs";
+import { BitmapText, Container, video } from "melonjs";
 
 import { data } from "./data";
 
 /**
- * a basic HUD item to display score
- */
-class ScoreItem extends Renderable {
-	private scoreRef: string;
-	private font: BitmapText; // Declare the 'font' property
-
-	/**
-	 * constructor
-	 */
-	constructor(score: string, align: string, x: number, y: number) {
-		// call the super constructor
-		// (size does not matter here)
-		super(x, y, 10, 10);
-
-		// create a font
-		this.font = new BitmapText(0, 0, {
-			font: "PressStart2P",
-			size: 1.5,
-			textAlign: align,
-			textBaseline: "top",
-		});
-
-		// ref to the score variable
-		this.scoreRef = score;
-
-		// make sure we use screen coordinates
-		this.floating = true;
-	}
-
-	/**
-	 * draw the score
-	 */
-	override draw(renderer: WebGLRenderer | CanvasRenderer) {
-		this.font.draw(
-			renderer,
-			data[this.scoreRef].toString(),
-			this.pos.x,
-			this.pos.y,
-		);
-	}
-}
-
-/**
- * a HUD container a
+ * a HUD container
  */
 export class HUDContainer extends Container {
+	score: BitmapText;
+	hiscore: BitmapText;
+
 	constructor() {
-		// call the constructor
 		super();
 
 		// persistent across level change
@@ -66,13 +18,36 @@ export class HUDContainer extends Container {
 		// make sure our object is always draw first
 		this.depth = Number.POSITIVE_INFINITY;
 
+		// make sure we use screen coordinates
+		this.floating = true;
+
 		// give a name
 		this.name = "HUD";
 
-		// add our child score object at position
-		this.addChild(new ScoreItem("score", "left", 10, 10));
+		// score display
+		this.score = new BitmapText(10, 10, {
+			font: "PressStart2P",
+			size: 1.5,
+			textAlign: "left",
+			textBaseline: "top",
+			text: "0",
+		});
+		this.addChild(this.score);
 
-		// add our child score object at position
-		this.addChild(new ScoreItem("hiscore", "right", video.renderer.width, 10));
+		// hiscore display
+		this.hiscore = new BitmapText(video.renderer.width, 10, {
+			font: "PressStart2P",
+			size: 1.5,
+			textAlign: "right",
+			textBaseline: "top",
+			text: data.hiscore.toString(),
+		});
+		this.addChild(this.hiscore);
+	}
+
+	override update(dt: number) {
+		this.score.setText(data.score.toString());
+		this.hiscore.setText(data.hiscore.toString());
+		return super.update(dt);
 	}
 }

--- a/packages/examples/src/examples/whac-a-mole/HUD.ts
+++ b/packages/examples/src/examples/whac-a-mole/HUD.ts
@@ -8,6 +8,8 @@ import { data } from "./data";
 export class HUDContainer extends Container {
 	score: BitmapText;
 	hiscore: BitmapText;
+	private lastScore = -1;
+	private lastHiscore = -1;
 
 	constructor() {
 		super();
@@ -15,7 +17,7 @@ export class HUDContainer extends Container {
 		// persistent across level change
 		this.isPersistent = true;
 
-		// make sure our object is always draw first
+		// make sure our object is always drawn last (on top)
 		this.depth = Number.POSITIVE_INFINITY;
 
 		// make sure we use screen coordinates
@@ -46,8 +48,14 @@ export class HUDContainer extends Container {
 	}
 
 	override update(dt: number) {
-		this.score.setText(data.score.toString());
-		this.hiscore.setText(data.hiscore.toString());
+		if (data.score !== this.lastScore) {
+			this.lastScore = data.score;
+			this.score.setText(data.score.toString());
+		}
+		if (data.hiscore !== this.lastHiscore) {
+			this.lastHiscore = data.hiscore;
+			this.hiscore.setText(data.hiscore.toString());
+		}
 		return super.update(dt);
 	}
 }

--- a/packages/examples/src/examples/whac-a-mole/play.ts
+++ b/packages/examples/src/examples/whac-a-mole/play.ts
@@ -1,4 +1,4 @@
-import { audio, loader, Sprite, Stage } from "melonjs";
+import { type Application, audio, loader, Sprite, Stage } from "melonjs";
 import { HUDContainer } from "./HUD";
 import { MoleManager } from "./manager";
 
@@ -6,10 +6,12 @@ import { MoleManager } from "./manager";
 const y_pos = [0, 127, 255, 383, 511, 639];
 
 export class PlayScreen extends Stage {
+	HUD?: HUDContainer;
+
 	/**
 	 * action to perform on state change
 	 */
-	override onResetEvent(app) {
+	override onResetEvent(app: Application) {
 		app.reset();
 
 		// add the background & foreground sprite elements
@@ -31,7 +33,7 @@ export class PlayScreen extends Stage {
 		});
 
 		// instantiate the mole Manager
-		const moleManager = new MoleManager(0, 0);
+		const moleManager = new MoleManager();
 		app.world.addChild(moleManager, 0);
 
 		// add our HUD (scores/hiscore)
@@ -45,9 +47,11 @@ export class PlayScreen extends Stage {
 	/**
 	 * action to perform when leaving this screen (state change)
 	 */
-	override onDestroyEvent(app) {
+	override onDestroyEvent(app: Application) {
 		// remove the HUD from the game world
-		app.world.removeChild(this.HUD);
+		if (this.HUD) {
+			app.world.removeChild(this.HUD);
+		}
 
 		// stop some music
 		audio.stopTrack();

--- a/packages/examples/src/examples/whac-a-mole/play.ts
+++ b/packages/examples/src/examples/whac-a-mole/play.ts
@@ -1,4 +1,4 @@
-import { audio, game, loader, Sprite, Stage } from "melonjs";
+import { audio, loader, Sprite, Stage } from "melonjs";
 import { HUDContainer } from "./HUD";
 import { MoleManager } from "./manager";
 
@@ -9,8 +9,8 @@ export class PlayScreen extends Stage {
 	/**
 	 * action to perform on state change
 	 */
-	onResetEvent() {
-		game.reset();
+	override onResetEvent(app) {
+		app.reset();
 
 		// add the background & foreground sprite elements
 		y_pos.forEach((y, i) => {
@@ -26,17 +26,17 @@ export class PlayScreen extends Stage {
 			background.anchorPoint.set(0, 0);
 			grass.anchorPoint.set(0, 0);
 			// add the game world
-			game.world.addChild(background, 0);
-			game.world.addChild(grass, i * 10 + 10);
+			app.world.addChild(background, 0);
+			app.world.addChild(grass, i * 10 + 10);
 		});
 
 		// instantiate the mole Manager
 		const moleManager = new MoleManager(0, 0);
-		game.world.addChild(moleManager, 0);
+		app.world.addChild(moleManager, 0);
 
 		// add our HUD (scores/hiscore)
 		this.HUD = new HUDContainer();
-		game.world.addChild(this.HUD);
+		app.world.addChild(this.HUD);
 
 		// start the main soundtrack
 		audio.playTrack("whack");
@@ -45,9 +45,9 @@ export class PlayScreen extends Stage {
 	/**
 	 * action to perform when leaving this screen (state change)
 	 */
-	onDestroyEvent() {
+	override onDestroyEvent(app) {
 		// remove the HUD from the game world
-		game.world.removeChild(this.HUD);
+		app.world.removeChild(this.HUD);
 
 		// stop some music
 		audio.stopTrack();


### PR DESCRIPTION
## Summary

- Replace `video.init()` with `new Application()` entry point
- Fix score display: replace standalone `font.draw()` (removed in #1364) with `BitmapText` children added directly to the HUD container
- Type `onResetEvent`/`onDestroyEvent` with `Application` parameter

## Test plan

- [x] Score and hiscore display correctly
- [x] All 9 moles respond to clicks (verified with #1373 fix)
- [x] Sound effects and music work
- [x] Fade transition between states works

🤖 Generated with [Claude Code](https://claude.com/claude-code)