### PR TITLE
Re-enable exactOptionalPropertyTypes

### DIFF
--- a/packages/melonjs/src/input/gamepad.ts
+++ b/packages/melonjs/src/input/gamepad.ts
@@ -20,7 +20,7 @@ interface ButtonBinding {
 	keyCode: number;
 	value: number;
 	pressed: boolean;
-	threshold?: number;
+	threshold?: number | undefined;
 }
 
 interface GamepadBindings {

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -17,6 +17,7 @@
 		"strictPropertyInitialization": false,
 		"allowImportingTsExtensions": true,
 		"noUnusedParameters": true,
-		"noImplicitOverride": true
+		"noImplicitOverride": true,
+		"exactOptionalPropertyTypes": true
 	}
 }


### PR DESCRIPTION
## Summary
- Re-enable `exactOptionalPropertyTypes: true` in the shared tsconfig
- Fix the single remaining error in `gamepad.ts` (`ButtonBinding.threshold` needed `| undefined`)
- Upstream type issues in vite 8.0.8, vitest 4.1.4, and @types/node 25.6.0 are now resolved

Closes #1271

## Test plan
- [x] Full build passes (all 5 turbo tasks including examples)
- [x] All 2388 tests pass
- [x] No type errors in melonJS source or third-party dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)