### PR TITLE
Add FBO-based post-processing pipeline for camera shader effects

### DIFF
--- a/packages/examples/src/examples/masking/ExampleMasking.tsx
+++ b/packages/examples/src/examples/masking/ExampleMasking.tsx
@@ -7,6 +7,7 @@ import {
 	RoundRect,
 	Sprite,
 	Text,
+	VignetteEffect,
 	video,
 } from "melonjs";
 import { createExampleComponent } from "../utils";
@@ -25,6 +26,8 @@ const createGame = () => {
 	}
 
 	loader.load({ name: "background", type: "image", src: bgImage }, () => {
+		// apply subtle vignette post-process effect on the camera
+		game.viewport.shader = new VignetteEffect(video.renderer);
 		const bg_sprite1 = new Sprite(
 			game.viewport.width / 2,
 			game.viewport.height / 2,

--- a/packages/examples/src/examples/platformer/entities/minimap.ts
+++ b/packages/examples/src/examples/platformer/entities/minimap.ts
@@ -1,4 +1,4 @@
-import { Camera2d, event, game, level } from "melonjs";
+import { Camera2d, event, game, level, VignetteEffect } from "melonjs";
 
 const MINIMAP_WIDTH = 180;
 const MINIMAP_HEIGHT = 100;
@@ -24,6 +24,9 @@ export class MinimapCamera extends Camera2d {
 			this.screenX = w - MINIMAP_WIDTH - 10;
 		};
 		event.on(event.CANVAS_ONRESIZE, this.boundOnResize);
+
+		// apply subtle vignette post-process effect on the minimap
+		this.shader = new VignetteEffect(game.renderer);
 
 		const currentLevel = level.getCurrentLevel();
 		if (currentLevel) {

--- a/packages/examples/src/examples/platformer/play.ts
+++ b/packages/examples/src/examples/platformer/play.ts
@@ -1,4 +1,12 @@
-import { type Application, audio, device, level, plugin, Stage } from "melonjs";
+import {
+	type Application,
+	audio,
+	device,
+	level,
+	plugin,
+	Stage,
+	VignetteEffect,
+} from "melonjs";
 import { VirtualJoypad } from "./entities/controls";
 import UIContainer from "./entities/HUD";
 import { MinimapCamera } from "./entities/minimap";
@@ -36,6 +44,9 @@ export class PlayScreen extends Stage {
 			}
 			app.world.addChild(this.virtualJoypad);
 		}
+
+		// apply subtle vignette post-process effect on the camera
+		app.viewport.shader = new VignetteEffect(app.renderer as any);
 
 		// play some music
 		audio.playTrack("dst-gameforest");

--- a/packages/examples/src/examples/shaderEffects/ExampleShaderEffects.tsx
+++ b/packages/examples/src/examples/shaderEffects/ExampleShaderEffects.tsx
@@ -18,7 +18,9 @@ import {
 	Sprite,
 	Text,
 	TintPulseEffect,
+	VignetteEffect,
 	WaveEffect,
+	type WebGLRenderer,
 } from "melonjs";
 import { createExampleComponent } from "../utils";
 import monsterImg from "./assets/monster.png";
@@ -29,6 +31,9 @@ const createGame = () => {
 		scale: "auto",
 		backgroundColor: "#202020",
 	});
+
+	// apply subtle vignette post-process effect on the camera
+	app.viewport.shader = new VignetteEffect(app.renderer as WebGLRenderer);
 
 	loader.preload([{ name: "monster", type: "image", src: monsterImg }], () => {
 		const r = app.renderer;

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [19.2.0] (melonJS 2) - _unreleased_
+
+### Added
+- Camera: FBO-based post-processing pipeline — assign a `ShaderEffect` to any camera's `shader` property to apply full-screen post-effects (vignette, scanlines, desaturation, etc.). Works with multiple cameras independently (e.g. main camera + minimap with different effects). Renderer manages FBO lifecycle via `beginPostEffect()`/`endPostEffect()`/`blitEffect()` methods.
+- WebGL: `VignetteEffect` built-in shader effect — darkens screen edges to draw focus to the center, with configurable `strength` and `size` parameters
+- WebGL: `WebGLRenderTarget` class — reusable FBO wrapper (framebuffer + color texture + depth/stencil renderbuffer) with bind/unbind/resize/destroy lifecycle
+- Renderer: `beginPostEffect(camera)`, `endPostEffect(camera)`, and `blitEffect(source, x, y, w, h, shader)` methods on the base Renderer (no-op for Canvas) and WebGLRenderer
+- RenderState: `currentShader` is now part of the save/restore stack — custom shaders are properly scoped per-renderable without leaking to siblings or parent cameras
+
+### Changed
+- Renderable: `preDraw()` now always sets `renderer.customShader = this.shader` unconditionally (was guarded by `if (this.shader)`), relying on save/restore to scope the shader correctly
+- Renderable: `postDraw()` no longer manually clears `renderer.customShader` — save/restore handles it
+
 ## [19.1.0] (melonJS 2) - _2026-04-16_
 
 ### Added

--- a/packages/melonjs/package.json
+++ b/packages/melonjs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "melonjs",
-	"version": "19.1.0",
+	"version": "19.2.0",
 	"description": "melonJS Game Engine",
 	"homepage": "http://www.melonjs.org/",
 	"type": "module",

--- a/packages/melonjs/src/camera/camera2d.ts
+++ b/packages/melonjs/src/camera/camera2d.ts
@@ -840,34 +840,36 @@ export default class Camera2d extends Renderable {
 		const r = renderer as any;
 		// fading effect
 		if (this._fadeIn.tween) {
+			const color = this._fadeIn.color;
 			// add an overlay
 			r.save();
-			// reset all transform so that the overaly cover the whole camera area
+			// reset all transform so that the overlay covers the whole camera area
 			r.resetTransform();
-			r.setColor(this._fadeIn.color!);
+			r.setColor(color);
 			r.fillRect(0, 0, this.width, this.height);
 			r.restore();
 			// remove the tween if over
-			if (this._fadeIn.color!.alpha === 1.0) {
+			if (color && color.alpha === 1.0) {
 				this._fadeIn.tween = null;
-				colorPool.release(this._fadeIn.color!);
+				colorPool.release(color);
 				this._fadeIn.color = null;
 			}
 		}
 
 		// flashing effect
 		if (this._fadeOut.tween) {
+			const color = this._fadeOut.color;
 			// add an overlay
 			r.save();
-			// reset all transform so that the overaly cover the whole camera area
+			// reset all transform so that the overlay covers the whole camera area
 			r.resetTransform();
-			r.setColor(this._fadeOut.color!);
+			r.setColor(color);
 			r.fillRect(0, 0, this.width, this.height);
 			r.restore();
 			// remove the tween if over
-			if (this._fadeOut.color!.alpha === 0.0) {
+			if (color && color.alpha === 0.0) {
 				this._fadeOut.tween = null;
-				colorPool.release(this._fadeOut.color!);
+				colorPool.release(color);
 				this._fadeOut.color = null;
 			}
 		}
@@ -888,13 +890,19 @@ export default class Camera2d extends Renderable {
 		const translateX = this.pos.x + this.offset.x + containerOffsetX;
 		const translateY = this.pos.y + this.offset.y + containerOffsetY;
 
+		// post-effect: bind FBO if a shader effect is set (WebGL only)
+		const usePostEffect = r.beginPostEffect(this);
+
 		// translate the world coordinates by default to screen coordinates
 		container.translate(-translateX, -translateY);
 
 		this.preDraw(r);
 
-		// clip to camera viewport on screen (after preDraw's save)
-		r.clipRect(this.screenX, this.screenY, this.width, this.height);
+		// clip to camera viewport on screen (skip when rendering to FBO —
+		// the FBO itself defines the render area)
+		if (!usePostEffect) {
+			r.clipRect(this.screenX, this.screenY, this.width, this.height);
+		}
 
 		// set camera projection for non-default cameras
 		if (isNonDefault) {
@@ -951,6 +959,9 @@ export default class Camera2d extends Renderable {
 		container.postDraw(r);
 
 		this.postDraw(r);
+
+		// post-effect: unbind FBO and blit to screen through shader effect
+		r.endPostEffect(this);
 
 		// translate the world coordinates by default to screen coordinates
 		container.translate(translateX, translateY);

--- a/packages/melonjs/src/index.ts
+++ b/packages/melonjs/src/index.ts
@@ -75,6 +75,7 @@ import PixelateEffect from "./video/webgl/effects/pixelate.js";
 import ScanlineEffect from "./video/webgl/effects/scanline.js";
 import SepiaEffect from "./video/webgl/effects/sepia.js";
 import TintPulseEffect from "./video/webgl/effects/tintPulse.js";
+import VignetteEffect from "./video/webgl/effects/vignette.js";
 import WaveEffect from "./video/webgl/effects/wave.js";
 import GLShader from "./video/webgl/glshader.js";
 import ShaderEffect from "./video/webgl/shadereffect.js";
@@ -193,6 +194,7 @@ export {
 	UIBaseElement,
 	UISpriteElement,
 	UITextButton,
+	VignetteEffect,
 	WaveEffect,
 	WebGLRenderer,
 	World,

--- a/packages/melonjs/src/renderable/renderable.js
+++ b/packages/melonjs/src/renderable/renderable.js
@@ -749,10 +749,8 @@ export default class Renderable extends Rect {
 			renderer.translate(-this.pos.x, -this.pos.y);
 		}
 
-		// use this renderable shader if defined
-		if (this.shader) {
-			renderer.customShader = this.shader;
-		}
+		// set the custom shader for this renderable (undefined clears it)
+		renderer.customShader = this.shader;
 
 		if (this.autoTransform === true && !this.currentTransform.isIdentity()) {
 			// apply the renderable transformation matrix
@@ -806,12 +804,7 @@ export default class Renderable extends Rect {
 			renderer.clearMask();
 		}
 
-		// revert to the default shader if defined
-		if (this.shader) {
-			renderer.customShader = undefined;
-		}
-
-		// restore the context
+		// restore the context (also restores customShader)
 		renderer.restore();
 
 		// reset the dirty flag

--- a/packages/melonjs/src/video/renderer.js
+++ b/packages/melonjs/src/video/renderer.js
@@ -257,6 +257,44 @@ export default class Renderer {
 	}
 
 	/**
+	 * Begin capturing rendering to an offscreen buffer for post-effect processing.
+	 * Call endPostEffect() after rendering to blit the result to the screen.
+	 * No-op on Canvas renderer.
+	 * @param {Camera2d} camera - the camera requesting post-effect processing
+	 * @returns {boolean} false (Canvas renderer does not support post-effect processing)
+	 * @ignore
+	 */
+	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+	beginPostEffect(camera) {
+		return false;
+	}
+
+	/**
+	 * End post-effect capture and blit the offscreen buffer to the screen
+	 * through the camera's shader effect.
+	 * No-op on Canvas renderer.
+	 * @param {Camera2d} camera - the camera with shader, screen position, and dimensions
+	 * @ignore
+	 */
+	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+	endPostEffect(camera) {}
+
+	/**
+	 * Blit a texture to the screen through a shader effect.
+	 * Draws a screen-aligned quad using the given texture as source
+	 * and the given shader for post-processing (e.g. scanlines, desaturation).
+	 * No-op on Canvas renderer.
+	 * @param {WebGLTexture} source - the source texture to blit
+	 * @param {number} x - destination x position
+	 * @param {number} y - destination y position
+	 * @param {number} width - destination width
+	 * @param {number} height - destination height
+	 * @param {ShaderEffect} shader - the shader effect to apply
+	 */
+	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+	blitEffect(source, x, y, width, height, shader) {}
+
+	/**
 	 * returns the current blend mode for this renderer
 	 * @returns {string} blend mode
 	 */

--- a/packages/melonjs/src/video/renderstate.js
+++ b/packages/melonjs/src/video/renderstate.js
@@ -187,6 +187,7 @@ export default class RenderState {
 		this.currentScissor[1] = 0;
 		this.currentScissor[2] = width;
 		this.currentScissor[3] = height;
+		this.currentShader = undefined;
 	}
 
 	/** @private — doubles stack capacity when exceeded */

--- a/packages/melonjs/src/video/renderstate.js
+++ b/packages/melonjs/src/video/renderstate.js
@@ -57,6 +57,12 @@ export default class RenderState {
 		 */
 		this.currentBlendMode = "none";
 
+		/**
+		 * current custom shader effect (undefined when using default shader)
+		 * @type {ShaderEffect|undefined}
+		 */
+		this.currentShader = undefined;
+
 		// ---- pre-allocated save/restore stack ----
 
 		/**
@@ -101,6 +107,9 @@ export default class RenderState {
 
 		/** @ignore */
 		this._blendStack = new Array(this._stackCapacity);
+
+		/** @ignore */
+		this._shaderStack = new Array(this._stackCapacity);
 	}
 
 	/**
@@ -120,6 +129,7 @@ export default class RenderState {
 		this._gradientStack[depth] = this.currentGradient;
 		this._lineDashStack[depth] = this.lineDash;
 		this._blendStack[depth] = this.currentBlendMode;
+		this._shaderStack[depth] = this.currentShader;
 
 		if (scissorTestActive) {
 			this._scissorStack[depth].set(this.currentScissor);
@@ -149,6 +159,7 @@ export default class RenderState {
 			this.currentTransform.copy(this._matrixStack[depth]);
 			this.currentGradient = this._gradientStack[depth];
 			this.lineDash = this._lineDashStack[depth];
+			this.currentShader = this._shaderStack[depth];
 			const scissorActive = !!this._scissorActive[depth];
 			if (scissorActive) {
 				this.currentScissor.set(this._scissorStack[depth]);
@@ -190,6 +201,7 @@ export default class RenderState {
 			this._gradientStack.push(null);
 			this._lineDashStack.push([]);
 			this._blendStack.push(undefined);
+			this._shaderStack.push(undefined);
 		}
 		const newScissorActive = new Uint8Array(newCap);
 		newScissorActive.set(this._scissorActive);

--- a/packages/melonjs/src/video/rendertarget/webglrendertarget.js
+++ b/packages/melonjs/src/video/rendertarget/webglrendertarget.js
@@ -1,0 +1,216 @@
+/**
+ * A WebGL Framebuffer Object (FBO) render target for offscreen rendering.
+ * Used by the post-processing pipeline to render a camera's output to a texture,
+ * which can then be drawn to the screen through a post-process shader.
+ * @ignore
+ */
+export default class WebGLRenderTarget {
+	/**
+	 * @param {WebGLRenderingContext|WebGL2RenderingContext} gl - the WebGL context
+	 * @param {number} width - initial width in pixels
+	 * @param {number} height - initial height in pixels
+	 */
+	constructor(gl, width, height) {
+		this.gl = gl;
+		this.width = width;
+		this.height = height;
+
+		// create framebuffer
+		this.framebuffer = gl.createFramebuffer();
+
+		// create color texture
+		this.texture = gl.createTexture();
+		gl.bindTexture(gl.TEXTURE_2D, this.texture);
+		gl.texImage2D(
+			gl.TEXTURE_2D,
+			0,
+			gl.RGBA,
+			width,
+			height,
+			0,
+			gl.RGBA,
+			gl.UNSIGNED_BYTE,
+			null,
+		);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+		// create depth+stencil renderbuffer (needed for masks)
+		this.depthStencilBuffer = gl.createRenderbuffer();
+		gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthStencilBuffer);
+		gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, width, height);
+
+		// attach to framebuffer
+		gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+		gl.framebufferTexture2D(
+			gl.FRAMEBUFFER,
+			gl.COLOR_ATTACHMENT0,
+			gl.TEXTURE_2D,
+			this.texture,
+			0,
+		);
+		gl.framebufferRenderbuffer(
+			gl.FRAMEBUFFER,
+			gl.DEPTH_STENCIL_ATTACHMENT,
+			gl.RENDERBUFFER,
+			this.depthStencilBuffer,
+		);
+
+		// unbind
+		gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+		gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+		gl.bindTexture(gl.TEXTURE_2D, null);
+	}
+
+	/**
+	 * Bind this FBO as the active render target.
+	 * All subsequent draw calls will render into this FBO's texture.
+	 */
+	bind() {
+		this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, this.framebuffer);
+	}
+
+	/**
+	 * Unbind this FBO and restore rendering to the screen.
+	 */
+	unbind() {
+		this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
+	}
+
+	/**
+	 * Resize the FBO texture and renderbuffer.
+	 * @param {number} width - new width in pixels
+	 * @param {number} height - new height in pixels
+	 */
+	resize(width, height) {
+		if (this.width === width && this.height === height) {
+			return;
+		}
+
+		const gl = this.gl;
+		this.width = width;
+		this.height = height;
+
+		// resize color texture
+		gl.bindTexture(gl.TEXTURE_2D, this.texture);
+		gl.texImage2D(
+			gl.TEXTURE_2D,
+			0,
+			gl.RGBA,
+			width,
+			height,
+			0,
+			gl.RGBA,
+			gl.UNSIGNED_BYTE,
+			null,
+		);
+
+		// resize depth+stencil renderbuffer
+		gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthStencilBuffer);
+		gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, width, height);
+
+		gl.bindTexture(gl.TEXTURE_2D, null);
+		gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+	}
+
+	/**
+	 * Returns an ImageData object representing the pixel contents of this render target.
+	 * The FBO must be bound before calling this method.
+	 * @param {number} [x=0] - x coordinate of the top-left corner
+	 * @param {number} [y=0] - y coordinate of the top-left corner
+	 * @param {number} [width=this.width] - width of the area to read
+	 * @param {number} [height=this.height] - height of the area to read
+	 * @returns {ImageData} the pixel data
+	 */
+	getImageData(x = 0, y = 0, width = this.width, height = this.height) {
+		const gl = this.gl;
+		const pixels = new Uint8ClampedArray(width * height * 4);
+		this.bind();
+		gl.readPixels(x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+		this.unbind();
+		// gl.readPixels returns bottom-up rows, flip to top-down
+		const rowSize = width * 4;
+		const temp = new Uint8ClampedArray(rowSize);
+		for (let i = 0; i < Math.floor(height / 2); i++) {
+			const topOffset = i * rowSize;
+			const bottomOffset = (height - 1 - i) * rowSize;
+			temp.set(pixels.subarray(topOffset, topOffset + rowSize));
+			pixels.copyWithin(topOffset, bottomOffset, bottomOffset + rowSize);
+			pixels.set(temp, bottomOffset);
+		}
+		return new ImageData(pixels, width, height);
+	}
+
+	/**
+	 * Creates a Blob object representing the image contained in this render target.
+	 * @param {string} [type="image/png"] - A string indicating the image format
+	 * @param {number} [quality] - A number between 0 and 1 for lossy formats (image/jpeg, image/webp)
+	 * @returns {Promise<Blob>} A Promise resolving to a Blob
+	 */
+	toBlob(type = "image/png", quality) {
+		const imageData = this.getImageData();
+		const canvas = new OffscreenCanvas(this.width, this.height);
+		const ctx = canvas.getContext("2d");
+		ctx.putImageData(imageData, 0, 0);
+		return canvas.convertToBlob({ type, quality });
+	}
+
+	/**
+	 * Creates an ImageBitmap object from the current contents of this render target.
+	 * @returns {Promise<ImageBitmap>} A Promise resolving to an ImageBitmap
+	 */
+	toImageBitmap() {
+		const imageData = this.getImageData();
+		return globalThis.createImageBitmap(imageData);
+	}
+
+	/**
+	 * Returns a data URL containing a representation of the current contents of this render target.
+	 * @param {string} [type="image/png"] - A string indicating the image format
+	 * @param {number} [quality] - A number between 0 and 1 for lossy formats (image/jpeg, image/webp)
+	 * @returns {Promise<string>} A Promise resolving to a data URL string
+	 */
+	toDataURL(type = "image/png", quality) {
+		return this.toBlob(type, quality).then((blob) => {
+			const reader = new FileReader();
+			return new Promise((resolve) => {
+				reader.onloadend = () => {
+					resolve(reader.result);
+				};
+				reader.readAsDataURL(blob);
+			});
+		});
+	}
+
+	/**
+	 * Clear the FBO contents to transparent black.
+	 */
+	clear() {
+		const gl = this.gl;
+		this.bind();
+		gl.clearColor(0, 0, 0, 0);
+		gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+		this.unbind();
+	}
+
+	/**
+	 * Release all GPU resources.
+	 */
+	destroy() {
+		const gl = this.gl;
+		if (this.framebuffer) {
+			gl.deleteFramebuffer(this.framebuffer);
+			this.framebuffer = null;
+		}
+		if (this.texture) {
+			gl.deleteTexture(this.texture);
+			this.texture = null;
+		}
+		if (this.depthStencilBuffer) {
+			gl.deleteRenderbuffer(this.depthStencilBuffer);
+			this.depthStencilBuffer = null;
+		}
+	}
+}

--- a/packages/melonjs/src/video/rendertarget/webglrendertarget.js
+++ b/packages/melonjs/src/video/rendertarget/webglrendertarget.js
@@ -40,7 +40,24 @@ export default class WebGLRenderTarget {
 		// create depth+stencil renderbuffer (needed for masks)
 		this.depthStencilBuffer = gl.createRenderbuffer();
 		gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthStencilBuffer);
-		gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, width, height);
+
+		// WebGL2 natively supports DEPTH_STENCIL; WebGL1 needs the extension
+		const usePackedDepthStencil =
+			(typeof WebGL2RenderingContext !== "undefined" &&
+				gl instanceof WebGL2RenderingContext) ||
+			gl.getExtension("WEBGL_depth_stencil") !== null;
+
+		if (usePackedDepthStencil) {
+			gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, width, height);
+		} else {
+			gl.renderbufferStorage(
+				gl.RENDERBUFFER,
+				gl.DEPTH_COMPONENT16,
+				width,
+				height,
+			);
+		}
+		this._usePackedDepthStencil = usePackedDepthStencil;
 
 		// attach to framebuffer
 		gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
@@ -51,12 +68,21 @@ export default class WebGLRenderTarget {
 			this.texture,
 			0,
 		);
-		gl.framebufferRenderbuffer(
-			gl.FRAMEBUFFER,
-			gl.DEPTH_STENCIL_ATTACHMENT,
-			gl.RENDERBUFFER,
-			this.depthStencilBuffer,
-		);
+		if (usePackedDepthStencil) {
+			gl.framebufferRenderbuffer(
+				gl.FRAMEBUFFER,
+				gl.DEPTH_STENCIL_ATTACHMENT,
+				gl.RENDERBUFFER,
+				this.depthStencilBuffer,
+			);
+		} else {
+			gl.framebufferRenderbuffer(
+				gl.FRAMEBUFFER,
+				gl.DEPTH_ATTACHMENT,
+				gl.RENDERBUFFER,
+				this.depthStencilBuffer,
+			);
+		}
 
 		// unbind
 		gl.bindFramebuffer(gl.FRAMEBUFFER, null);
@@ -109,7 +135,12 @@ export default class WebGLRenderTarget {
 
 		// resize depth+stencil renderbuffer
 		gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthStencilBuffer);
-		gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, width, height);
+		gl.renderbufferStorage(
+			gl.RENDERBUFFER,
+			this._usePackedDepthStencil ? gl.DEPTH_STENCIL : gl.DEPTH_COMPONENT16,
+			width,
+			height,
+		);
 
 		gl.bindTexture(gl.TEXTURE_2D, null);
 		gl.bindRenderbuffer(gl.RENDERBUFFER, null);
@@ -117,7 +148,6 @@ export default class WebGLRenderTarget {
 
 	/**
 	 * Returns an ImageData object representing the pixel contents of this render target.
-	 * The FBO must be bound before calling this method.
 	 * @param {number} [x=0] - x coordinate of the top-left corner
 	 * @param {number} [y=0] - y coordinate of the top-left corner
 	 * @param {number} [width=this.width] - width of the area to read
@@ -126,6 +156,11 @@ export default class WebGLRenderTarget {
 	 */
 	getImageData(x = 0, y = 0, width = this.width, height = this.height) {
 		const gl = this.gl;
+		// clamp to render target bounds
+		x = Math.max(0, Math.min(Math.floor(x), this.width - 1));
+		y = Math.max(0, Math.min(Math.floor(y), this.height - 1));
+		width = Math.max(1, Math.min(width, this.width - x));
+		height = Math.max(1, Math.min(height, this.height - y));
 		const pixels = new Uint8ClampedArray(width * height * 4);
 		this.bind();
 		gl.readPixels(x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
@@ -151,10 +186,27 @@ export default class WebGLRenderTarget {
 	 */
 	toBlob(type = "image/png", quality) {
 		const imageData = this.getImageData();
-		const canvas = new OffscreenCanvas(this.width, this.height);
+		if (typeof OffscreenCanvas !== "undefined") {
+			const canvas = new OffscreenCanvas(this.width, this.height);
+			const ctx = canvas.getContext("2d");
+			ctx.putImageData(imageData, 0, 0);
+			return canvas.convertToBlob({ type, quality });
+		}
+		// fallback for environments without OffscreenCanvas
+		const canvas = document.createElement("canvas");
+		canvas.width = this.width;
+		canvas.height = this.height;
 		const ctx = canvas.getContext("2d");
 		ctx.putImageData(imageData, 0, 0);
-		return canvas.convertToBlob({ type, quality });
+		return new Promise((resolve) => {
+			canvas.toBlob(
+				(blob) => {
+					resolve(blob);
+				},
+				type,
+				quality,
+			);
+		});
 	}
 
 	/**

--- a/packages/melonjs/src/video/webgl/batchers/quad_batcher.js
+++ b/packages/melonjs/src/video/webgl/batchers/quad_batcher.js
@@ -100,7 +100,8 @@ export default class QuadBatcher extends MaterialBatcher {
 	 * Multi-texture batching is automatically enabled when the default
 	 * shader is active, and disabled for custom ShaderEffect shaders.
 	 * @see GLShader
-	 * @param {GLShader} shader - a reference to a GLShader instance
+	 * @see ShaderEffect
+	 * @param {GLShader|ShaderEffect} shader - a reference to a GLShader or ShaderEffect instance
 	 */
 	useShader(shader) {
 		super.useShader(shader);
@@ -167,6 +168,45 @@ export default class QuadBatcher extends MaterialBatcher {
 
 			vertex.clear();
 		}
+	}
+
+	/**
+	 * Draw a screen-aligned quad with the given raw WebGL texture through the given shader.
+	 * Binds the texture to unit 0, pushes 4 vertices (Y-flipped UVs), flushes,
+	 * then unbinds the texture.
+	 * @param {WebGLTexture} source - the raw GL texture to blit
+	 * @param {number} x - destination x
+	 * @param {number} y - destination y
+	 * @param {number} width - destination width
+	 * @param {number} height - destination height
+	 * @param {GLShader|ShaderEffect} shader - the shader effect to apply
+	 */
+	blitTexture(source, x, y, width, height, shader) {
+		const gl = this.gl;
+
+		this.useShader(shader);
+
+		// bind the source texture to unit 0
+		gl.activeTexture(gl.TEXTURE0);
+		gl.bindTexture(gl.TEXTURE_2D, source);
+		shader.setUniform("uSampler", 0);
+
+		// push a screen-aligned quad with Y-flipped UVs
+		const tint = 0xffffffff;
+		this.vertexData.push(x, y, 0, 1, tint, 0);
+		this.vertexData.push(x + width, y, 1, 1, tint, 0);
+		this.vertexData.push(x, y + height, 0, 0, tint, 0);
+		this.vertexData.push(x + width, y + height, 1, 0, tint, 0);
+
+		this.flush();
+
+		// unbind the texture to prevent feedback loop on next frame
+		gl.activeTexture(gl.TEXTURE0);
+		gl.bindTexture(gl.TEXTURE_2D, null);
+		delete this.boundTextures[0];
+
+		// restore the default shader (also re-enables multi-texture batching)
+		this.useShader(this.defaultShader);
 	}
 
 	/**

--- a/packages/melonjs/src/video/webgl/effects/vignette.js
+++ b/packages/melonjs/src/video/webgl/effects/vignette.js
@@ -20,7 +20,7 @@ export default class VignetteEffect extends ShaderEffect {
 	/**
 	 * @param {import("../webgl_renderer.js").default} renderer - the current renderer instance
 	 * @param {object} [options] - effect options
-	 * @param {number} [options.strength=0.15] - edge darkening power (higher = more subtle, 0.1 = strong, 0.3 = very soft)
+	 * @param {number} [options.strength=0.15] - edge darkening power (lower = stronger darkening, higher = softer falloff)
 	 * @param {number} [options.size=25.0] - vignette spread multiplier (higher = smaller dark area)
 	 */
 	constructor(renderer, options = {}) {
@@ -46,7 +46,7 @@ export default class VignetteEffect extends ShaderEffect {
 
 	/**
 	 * set the vignette strength
-	 * @param {number} strength - edge darkening power (higher = more subtle)
+	 * @param {number} strength - edge darkening power (lower = stronger, higher = softer)
 	 */
 	setStrength(strength) {
 		this.strength = Math.max(0, strength);

--- a/packages/melonjs/src/video/webgl/effects/vignette.js
+++ b/packages/melonjs/src/video/webgl/effects/vignette.js
@@ -1,0 +1,64 @@
+import ShaderEffect from "../shadereffect.js";
+
+/**
+ * A shader effect that darkens the edges of the screen, drawing focus
+ * to the center. Commonly used for atmosphere, cinematic feel, or to
+ * naturally frame a camera viewport (e.g. minimap).
+ * @category Effects
+ * @see {@link Renderable.shader} for usage
+ * @example
+ * // subtle vignette on the main camera
+ * app.viewport.shader = new VignetteEffect(renderer);
+ * @example
+ * // stronger cinematic vignette
+ * app.viewport.shader = new VignetteEffect(renderer, {
+ *     strength: 0.3,
+ *     size: 20.0,
+ * });
+ */
+export default class VignetteEffect extends ShaderEffect {
+	/**
+	 * @param {import("../webgl_renderer.js").default} renderer - the current renderer instance
+	 * @param {object} [options] - effect options
+	 * @param {number} [options.strength=0.15] - edge darkening power (higher = more subtle, 0.1 = strong, 0.3 = very soft)
+	 * @param {number} [options.size=25.0] - vignette spread multiplier (higher = smaller dark area)
+	 */
+	constructor(renderer, options = {}) {
+		super(
+			renderer,
+			`
+			uniform float uStrength;
+			uniform float uSize;
+			vec4 apply(vec4 color, vec2 uv) {
+				vec2 vig = uv * (1.0 - uv);
+				float v = clamp(pow(vig.x * vig.y * uSize, uStrength), 0.0, 1.0);
+				return vec4(color.rgb * v, color.a);
+			}
+			`,
+		);
+
+		this.strength = options.strength ?? 0.15;
+		this.size = options.size ?? 25.0;
+
+		this.setUniform("uStrength", this.strength);
+		this.setUniform("uSize", this.size);
+	}
+
+	/**
+	 * set the vignette strength
+	 * @param {number} strength - edge darkening power (higher = more subtle)
+	 */
+	setStrength(strength) {
+		this.strength = Math.max(0, strength);
+		this.setUniform("uStrength", this.strength);
+	}
+
+	/**
+	 * set the vignette size
+	 * @param {number} size - spread multiplier (higher = smaller dark area)
+	 */
+	setSize(size) {
+		this.size = Math.max(0, size);
+		this.setUniform("uSize", this.size);
+	}
+}

--- a/packages/melonjs/src/video/webgl/webgl_renderer.js
+++ b/packages/melonjs/src/video/webgl/webgl_renderer.js
@@ -11,6 +11,7 @@ import {
 } from "../../system/event.ts";
 import { Gradient } from "../gradient.js";
 import Renderer from "./../renderer.js";
+import WebGLRenderTarget from "./../rendertarget/webglrendertarget.js";
 import { createAtlas, TextureAtlas } from "./../texture/atlas.js";
 import TextureCache from "./../texture/cache.js";
 import { dashPath, dashSegments } from "../utils/dash.js";
@@ -37,6 +38,10 @@ import { getMaxShaderPrecision } from "./utils/precision.js";
 
 // reusable constants for 2D→3D matrix operations
 const _tempMatrix = new Matrix3d();
+
+// pre-allocated matrices for blitEffect (avoids per-frame allocation)
+const _savedTransform = new Matrix3d();
+const _savedProjection = new Matrix3d();
 
 // list of supported compressed texture formats
 let supportedCompressedTextureFormats;
@@ -75,6 +80,13 @@ export default class WebGLRenderer extends Renderer {
 		 * @type {WebGLRenderingContext}
 		 */
 		this.gl = this.renderTarget.context;
+
+		/**
+		 * cached FBO for post-effect processing (lazily created on first use)
+		 * @type {WebGLRenderTarget|null}
+		 * @ignore
+		 */
+		this.currentEffectFBO = null;
 
 		/**
 		 * sets or returns the thickness of lines for shape drawing
@@ -338,6 +350,12 @@ export default class WebGLRenderer extends Renderer {
 
 		this.gl.disable(this.gl.SCISSOR_TEST);
 		this._scissorActive = false;
+
+		// release post-process FBO (will be recreated on demand)
+		if (this.currentEffectFBO) {
+			this.currentEffectFBO.destroy();
+			this.currentEffectFBO = null;
+		}
 	}
 
 	/**
@@ -456,6 +474,109 @@ export default class WebGLRenderer extends Renderer {
 	 */
 	flush() {
 		this.currentBatcher.flush();
+	}
+
+	/**
+	 * Begin capturing rendering to an offscreen FBO for post-effect processing.
+	 * Returns true if post-effect processing is active (camera has a valid shader).
+	 * @param {Camera2d} camera - the camera requesting post-effect processing
+	 * @returns {boolean} true if FBO capture started, false if skipped
+	 * @ignore
+	 */
+	beginPostEffect(camera) {
+		if (!camera.shader || !camera.shader.enabled) {
+			return false;
+		}
+		const canvas = this.getCanvas();
+		if (!this.currentEffectFBO) {
+			this.currentEffectFBO = new WebGLRenderTarget(
+				this.gl,
+				canvas.width,
+				canvas.height,
+			);
+		} else {
+			this.currentEffectFBO.resize(canvas.width, canvas.height);
+		}
+		this.flush();
+		// save renderer state before modifying it for FBO rendering
+		this.save();
+		this.currentEffectFBO.bind();
+		this.gl.disable(this.gl.SCISSOR_TEST);
+		this._scissorActive = false;
+		this.setGlobalAlpha(1.0);
+		this.setBlendMode("normal");
+		this.clear();
+		return true;
+	}
+
+	/** @ignore */
+	endPostEffect(camera) {
+		if (!camera.shader || !camera.shader.enabled) {
+			return;
+		}
+		this.flush();
+		this.currentEffectFBO.unbind();
+		if (!camera.isDefault) {
+			this.clipRect(
+				camera.screenX,
+				camera.screenY,
+				camera.width,
+				camera.height,
+			);
+		}
+		this.blitEffect(
+			this.currentEffectFBO.texture,
+			0,
+			0,
+			this.width,
+			this.height,
+			camera.shader,
+		);
+		if (!camera.isDefault) {
+			this.gl.disable(this.gl.SCISSOR_TEST);
+			this._scissorActive = false;
+		}
+		// restore renderer state saved in beginPostEffect
+		this.restore();
+	}
+
+	/**
+	 * Blit a texture to the screen through a shader effect.
+	 * Draws a screen-aligned quad using the given texture as source
+	 * and the given shader for post-processing (e.g. scanlines, desaturation).
+	 * @param {WebGLTexture} source - the source texture to blit
+	 * @param {number} x - destination x position
+	 * @param {number} y - destination y position
+	 * @param {number} width - destination width
+	 * @param {number} height - destination height
+	 * @param {ShaderEffect} shader - the shader effect to apply
+	 */
+	blitEffect(source, x, y, width, height, shader) {
+		const gl = this.gl;
+
+		// flush any pending draws
+		this.flush();
+
+		const batcher = this.setBatcher("quad");
+
+		// set up a screen-space ortho projection for the blit quad
+		// (not the camera's world projection which includes scrolling)
+		_savedTransform.copy(this.currentTransform);
+		_savedProjection.copy(this.projectionMatrix);
+		this.currentTransform.identity();
+		this.projectionMatrix.ortho(0, width, height, 0, -1, 1);
+		batcher.setProjection(this.projectionMatrix);
+
+		// blit the FBO without alpha blending — the FBO already contains
+		// the fully composited scene (particles, additive blend, etc.)
+		gl.disable(gl.BLEND);
+		batcher.blitTexture(source, x, y, width, height, shader);
+		gl.enable(gl.BLEND);
+
+		// restore state
+		this.currentTransform.copy(_savedTransform);
+		this.projectionMatrix.copy(_savedProjection);
+		batcher.setProjection(this.projectionMatrix);
 	}
 
 	/**
@@ -973,8 +1094,9 @@ export default class WebGLRenderer extends Renderer {
 				this._scissorActive = false;
 			}
 		}
-		// sync gradient from renderState
+		// sync gradient and shader from renderState
 		this._currentGradient = this.renderState.currentGradient;
+		this.customShader = this.renderState.currentShader;
 	}
 
 	/**
@@ -991,6 +1113,7 @@ export default class WebGLRenderer extends Renderer {
 	 * renderer.restore();
 	 */
 	save() {
+		this.renderState.currentShader = this.customShader;
 		this.renderState.save(this._scissorActive === true);
 	}
 

--- a/packages/melonjs/src/video/webgl/webgl_renderer.js
+++ b/packages/melonjs/src/video/webgl/webgl_renderer.js
@@ -484,7 +484,7 @@ export default class WebGLRenderer extends Renderer {
 	 * @ignore
 	 */
 	beginPostEffect(camera) {
-		if (!camera.shader || !camera.shader.enabled) {
+		if (!camera.shader || camera.shader.enabled === false) {
 			return false;
 		}
 		const canvas = this.getCanvas();
@@ -511,7 +511,7 @@ export default class WebGLRenderer extends Renderer {
 
 	/** @ignore */
 	endPostEffect(camera) {
-		if (!camera.shader || !camera.shader.enabled) {
+		if (!camera.shader || camera.shader.enabled === false) {
 			return;
 		}
 		this.flush();

--- a/packages/melonjs/tests/renderstate.spec.js
+++ b/packages/melonjs/tests/renderstate.spec.js
@@ -119,6 +119,73 @@ describe("RenderState", () => {
 		expect(result.blendMode).toBe("additive");
 	});
 
+	// ---- Custom shader ----
+
+	it("should preserve currentShader across save/restore", () => {
+		const fakeShader = { name: "scanline" };
+		state.currentShader = fakeShader;
+
+		state.save();
+		state.currentShader = { name: "desaturate" };
+		state.restore(800, 600);
+
+		expect(state.currentShader).toBe(fakeShader);
+	});
+
+	it("should restore currentShader to undefined when it was unset", () => {
+		expect(state.currentShader).toBeUndefined();
+
+		state.save();
+		state.currentShader = { name: "scanline" };
+		state.restore(800, 600);
+
+		expect(state.currentShader).toBeUndefined();
+	});
+
+	it("should scope currentShader through nested save/restore", () => {
+		const shaderA = { name: "A" };
+		const shaderB = { name: "B" };
+
+		state.currentShader = shaderA;
+		state.save();
+
+		state.currentShader = shaderB;
+		state.save();
+
+		state.currentShader = undefined;
+
+		// restore depth 2 — should get shaderB back
+		state.restore(800, 600);
+		expect(state.currentShader).toBe(shaderB);
+
+		// restore depth 1 — should get shaderA back
+		state.restore(800, 600);
+		expect(state.currentShader).toBe(shaderA);
+	});
+
+	it("should not leak currentShader when child has no shader", () => {
+		const cameraShader = { name: "camera-effect" };
+
+		// simulate camera preDraw: save + set shader
+		state.save();
+		state.currentShader = cameraShader;
+
+		// simulate child preDraw: save + set undefined (no shader)
+		state.save();
+		state.currentShader = undefined;
+
+		// child rendering should see no custom shader
+		expect(state.currentShader).toBeUndefined();
+
+		// simulate child postDraw: restore
+		state.restore(800, 600);
+		expect(state.currentShader).toBe(cameraShader);
+
+		// simulate camera postDraw: restore
+		state.restore(800, 600);
+		expect(state.currentShader).toBeUndefined();
+	});
+
 	// ---- Scissor ----
 
 	it("should preserve scissor when active", () => {
@@ -331,6 +398,8 @@ describe("RenderState", () => {
 		state.currentColor.parseCSS("rgba(10, 20, 30, 0.5)");
 		state.currentTint.parseCSS("rgb(128, 64, 32)");
 		state.currentBlendMode = "additive";
+		const shaderBefore = { name: "test-shader" };
+		state.currentShader = shaderBefore;
 
 		const colorBefore = state.currentColor.toArray().slice();
 		const tintBefore = state.currentTint.toArray().slice();
@@ -345,11 +414,13 @@ describe("RenderState", () => {
 		state.currentColor.parseCSS("rgba(200, 100, 50, 1.0)");
 		state.currentTint.parseCSS("white");
 		state.currentBlendMode = "multiply";
+		state.currentShader = { name: "different-shader" };
 
 		const result = state.restore(800, 600);
 
 		// verify ALL properties restored
 		expect(result.blendMode).toBe("additive");
+		expect(state.currentShader).toBe(shaderBefore);
 
 		const colorAfter = state.currentColor.toArray();
 		for (let i = 0; i < 4; i++) {


### PR DESCRIPTION
## Summary

Closes #1367

- **Camera post-processing**: assign a `ShaderEffect` to any camera's `shader` property to apply full-screen post-effects (vignette, scanlines, desaturation, etc.). Works with multiple cameras independently (e.g. main camera + minimap with different effects)
- **WebGLRenderTarget**: new FBO wrapper class with bind/unbind/resize/destroy/clear, plus getImageData/toBlob/toImageBitmap/toDataURL (API aligned with CanvasRenderTarget)
- **Renderer methods**: `beginPostEffect(camera)`, `endPostEffect(camera)`, `blitEffect(source, x, y, w, h, shader)` — no-op on Canvas renderer
- **QuadBatcher.blitTexture()**: screen-aligned quad rendering through a shader effect
- **VignetteEffect**: new built-in shader effect for edge darkening
- **RenderState**: `currentShader` added to save/restore stack, fixing shader leak between parent cameras and child renderables
- **Renderable**: preDraw/postDraw shader scoping simplified — always sets `renderer.customShader = this.shader`, relies on save/restore
- **Examples**: platformer uses VignetteEffect on both main camera and minimap
- Version bumped to 19.2.0

## Test plan

- [x] RenderState unit tests pass (21 tests, including 4 new tests for shader save/restore)
- [ ] Platformer example: vignette on main camera + minimap, particles render correctly, no shader leaking
- [ ] Multi-camera: each camera renders with its own independent effect
- [ ] No visual regression when no shader is assigned (zero overhead path)
- [ ] Context loss/restore: FBO is recreated on demand after context restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)