### PR TITLE
Add highPrecisionShader application setting (#1390)

### DIFF
--- a/packages/examples/src/examples/platformer/createGame.ts
+++ b/packages/examples/src/examples/platformer/createGame.ts
@@ -27,6 +27,7 @@ export const createGame = () => {
 		renderer: AUTO,
 		preferWebGL1: false,
 		subPixel: false,
+		highPrecisionShader: !device.isMobile,
 	});
 
 	// register the debug plugin

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - WebGL: multi-texture batching — up to 16 textures (based on device capabilities) drawn in a single batch/draw call, eliminating GPU flushes on texture changes. Automatically falls back to single-texture mode when a custom `ShaderEffect` is active. ~80% fewer draw calls on the platformer example (14 vs ~70 flushes/frame), with an estimated 30-50% FPS improvement on low-end mobile devices.
+- WebGL: `highPrecisionShader` application setting — when `false`, caps shader precision at `mediump` for better performance on mobile GPUs that support `highp` but run faster at `mediump`. Default `true` (auto-detect highest precision).
 
 ### Fixed
 - WebGL: `getSupportedCompressedTextureFormats()` no longer crashes when the GL context is unavailable — falls back to the base renderer's empty format list

--- a/packages/melonjs/src/application/defaultApplicationSettings.ts
+++ b/packages/melonjs/src/application/defaultApplicationSettings.ts
@@ -14,6 +14,7 @@ export const defaultApplicationSettings = {
 	blendMode: "normal",
 	physic: "builtin",
 	failIfMajorPerformanceCaveat: true,
+	highPrecisionShader: true,
 	subPixel: false,
 	verbose: false,
 	legacy: false,

--- a/packages/melonjs/src/application/settings.ts
+++ b/packages/melonjs/src/application/settings.ts
@@ -88,6 +88,23 @@ export type ApplicationSettings = {
 	failIfMajorPerformanceCaveat: boolean;
 
 	/**
+	 * enable high precision shaders (WebGL only).
+	 * When false, shaders prefer "mediump" precision for better performance on
+	 * some mobile GPUs, falling back to "lowp" if "mediump" is not supported.
+	 * When true (default), the highest precision supported by the device is used.
+	 * This setting is ignored by the Canvas renderer.
+	 * @default true
+	 * @example
+	 * import { Application, device } from "melonjs";
+	 * const app = new Application(800, 600, {
+	 *     parent: "screen",
+	 *     // prefer lower shader precision on mobile for better performance
+	 *     highPrecisionShader: !device.isMobile,
+	 * });
+	 */
+	highPrecisionShader: boolean;
+
+	/**
 	 * whether to enable sub-pixel rendering (avoid sprite flickering when using transforms)
 	 * @default false
 	 */

--- a/packages/melonjs/src/video/webgl/batchers/batcher.js
+++ b/packages/melonjs/src/video/webgl/batchers/batcher.js
@@ -134,6 +134,7 @@ export class Batcher {
 				this.gl,
 				settings.shader.vertex,
 				settings.shader.fragment,
+				this.renderer.shaderPrecision,
 			);
 		} else {
 			throw new Error("shader definition missing");

--- a/packages/melonjs/src/video/webgl/shadereffect.js
+++ b/packages/melonjs/src/video/webgl/shadereffect.js
@@ -71,7 +71,12 @@ export default class ShaderEffect {
 		].join("\n");
 
 		/** @ignore */
-		this._shader = new GLShader(renderer.gl, quadVertex, fragment, precision);
+		this._shader = new GLShader(
+			renderer.gl,
+			quadVertex,
+			fragment,
+			precision || renderer.shaderPrecision,
+		);
 		this.enabled = true;
 	}
 

--- a/packages/melonjs/src/video/webgl/utils/precision.js
+++ b/packages/melonjs/src/video/webgl/utils/precision.js
@@ -11,13 +11,15 @@ export function setPrecision(src, precision) {
 }
 
 /**
- * return the highest precision format supported by this device for GL Shaders
+ * return the best shader precision for this device, up to the requested cap.
  * @ignore
  * @param {WebGLRenderingContext} gl - the current WebGL context
- * @returns {boolean} "lowp", "mediump", or "highp"
+ * @param {boolean} [highPrecision=true] - if false, cap at "mediump" even when "highp" is available
+ * @returns {string} "lowp", "mediump", or "highp"
  */
-export function getMaxShaderPrecision(gl) {
+export function getMaxShaderPrecision(gl, highPrecision = true) {
 	if (
+		highPrecision &&
 		gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.HIGH_FLOAT).precision >
 			0 &&
 		gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT).precision > 0

--- a/packages/melonjs/src/video/webgl/webgl_renderer.js
+++ b/packages/melonjs/src/video/webgl/webgl_renderer.js
@@ -21,6 +21,7 @@ import {
 import MeshBatcher from "./batchers/mesh_batcher";
 import PrimitiveBatcher from "./batchers/primitive_batcher";
 import QuadBatcher from "./batchers/quad_batcher";
+import { getMaxShaderPrecision } from "./utils/precision.js";
 
 /**
  * additional import for TypeScript
@@ -102,6 +103,16 @@ export default class WebGLRenderer extends Renderer {
 		 * @readonly
 		 */
 		this.maxTextures = this.gl.getParameter(this.gl.MAX_TEXTURE_IMAGE_UNITS);
+
+		/**
+		 * the default shader precision based on application settings
+		 * @type {string}
+		 * @ignore
+		 */
+		this.shaderPrecision = getMaxShaderPrecision(
+			this.gl,
+			this.settings.highPrecisionShader !== false,
+		);
 
 		/**
 		 * reusable scratch array for fillRect (2 triangles = 6 vertices)


### PR DESCRIPTION
## Summary
Add `highPrecisionShader` boolean to Application settings. When `false`, caps shader precision at `mediump` for better performance on mobile GPUs that support `highp` but run faster at `mediump`.

### Changes
- `ApplicationSettings.highPrecisionShader` — new boolean, default `true`
- `getMaxShaderPrecision(gl, highPrecision)` — skips `highp` check when `highPrecision` is `false`
- `WebGLRenderer.shaderPrecision` — resolved once at init, passed to all shader creation
- `Batcher` and `ShaderEffect` pass the renderer's precision to `GLShader`
- Per-shader `precision` parameter still overrides the global setting

### Usage
```js
import { Application, device } from "melonjs";
const app = new Application(800, 600, {
    parent: "screen",
    // use mediump on mobile for better performance
    highPrecisionShader: !device.isMobile,
});
```

## Test plan
- [x] All 2491 tests pass
- [x] Build succeeds

Closes #1390

🤖 Generated with [Claude Code](https://claude.com/claude-code)