### PR TITLE
Add ColorMatrix class and ColorMatrixEffect shader effect

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -14,10 +14,14 @@
 - Camera: `MaskEffect` — shape-based mask transition effect using Ellipse or Polygon. Supports `direction: "hide"` (shape shrinks) and `direction: "reveal"` (shape expands) with configurable color and duration. Uses inverted clip masking on both Canvas (evenodd) and WebGL (stencil).
 - Trigger: `transition` setting — accepts `"fade"` (default, backward compatible) or `"mask"` for shape-based level transitions. When `"mask"` is used, a `shape` setting (Ellipse or Polygon) defines the mask geometry.
 - Trigger: `color` setting replaces legacy `fade` property (backward compatible — `fade` still works as fallback)
+- Math: `ColorMatrix` class extending `Matrix3d` — chainable color adjustment methods (`brightness`, `contrast`, `saturate`, `hueRotate`, `sepia`, `invertColors`) using zero-allocation `transform()` on the parent matrix
+- Math: `Matrix3d.transform()` — accepts either 16 values (full 4x4) or 6 values (2D affine, promoted to 4x4). Mirrors the `Matrix2d.transform()` API.
+- WebGL: `ColorMatrixEffect` shader effect — applies a `ColorMatrix` to any renderable or camera. Exposes chainable color methods (`brightness`, `contrast`, `saturate`, `hueRotate`, `sepia`, `invertColors`, `reset`) that auto-push the GPU uniform.
 
 ### Changed
 - Camera: `shake()`, `fadeIn()`, `fadeOut()` are now convenience wrappers that create `ShakeEffect`/`FadeEffect` instances — same signatures, fully backward compatible
 - Trigger: internally uses `FadeEffect`/`MaskEffect` instead of `viewport.fadeIn()`/`viewport.fadeOut()`, with both hide and reveal effects
+- WebGL: `SepiaEffect`, `InvertEffect`, `DesaturateEffect` now extend `ColorMatrixEffect` — share a single color matrix shader instead of individual GLSL shaders
 
 ### Fixed
 - Canvas: `setMask(shape, true)` now uses `evenodd` clipping for proper inverted mask support (was using `destination-atop` composite which didn't clip subsequent draws)

--- a/packages/melonjs/src/index.ts
+++ b/packages/melonjs/src/index.ts
@@ -19,6 +19,7 @@ import TMXTileMap from "./level/tiled/TMXTileMap.js";
 import TMXTileset from "./level/tiled/TMXTileset.js";
 import TMXTilesetGroup from "./level/tiled/TMXTilesetGroup.js";
 import * as TMXUtils from "./level/tiled/TMXUtils.js";
+import { ColorMatrix } from "./math/color_matrix.ts";
 import ParticleEmitter from "./particles/emitter.ts";
 import Particle from "./particles/particle.ts";
 import ParticleEmitterSettings from "./particles/settings.js";
@@ -67,6 +68,7 @@ import PrimitiveBatcher from "./video/webgl/batchers/primitive_batcher.js";
 import QuadBatcher from "./video/webgl/batchers/quad_batcher.js";
 import BlurEffect from "./video/webgl/effects/blur.js";
 import ChromaticAberrationEffect from "./video/webgl/effects/chromaticAberration.js";
+import ColorMatrixEffect from "./video/webgl/effects/colorMatrix.js";
 import DesaturateEffect from "./video/webgl/effects/desaturate.js";
 import DissolveEffect from "./video/webgl/effects/dissolve.js";
 import DropShadowEffect from "./video/webgl/effects/dropShadow.js";
@@ -140,6 +142,8 @@ export {
 	ChromaticAberrationEffect,
 	Collectable,
 	ColorLayer,
+	ColorMatrix,
+	ColorMatrixEffect,
 	Container,
 	DesaturateEffect,
 	DissolveEffect,

--- a/packages/melonjs/src/math/color_matrix.ts
+++ b/packages/melonjs/src/math/color_matrix.ts
@@ -1,0 +1,202 @@
+import { Matrix3d } from "./matrix3d.ts";
+
+/**
+ * A 4x4 color transformation matrix extending {@link Matrix3d}.
+ * Provides chainable methods for common color adjustments.
+ * @category Math
+ * @example
+ * // grayscale
+ * const cm = new ColorMatrix().saturate(0.0);
+ * @example
+ * // combine brightness + contrast
+ * const cm = new ColorMatrix().brightness(1.3).contrast(1.5);
+ */
+export class ColorMatrix extends Matrix3d {
+	/**
+	 * Apply a brightness adjustment.
+	 * @param amount - brightness multiplier (1.0 = normal, >1 brighter, <1 darker)
+	 * @returns this instance for chaining
+	 */
+	brightness(amount: number): this {
+		return this.transform(
+			amount,
+			0,
+			0,
+			0,
+			0,
+			amount,
+			0,
+			0,
+			0,
+			0,
+			amount,
+			0,
+			0,
+			0,
+			0,
+			1,
+		);
+	}
+
+	/**
+	 * Apply a contrast adjustment.
+	 * @param amount - contrast multiplier (1.0 = normal, >1 more contrast, <1 less)
+	 * @returns this instance for chaining
+	 */
+	contrast(amount: number): this {
+		const o = (1 - amount) / 2;
+		return this.transform(
+			amount,
+			0,
+			0,
+			0,
+			0,
+			amount,
+			0,
+			0,
+			0,
+			0,
+			amount,
+			0,
+			o,
+			o,
+			o,
+			1,
+		);
+	}
+
+	/**
+	 * Apply a saturation adjustment.
+	 * @param amount - saturation level (0.0 = grayscale, 1.0 = normal, >1 over-saturated)
+	 * @returns this instance for chaining
+	 */
+	saturate(amount: number): this {
+		const ir = 0.299 * (1 - amount);
+		const ig = 0.587 * (1 - amount);
+		const ib = 0.114 * (1 - amount);
+		return this.transform(
+			ir + amount,
+			ir,
+			ir,
+			0,
+			ig,
+			ig + amount,
+			ig,
+			0,
+			ib,
+			ib,
+			ib + amount,
+			0,
+			0,
+			0,
+			0,
+			1,
+		);
+	}
+
+	/**
+	 * Apply a hue rotation.
+	 * @param angle - rotation angle in radians
+	 * @returns this instance for chaining
+	 */
+	hueRotate(angle: number): this {
+		const cos = Math.cos(angle);
+		const sin = Math.sin(angle);
+		const lumR = 0.299;
+		const lumG = 0.587;
+		const lumB = 0.114;
+		return this.transform(
+			lumR + cos * (1 - lumR) + sin * -lumR,
+			lumR + cos * -lumR + sin * 0.143,
+			lumR + cos * -lumR + sin * -(1 - lumR),
+			0,
+			lumG + cos * -lumG + sin * -lumG,
+			lumG + cos * (1 - lumG) + sin * 0.14,
+			lumG + cos * -lumG + sin * lumG,
+			0,
+			lumB + cos * -lumB + sin * (1 - lumB),
+			lumB + cos * -lumB + sin * -0.283,
+			lumB + cos * (1 - lumB) + sin * lumB,
+			0,
+			0,
+			0,
+			0,
+			1,
+		);
+	}
+
+	/**
+	 * Apply a sepia tone.
+	 * @param amount - sepia intensity (0.0 = original, 1.0 = full sepia)
+	 * @returns this instance for chaining
+	 */
+	sepia(amount: number = 1.0): this {
+		if (amount >= 1.0) {
+			return this.transform(
+				0.393,
+				0.349,
+				0.272,
+				0,
+				0.769,
+				0.686,
+				0.534,
+				0,
+				0.189,
+				0.168,
+				0.131,
+				0,
+				0,
+				0,
+				0,
+				1,
+			);
+		}
+		const a = amount;
+		const b = 1 - a;
+		return this.transform(
+			b + 0.393 * a,
+			0.349 * a,
+			0.272 * a,
+			0,
+			0.769 * a,
+			b + 0.686 * a,
+			0.534 * a,
+			0,
+			0.189 * a,
+			0.168 * a,
+			b + 0.131 * a,
+			0,
+			0,
+			0,
+			0,
+			1,
+		);
+	}
+
+	/**
+	 * Apply a color inversion.
+	 * @param amount - inversion amount (0.0 = original, 1.0 = fully inverted)
+	 * @returns this instance for chaining
+	 */
+	invertColors(amount: number = 1.0): this {
+		const c = 1 - 2 * amount;
+		return this.transform(
+			c,
+			0,
+			0,
+			0,
+			0,
+			c,
+			0,
+			0,
+			0,
+			0,
+			c,
+			0,
+			amount,
+			amount,
+			amount,
+			1,
+		);
+	}
+}

--- a/packages/melonjs/src/math/matrix2d.ts
+++ b/packages/melonjs/src/math/matrix2d.ts
@@ -109,12 +109,12 @@ export class Matrix2d {
 
 	/**
 	 * Multiplies the current transformation with the matrix described by the arguments of this method.
-	 * @param a a component
-	 * @param b b component
-	 * @param c c component
-	 * @param d d component
-	 * @param e e component
-	 * @param f f component
+	 * @param a - a component (scale x / cos)
+	 * @param b - b component (skew y / sin)
+	 * @param c - c component (skew x / -sin)
+	 * @param d - d component (scale y / cos)
+	 * @param e - e component (translate x)
+	 * @param f - f component (translate y)
 	 * @returns Reference to this object for method chaining
 	 */
 	transform(a: number, b: number, c: number, d: number, e: number, f: number) {

--- a/packages/melonjs/src/math/matrix3d.ts
+++ b/packages/melonjs/src/math/matrix3d.ts
@@ -252,12 +252,7 @@ export class Matrix3d {
 	}
 
 	/**
-	 * Multiplies the current transformation with the matrix described by the arguments of this method.
-	 * Accepts either 16 values (full 4x4) or 6 values (2D affine: a, b, c, d, tx, ty — promoted to 4x4).
-	 * @returns Reference to this object for method chaining
-	 */
-	/**
-	 * Multiplies the current transformation with a 2D affine matrix.
+	 * Multiplies the current transformation with a 2D affine matrix (a, b, c, d, e, f).
 	 * The 2D matrix is promoted to 4x4 internally.
 	 * @param a - a component (scale x / cos)
 	 * @param b - b component (skew y / sin)
@@ -316,11 +311,15 @@ export class Matrix3d {
 		b33?: number,
 	) {
 		// resolve all 16 components (promote 2D affine if only 6 args)
+		const argc = arguments.length;
+		if (argc !== 6 && argc !== 16) {
+			throw new Error(`transform() requires 6 or 16 arguments, got ${argc}`);
+		}
 		let c0: number, c1: number, c2: number, c3: number;
 		let c4: number, c5: number, c6: number, c7: number;
 		let c8: number, c9: number, c10: number, c11: number;
 		let c12: number, c13: number, c14: number, c15: number;
-		if (arguments.length === 6) {
+		if (argc === 6) {
 			// 2D affine (a, b, c, d, tx, ty) → 4x4
 			c0 = b00;
 			c1 = b01;

--- a/packages/melonjs/src/math/matrix3d.ts
+++ b/packages/melonjs/src/math/matrix3d.ts
@@ -252,6 +252,152 @@ export class Matrix3d {
 	}
 
 	/**
+	 * Multiplies the current transformation with the matrix described by the arguments of this method.
+	 * Accepts either 16 values (full 4x4) or 6 values (2D affine: a, b, c, d, tx, ty — promoted to 4x4).
+	 * @returns Reference to this object for method chaining
+	 */
+	/**
+	 * Multiplies the current transformation with a 2D affine matrix.
+	 * The 2D matrix is promoted to 4x4 internally.
+	 * @param a - a component (scale x / cos)
+	 * @param b - b component (skew y / sin)
+	 * @param c - c component (skew x / -sin)
+	 * @param d - d component (scale y / cos)
+	 * @param e - e component (translate x)
+	 * @param f - f component (translate y)
+	 * @returns Reference to this object for method chaining
+	 */
+	transform(
+		a: number,
+		b: number,
+		c: number,
+		d: number,
+		e: number,
+		f: number,
+	): this;
+	/**
+	 * Multiplies the current transformation with a full 4x4 matrix specified as 16 individual values (column-major).
+	 * @returns Reference to this object for method chaining
+	 */
+	transform(
+		b00: number,
+		b01: number,
+		b02: number,
+		b03: number,
+		b10: number,
+		b11: number,
+		b12: number,
+		b13: number,
+		b20: number,
+		b21: number,
+		b22: number,
+		b23: number,
+		b30: number,
+		b31: number,
+		b32: number,
+		b33: number,
+	): this;
+	transform(
+		b00: number,
+		b01: number,
+		b02: number,
+		b03: number,
+		b10: number,
+		b11: number,
+		b12?: number,
+		b13?: number,
+		b20?: number,
+		b21?: number,
+		b22?: number,
+		b23?: number,
+		b30?: number,
+		b31?: number,
+		b32?: number,
+		b33?: number,
+	) {
+		// resolve all 16 components (promote 2D affine if only 6 args)
+		let c0: number, c1: number, c2: number, c3: number;
+		let c4: number, c5: number, c6: number, c7: number;
+		let c8: number, c9: number, c10: number, c11: number;
+		let c12: number, c13: number, c14: number, c15: number;
+		if (arguments.length === 6) {
+			// 2D affine (a, b, c, d, tx, ty) → 4x4
+			c0 = b00;
+			c1 = b01;
+			c2 = 0;
+			c3 = 0;
+			c4 = b02;
+			c5 = b03;
+			c6 = 0;
+			c7 = 0;
+			c8 = 0;
+			c9 = 0;
+			c10 = 1;
+			c11 = 0;
+			c12 = b10;
+			c13 = b11;
+			c14 = 0;
+			c15 = 1;
+		} else {
+			c0 = b00;
+			c1 = b01;
+			c2 = b02;
+			c3 = b03;
+			c4 = b10;
+			c5 = b11;
+			c6 = b12!;
+			c7 = b13!;
+			c8 = b20!;
+			c9 = b21!;
+			c10 = b22!;
+			c11 = b23!;
+			c12 = b30!;
+			c13 = b31!;
+			c14 = b32!;
+			c15 = b33!;
+		}
+		const a = this.val;
+		const a00 = a[0],
+			a01 = a[1],
+			a02 = a[2],
+			a03 = a[3];
+		const a10 = a[4],
+			a11 = a[5],
+			a12 = a[6],
+			a13 = a[7];
+		const a20 = a[8],
+			a21 = a[9],
+			a22 = a[10],
+			a23 = a[11];
+		const a30 = a[12],
+			a31 = a[13],
+			a32 = a[14],
+			a33 = a[15];
+
+		a[0] = c0 * a00 + c1 * a10 + c2 * a20 + c3 * a30;
+		a[1] = c0 * a01 + c1 * a11 + c2 * a21 + c3 * a31;
+		a[2] = c0 * a02 + c1 * a12 + c2 * a22 + c3 * a32;
+		a[3] = c0 * a03 + c1 * a13 + c2 * a23 + c3 * a33;
+
+		a[4] = c4 * a00 + c5 * a10 + c6 * a20 + c7 * a30;
+		a[5] = c4 * a01 + c5 * a11 + c6 * a21 + c7 * a31;
+		a[6] = c4 * a02 + c5 * a12 + c6 * a22 + c7 * a32;
+		a[7] = c4 * a03 + c5 * a13 + c6 * a23 + c7 * a33;
+
+		a[8] = c8 * a00 + c9 * a10 + c10 * a20 + c11 * a30;
+		a[9] = c8 * a01 + c9 * a11 + c10 * a21 + c11 * a31;
+		a[10] = c8 * a02 + c9 * a12 + c10 * a22 + c11 * a32;
+		a[11] = c8 * a03 + c9 * a13 + c10 * a23 + c11 * a33;
+
+		a[12] = c12 * a00 + c13 * a10 + c14 * a20 + c15 * a30;
+		a[13] = c12 * a01 + c13 * a11 + c14 * a21 + c15 * a31;
+		a[14] = c12 * a02 + c13 * a12 + c14 * a22 + c15 * a32;
+		a[15] = c12 * a03 + c13 * a13 + c14 * a23 + c15 * a33;
+
+		return this;
+	}
+
+	/**
 	 * Transpose the value of this matrix.
 	 * @returns Reference to this object for method chaining
 	 */

--- a/packages/melonjs/src/video/webgl/effects/colorMatrix.js
+++ b/packages/melonjs/src/video/webgl/effects/colorMatrix.js
@@ -138,22 +138,8 @@ export default class ColorMatrixEffect extends ShaderEffect {
 
 	/**
 	 * Multiplies the current matrix with a transform described by individual values.
-	 * @param {number} a - value
-	 * @param {number} b - value
-	 * @param {number} c - value
-	 * @param {number} d - value
-	 * @param {number} e - value
-	 * @param {number} f - value
-	 * @param {number} [g] - value
-	 * @param {number} [h] - value
-	 * @param {number} [i] - value
-	 * @param {number} [j] - value
-	 * @param {number} [k] - value
-	 * @param {number} [l] - value
-	 * @param {number} [m] - value
-	 * @param {number} [n] - value
-	 * @param {number} [o] - value
-	 * @param {number} [p] - value
+	 * Accepts either 6 values (2D affine: a, b, c, d, e, f) or 16 values (full 4x4 column-major).
+	 * @param {...number} args - 6 or 16 numeric values
 	 * @returns {this} this instance for chaining
 	 */
 	transform(...args) {

--- a/packages/melonjs/src/video/webgl/effects/colorMatrix.js
+++ b/packages/melonjs/src/video/webgl/effects/colorMatrix.js
@@ -1,0 +1,164 @@
+import { ColorMatrix } from "../../../math/color_matrix.ts";
+import ShaderEffect from "../shadereffect.js";
+
+/**
+ * A shader effect that applies a 4x4 color transformation matrix.
+ * Provides chainable color adjustment methods that automatically update the GPU uniform.
+ * @category Effects
+ * @see {@link Renderable.shader} for usage
+ * @example
+ * // desaturate a sprite
+ * mySprite.shader = new ColorMatrixEffect(renderer).saturate(0.0);
+ * @example
+ * // combine brightness + contrast on a camera
+ * camera.shader = new ColorMatrixEffect(renderer).brightness(1.3).contrast(1.5);
+ * @example
+ * // update dynamically
+ * effect.reset().brightness(1.5).saturate(0.5);
+ */
+export default class ColorMatrixEffect extends ShaderEffect {
+	/**
+	 * @param {import("../webgl_renderer.js").default} renderer - the current renderer instance
+	 * @param {object} [options] - effect options
+	 * @param {ColorMatrix} [options.matrix] - an initial color matrix. Defaults to identity.
+	 */
+	constructor(renderer, options = {}) {
+		super(
+			renderer,
+			`
+			uniform mat4 uColorMatrix;
+			vec4 apply(vec4 color, vec2 uv) {
+				return uColorMatrix * color;
+			}
+			`,
+		);
+
+		/**
+		 * the internal color matrix
+		 * @ignore
+		 */
+		this._matrix = options.matrix || new ColorMatrix();
+		this._syncUniform();
+	}
+
+	/**
+	 * Push the current matrix values to the GPU.
+	 * @ignore
+	 */
+	_syncUniform() {
+		this.setUniform("uColorMatrix", this._matrix.val);
+	}
+
+	/**
+	 * Reset the color matrix to identity (no color change).
+	 * @returns {this} this instance for chaining
+	 */
+	reset() {
+		this._matrix.identity();
+		this._syncUniform();
+		return this;
+	}
+
+	/**
+	 * Apply a brightness adjustment.
+	 * @param {number} amount - brightness multiplier (1.0 = normal, >1 brighter, <1 darker)
+	 * @returns {this} this instance for chaining
+	 */
+	brightness(amount) {
+		this._matrix.brightness(amount);
+		this._syncUniform();
+		return this;
+	}
+
+	/**
+	 * Apply a contrast adjustment.
+	 * @param {number} amount - contrast multiplier (1.0 = normal, >1 more contrast, <1 less)
+	 * @returns {this} this instance for chaining
+	 */
+	contrast(amount) {
+		this._matrix.contrast(amount);
+		this._syncUniform();
+		return this;
+	}
+
+	/**
+	 * Apply a saturation adjustment.
+	 * @param {number} amount - saturation level (0.0 = grayscale, 1.0 = normal, >1 over-saturated)
+	 * @returns {this} this instance for chaining
+	 */
+	saturate(amount) {
+		this._matrix.saturate(amount);
+		this._syncUniform();
+		return this;
+	}
+
+	/**
+	 * Apply a hue rotation.
+	 * @param {number} angle - rotation angle in radians
+	 * @returns {this} this instance for chaining
+	 */
+	hueRotate(angle) {
+		this._matrix.hueRotate(angle);
+		this._syncUniform();
+		return this;
+	}
+
+	/**
+	 * Apply a sepia tone.
+	 * @param {number} [amount=1.0] - sepia intensity (0.0 = original, 1.0 = full sepia)
+	 * @returns {this} this instance for chaining
+	 */
+	sepia(amount = 1.0) {
+		this._matrix.sepia(amount);
+		this._syncUniform();
+		return this;
+	}
+
+	/**
+	 * Apply a color inversion.
+	 * @param {number} [amount=1.0] - inversion amount (0.0 = original, 1.0 = fully inverted)
+	 * @returns {this} this instance for chaining
+	 */
+	invertColors(amount = 1.0) {
+		this._matrix.invertColors(amount);
+		this._syncUniform();
+		return this;
+	}
+
+	/**
+	 * Multiply the current matrix by another color matrix.
+	 * @param {ColorMatrix} matrix - the matrix to multiply with
+	 * @returns {this} this instance for chaining
+	 */
+	multiply(matrix) {
+		this._matrix.multiply(matrix);
+		this._syncUniform();
+		return this;
+	}
+
+	/**
+	 * Multiplies the current matrix with a transform described by individual values.
+	 * @param {number} a - value
+	 * @param {number} b - value
+	 * @param {number} c - value
+	 * @param {number} d - value
+	 * @param {number} e - value
+	 * @param {number} f - value
+	 * @param {number} [g] - value
+	 * @param {number} [h] - value
+	 * @param {number} [i] - value
+	 * @param {number} [j] - value
+	 * @param {number} [k] - value
+	 * @param {number} [l] - value
+	 * @param {number} [m] - value
+	 * @param {number} [n] - value
+	 * @param {number} [o] - value
+	 * @param {number} [p] - value
+	 * @returns {this} this instance for chaining
+	 */
+	transform(...args) {
+		this._matrix.transform(...args);
+		this._syncUniform();
+		return this;
+	}
+}

--- a/packages/melonjs/src/video/webgl/effects/desaturate.js
+++ b/packages/melonjs/src/video/webgl/effects/desaturate.js
@@ -1,9 +1,7 @@
-import ShaderEffect from "../shadereffect.js";
+import ColorMatrixEffect from "./colorMatrix.js";
 
 /**
  * A shader effect that desaturates (grayscales) the sprite.
- * The `intensity` uniform controls how much color is removed
- * (0.0 = full color, 1.0 = fully grayscale).
  * Commonly used for disabled states, death effects, or petrification.
  * @category Effects
  * @see {@link Renderable.shader} for usage
@@ -14,27 +12,17 @@ import ShaderEffect from "../shadereffect.js";
  * // partial desaturation (50%)
  * mySprite.shader = new DesaturateEffect(renderer, { intensity: 0.5 });
  */
-export default class DesaturateEffect extends ShaderEffect {
+export default class DesaturateEffect extends ColorMatrixEffect {
 	/**
 	 * @param {import("../webgl_renderer.js").default} renderer - the current renderer instance
 	 * @param {object} [options] - effect options
 	 * @param {number} [options.intensity=1.0] - desaturation intensity (0.0 = full color, 1.0 = grayscale)
 	 */
 	constructor(renderer, options = {}) {
-		super(
-			renderer,
-			`
-			uniform float uDesatIntensity;
-			vec4 apply(vec4 color, vec2 uv) {
-				float gray = dot(color.rgb, vec3(0.299, 0.587, 0.114));
-				return vec4(mix(color.rgb, vec3(gray), uDesatIntensity), color.a);
-			}
-			`,
-		);
-
+		super(renderer);
 		this.intensity =
 			typeof options.intensity === "number" ? options.intensity : 1.0;
-		this.setUniform("uDesatIntensity", this.intensity);
+		this.saturate(1 - this.intensity);
 	}
 
 	/**
@@ -43,6 +31,6 @@ export default class DesaturateEffect extends ShaderEffect {
 	 */
 	setIntensity(value) {
 		this.intensity = Math.max(0, Math.min(1, value));
-		this.setUniform("uDesatIntensity", this.intensity);
+		this.reset().saturate(1 - this.intensity);
 	}
 }

--- a/packages/melonjs/src/video/webgl/effects/invert.js
+++ b/packages/melonjs/src/video/webgl/effects/invert.js
@@ -1,4 +1,4 @@
-import ShaderEffect from "../shadereffect.js";
+import ColorMatrixEffect from "./colorMatrix.js";
 
 /**
  * A shader effect that inverts the colors of the sprite.
@@ -11,27 +11,17 @@ import ShaderEffect from "../shadereffect.js";
  * // partial inversion
  * mySprite.shader = new InvertEffect(renderer, { intensity: 0.5 });
  */
-export default class InvertEffect extends ShaderEffect {
+export default class InvertEffect extends ColorMatrixEffect {
 	/**
 	 * @param {import("../webgl_renderer.js").default} renderer - the current renderer instance
 	 * @param {object} [options] - effect options
 	 * @param {number} [options.intensity=1.0] - inversion intensity (0.0 = original, 1.0 = fully inverted)
 	 */
 	constructor(renderer, options = {}) {
-		super(
-			renderer,
-			`
-			uniform float uInvertIntensity;
-			vec4 apply(vec4 color, vec2 uv) {
-				vec3 inverted = vec3(color.a) - color.rgb;
-				return vec4(mix(color.rgb, inverted, uInvertIntensity), color.a);
-			}
-			`,
-		);
-
+		super(renderer);
 		this.intensity =
 			typeof options.intensity === "number" ? options.intensity : 1.0;
-		this.setUniform("uInvertIntensity", this.intensity);
+		this.invertColors(this.intensity);
 	}
 
 	/**
@@ -40,6 +30,6 @@ export default class InvertEffect extends ShaderEffect {
 	 */
 	setIntensity(value) {
 		this.intensity = Math.max(0, Math.min(1, value));
-		this.setUniform("uInvertIntensity", this.intensity);
+		this.reset().invertColors(this.intensity);
 	}
 }

--- a/packages/melonjs/src/video/webgl/effects/sepia.js
+++ b/packages/melonjs/src/video/webgl/effects/sepia.js
@@ -1,4 +1,4 @@
-import ShaderEffect from "../shadereffect.js";
+import ColorMatrixEffect from "./colorMatrix.js";
 
 /**
  * A shader effect that applies a warm sepia (vintage photo) tone to the sprite.
@@ -10,30 +10,17 @@ import ShaderEffect from "../shadereffect.js";
  * // partial sepia
  * mySprite.shader = new SepiaEffect(renderer, { intensity: 0.5 });
  */
-export default class SepiaEffect extends ShaderEffect {
+export default class SepiaEffect extends ColorMatrixEffect {
 	/**
 	 * @param {import("../webgl_renderer.js").default} renderer - the current renderer instance
 	 * @param {object} [options] - effect options
 	 * @param {number} [options.intensity=1.0] - sepia intensity (0.0 = original, 1.0 = full sepia)
 	 */
 	constructor(renderer, options = {}) {
-		super(
-			renderer,
-			`
-			uniform float uSepiaIntensity;
-			vec4 apply(vec4 color, vec2 uv) {
-				vec3 sepia;
-				sepia.r = dot(color.rgb, vec3(0.393, 0.769, 0.189));
-				sepia.g = dot(color.rgb, vec3(0.349, 0.686, 0.168));
-				sepia.b = dot(color.rgb, vec3(0.272, 0.534, 0.131));
-				return vec4(mix(color.rgb, sepia, uSepiaIntensity), color.a);
-			}
-			`,
-		);
-
+		super(renderer);
 		this.intensity =
 			typeof options.intensity === "number" ? options.intensity : 1.0;
-		this.setUniform("uSepiaIntensity", this.intensity);
+		this.sepia(this.intensity);
 	}
 
 	/**
@@ -42,6 +29,6 @@ export default class SepiaEffect extends ShaderEffect {
 	 */
 	setIntensity(value) {
 		this.intensity = Math.max(0, Math.min(1, value));
-		this.setUniform("uSepiaIntensity", this.intensity);
+		this.reset().sepia(this.intensity);
 	}
 }

--- a/packages/melonjs/tests/colorMatrix.spec.ts
+++ b/packages/melonjs/tests/colorMatrix.spec.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { ColorMatrix } from "../src/math/color_matrix.ts";
+import { Matrix3d } from "../src/math/matrix3d.ts";
+
+describe("ColorMatrix", () => {
+	describe("constructor", () => {
+		it("should create an identity matrix by default", () => {
+			const cm = new ColorMatrix();
+			expect(cm.isIdentity()).toEqual(true);
+		});
+
+		it("should extend Matrix3d", () => {
+			const cm = new ColorMatrix();
+			expect(cm).toBeInstanceOf(Matrix3d);
+		});
+	});
+
+	describe("brightness", () => {
+		it("should not change colors at 1.0", () => {
+			const cm = new ColorMatrix().brightness(1.0);
+			expect(cm.isIdentity()).toEqual(true);
+		});
+
+		it("should scale RGB channels", () => {
+			const cm = new ColorMatrix().brightness(2.0);
+			const v = cm.val;
+			expect(v[0]).toBeCloseTo(2.0);
+			expect(v[5]).toBeCloseTo(2.0);
+			expect(v[10]).toBeCloseTo(2.0);
+			expect(v[15]).toBeCloseTo(1.0); // alpha unchanged
+		});
+
+		it("should darken at values below 1", () => {
+			const cm = new ColorMatrix().brightness(0.5);
+			expect(cm.val[0]).toBeCloseTo(0.5);
+			expect(cm.val[5]).toBeCloseTo(0.5);
+			expect(cm.val[10]).toBeCloseTo(0.5);
+		});
+	});
+
+	describe("contrast", () => {
+		it("should not change colors at 1.0", () => {
+			const cm = new ColorMatrix().contrast(1.0);
+			expect(cm.isIdentity()).toEqual(true);
+		});
+
+		it("should increase contrast above 1.0", () => {
+			const cm = new ColorMatrix().contrast(2.0);
+			expect(cm.val[0]).toBeCloseTo(2.0);
+			expect(cm.val[5]).toBeCloseTo(2.0);
+			expect(cm.val[10]).toBeCloseTo(2.0);
+			// offset should be (1 - 2) / 2 = -0.5
+			expect(cm.val[12]).toBeCloseTo(-0.5);
+			expect(cm.val[13]).toBeCloseTo(-0.5);
+			expect(cm.val[14]).toBeCloseTo(-0.5);
+		});
+
+		it("should reduce contrast below 1.0", () => {
+			const cm = new ColorMatrix().contrast(0.0);
+			// all channels should map to 0.5 (gray)
+			expect(cm.val[0]).toBeCloseTo(0.0);
+			expect(cm.val[12]).toBeCloseTo(0.5);
+		});
+	});
+
+	describe("saturate", () => {
+		it("should not change colors at 1.0", () => {
+			const cm = new ColorMatrix().saturate(1.0);
+			expect(cm.isIdentity()).toEqual(true);
+		});
+
+		it("should produce grayscale at 0.0", () => {
+			const cm = new ColorMatrix().saturate(0.0);
+			const v = cm.val;
+			// each row should sum to ~1.0 (luminance coefficients)
+			expect(v[0] + v[4] + v[8]).toBeCloseTo(1.0);
+			expect(v[1] + v[5] + v[9]).toBeCloseTo(1.0);
+			expect(v[2] + v[6] + v[10]).toBeCloseTo(1.0);
+			// R channel should use standard luminance weights
+			expect(v[0]).toBeCloseTo(0.299);
+			expect(v[4]).toBeCloseTo(0.587);
+			expect(v[8]).toBeCloseTo(0.114);
+		});
+	});
+
+	describe("hueRotate", () => {
+		it("should not change colors at 0 radians", () => {
+			const cm = new ColorMatrix().hueRotate(0);
+			expect(cm.isIdentity()).toEqual(true);
+		});
+
+		it("should produce a different matrix for non-zero rotation", () => {
+			const cm = new ColorMatrix().hueRotate(Math.PI / 2);
+			expect(cm.isIdentity()).toEqual(false);
+		});
+
+		it("should return to identity after full 2π rotation", () => {
+			const cm = new ColorMatrix().hueRotate(Math.PI * 2);
+			// should be very close to identity
+			const id = new Matrix3d();
+			for (let i = 0; i < 16; i++) {
+				expect(cm.val[i]).toBeCloseTo(id.val[i], 3);
+			}
+		});
+	});
+
+	describe("sepia", () => {
+		it("should apply full sepia at 1.0", () => {
+			const cm = new ColorMatrix().sepia(1.0);
+			expect(cm.val[0]).toBeCloseTo(0.393);
+			expect(cm.val[1]).toBeCloseTo(0.349);
+			expect(cm.val[2]).toBeCloseTo(0.272);
+		});
+
+		it("should not change at 0.0", () => {
+			const cm = new ColorMatrix().sepia(0.0);
+			expect(cm.isIdentity()).toEqual(true);
+		});
+
+		it("should interpolate at 0.5", () => {
+			const cm = new ColorMatrix().sepia(0.5);
+			// should be between identity and full sepia
+			expect(cm.val[0]).toBeGreaterThan(0.393);
+			expect(cm.val[0]).toBeLessThan(1.0);
+		});
+	});
+
+	describe("invertColors", () => {
+		it("should fully invert at 1.0", () => {
+			const cm = new ColorMatrix().invertColors(1.0);
+			expect(cm.val[0]).toBeCloseTo(-1.0);
+			expect(cm.val[5]).toBeCloseTo(-1.0);
+			expect(cm.val[10]).toBeCloseTo(-1.0);
+			expect(cm.val[12]).toBeCloseTo(1.0);
+			expect(cm.val[13]).toBeCloseTo(1.0);
+			expect(cm.val[14]).toBeCloseTo(1.0);
+		});
+
+		it("should not change at 0.0", () => {
+			const cm = new ColorMatrix().invertColors(0.0);
+			expect(cm.isIdentity()).toEqual(true);
+		});
+
+		it("should half-invert at 0.5", () => {
+			const cm = new ColorMatrix().invertColors(0.5);
+			expect(cm.val[0]).toBeCloseTo(0.0);
+			expect(cm.val[12]).toBeCloseTo(0.5);
+		});
+	});
+
+	describe("chaining", () => {
+		it("should support method chaining", () => {
+			const cm = new ColorMatrix().brightness(1.2).contrast(1.5).saturate(0.8);
+			expect(cm).toBeInstanceOf(ColorMatrix);
+			expect(cm.isIdentity()).toEqual(false);
+		});
+
+		it("should return the same instance when chaining", () => {
+			const cm = new ColorMatrix();
+			const result = cm.brightness(1.2);
+			expect(result).toBe(cm);
+		});
+
+		it("should combine transforms (order matters)", () => {
+			const a = new ColorMatrix().brightness(2.0).contrast(0.5);
+			const b = new ColorMatrix().contrast(0.5).brightness(2.0);
+			// different order should produce different results
+			let same = true;
+			for (let i = 0; i < 16; i++) {
+				if (Math.abs(a.val[i] - b.val[i]) > 0.001) {
+					same = false;
+					break;
+				}
+			}
+			expect(same).toEqual(false);
+		});
+	});
+
+	describe("reset and reuse", () => {
+		it("should be resettable via identity()", () => {
+			const cm = new ColorMatrix().brightness(2.0).contrast(0.5);
+			expect(cm.isIdentity()).toEqual(false);
+			cm.identity();
+			expect(cm.isIdentity()).toEqual(true);
+		});
+
+		it("should produce correct results after reset", () => {
+			const cm = new ColorMatrix().brightness(2.0);
+			cm.identity();
+			cm.saturate(0.0);
+			// should be pure grayscale, not affected by previous brightness
+			expect(cm.val[0]).toBeCloseTo(0.299);
+		});
+	});
+});

--- a/packages/melonjs/tests/mat2d.spec.ts
+++ b/packages/melonjs/tests/mat2d.spec.ts
@@ -133,4 +133,96 @@ describe("Matrix2d", () => {
 		// and we should have back the original vector values
 		expect(matA.equals(matB)).toEqual(true);
 	});
+
+	describe("transform(a, b, c, d, e, f)", () => {
+		it("should not change when multiplied by identity values", () => {
+			const m = new Matrix2d(2, 0, 0, 0, 3, 0, 10, 20, 1);
+			const before = m.toArray().slice();
+			m.transform(1, 0, 0, 1, 0, 0);
+			for (let i = 0; i < 9; i++) {
+				expect(m.val[i]).toBeCloseTo(before[i]);
+			}
+		});
+
+		it("should apply a translation", () => {
+			const m = new Matrix2d();
+			m.transform(1, 0, 0, 1, 100, 200);
+			expect(m.val[6]).toBeCloseTo(100); // e (translate x)
+			expect(m.val[7]).toBeCloseTo(200); // f (translate y)
+			expect(m.val[0]).toBeCloseTo(1);
+			expect(m.val[4]).toBeCloseTo(1);
+		});
+
+		it("should apply a scale", () => {
+			const m = new Matrix2d();
+			m.transform(2, 0, 0, 3, 0, 0);
+			expect(m.val[0]).toBeCloseTo(2); // a (scale x)
+			expect(m.val[4]).toBeCloseTo(3); // d (scale y)
+		});
+
+		it("should apply a rotation", () => {
+			const m = new Matrix2d();
+			const angle = Math.PI / 4;
+			const cos = Math.cos(angle);
+			const sin = Math.sin(angle);
+			m.transform(cos, sin, -sin, cos, 0, 0);
+			expect(m.val[0]).toBeCloseTo(cos);
+			expect(m.val[1]).toBeCloseTo(sin);
+			expect(m.val[3]).toBeCloseTo(-sin);
+			expect(m.val[4]).toBeCloseTo(cos);
+		});
+
+		it("should accumulate with existing transform", () => {
+			const m = new Matrix2d();
+			// translate then scale
+			m.transform(1, 0, 0, 1, 10, 20);
+			m.transform(2, 0, 0, 2, 0, 0);
+			expect(m.val[0]).toBeCloseTo(2);
+			expect(m.val[4]).toBeCloseTo(2);
+			expect(m.val[6]).toBeCloseTo(10); // translation preserved
+			expect(m.val[7]).toBeCloseTo(20);
+		});
+
+		it("should produce same result as multiply()", () => {
+			const m1 = new Matrix2d(2, 1, 0, 1, 3, 0, 5, 10, 1);
+			const m2 = new Matrix2d(2, 1, 0, 1, 3, 0, 5, 10, 1);
+			const other = new Matrix2d(0.5, 0, 0, 0, 0.5, 0, 3, 7, 1);
+
+			m1.multiply(other);
+			m2.transform(0.5, 0, 0, 0.5, 3, 7);
+
+			for (let i = 0; i < 9; i++) {
+				expect(m2.val[i]).toBeCloseTo(m1.val[i]);
+			}
+		});
+
+		it("should return this for chaining", () => {
+			const m = new Matrix2d();
+			const result = m.transform(1, 0, 0, 1, 0, 0);
+			expect(result).toBe(m);
+		});
+
+		it("should handle combined scale + translate", () => {
+			const m = new Matrix2d();
+			m.transform(2, 0, 0, 3, 50, 100);
+			expect(m.val[0]).toBeCloseTo(2);
+			expect(m.val[4]).toBeCloseTo(3);
+			expect(m.val[6]).toBeCloseTo(50);
+			expect(m.val[7]).toBeCloseTo(100);
+		});
+
+		it("should handle zero scale", () => {
+			const m = new Matrix2d();
+			m.transform(0, 0, 0, 0, 0, 0);
+			expect(m.val[0]).toBeCloseTo(0);
+			expect(m.val[4]).toBeCloseTo(0);
+		});
+
+		it("should handle negative scale (flip)", () => {
+			const m = new Matrix2d();
+			m.transform(-1, 0, 0, -1, 0, 0);
+			expect(m.val[0]).toBeCloseTo(-1);
+			expect(m.val[4]).toBeCloseTo(-1);
+		});
+	});
 });

--- a/packages/melonjs/tests/matrix3d_transform.spec.ts
+++ b/packages/melonjs/tests/matrix3d_transform.spec.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import { Matrix3d } from "../src/math/matrix3d.ts";
+
+describe("Matrix3d.transform()", () => {
+	describe("16-argument form (full 4x4)", () => {
+		it("should not change when multiplied by identity", () => {
+			const m = new Matrix3d(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 4, 0, 5, 6, 7, 1);
+			const before = Float64Array.from(m.val);
+			m.transform(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+			for (let i = 0; i < 16; i++) {
+				expect(m.val[i]).toBeCloseTo(before[i]);
+			}
+		});
+
+		it("should produce the same result as multiply()", () => {
+			const a = new Matrix3d(
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+			);
+			const viaMultiply = new Matrix3d(
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+			);
+			const b = new Matrix3d(
+				16,
+				15,
+				14,
+				13,
+				12,
+				11,
+				10,
+				9,
+				8,
+				7,
+				6,
+				5,
+				4,
+				3,
+				2,
+				1,
+			);
+			viaMultiply.multiply(b);
+			a.transform(16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
+			for (let i = 0; i < 16; i++) {
+				expect(a.val[i]).toBeCloseTo(viaMultiply.val[i]);
+			}
+		});
+
+		it("should return this for chaining", () => {
+			const m = new Matrix3d();
+			const result = m.transform(
+				1,
+				0,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+				1,
+			);
+			expect(result).toBe(m);
+		});
+
+		it("should handle zero matrix", () => {
+			const m = new Matrix3d();
+			m.transform(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+			for (let i = 0; i < 16; i++) {
+				expect(m.val[i]).toBeCloseTo(0);
+			}
+		});
+	});
+
+	describe("6-argument form (2D affine)", () => {
+		it("should not change when multiplied by 2D identity", () => {
+			const m = new Matrix3d(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1, 0, 10, 20, 0, 1);
+			const before = Float64Array.from(m.val);
+			m.transform(1, 0, 0, 1, 0, 0);
+			for (let i = 0; i < 16; i++) {
+				expect(m.val[i]).toBeCloseTo(before[i]);
+			}
+		});
+
+		it("should apply a 2D translation", () => {
+			const m = new Matrix3d();
+			m.transform(1, 0, 0, 1, 100, 200);
+			expect(m.val[12]).toBeCloseTo(100); // e (translate x)
+			expect(m.val[13]).toBeCloseTo(200); // f (translate y)
+			expect(m.val[0]).toBeCloseTo(1);
+			expect(m.val[5]).toBeCloseTo(1);
+		});
+
+		it("should apply a 2D scale", () => {
+			const m = new Matrix3d();
+			m.transform(2, 0, 0, 3, 0, 0);
+			expect(m.val[0]).toBeCloseTo(2);
+			expect(m.val[5]).toBeCloseTo(3);
+		});
+
+		it("should apply a 2D rotation", () => {
+			const m = new Matrix3d();
+			const angle = Math.PI / 4;
+			const cos = Math.cos(angle);
+			const sin = Math.sin(angle);
+			m.transform(cos, sin, -sin, cos, 0, 0);
+			expect(m.val[0]).toBeCloseTo(cos);
+			expect(m.val[1]).toBeCloseTo(sin);
+			expect(m.val[4]).toBeCloseTo(-sin);
+			expect(m.val[5]).toBeCloseTo(cos);
+		});
+
+		it("should preserve z-axis as identity", () => {
+			const m = new Matrix3d();
+			m.transform(2, 0, 0, 2, 50, 50);
+			expect(m.val[2]).toBeCloseTo(0);
+			expect(m.val[6]).toBeCloseTo(0);
+			expect(m.val[10]).toBeCloseTo(1);
+			expect(m.val[14]).toBeCloseTo(0);
+		});
+
+		it("should return this for chaining", () => {
+			const m = new Matrix3d();
+			const result = m.transform(1, 0, 0, 1, 0, 0);
+			expect(result).toBe(m);
+		});
+
+		it("should accumulate with existing transform", () => {
+			const m = new Matrix3d();
+			m.transform(1, 0, 0, 1, 10, 20);
+			m.transform(2, 0, 0, 2, 0, 0);
+			expect(m.val[0]).toBeCloseTo(2);
+			expect(m.val[5]).toBeCloseTo(2);
+			expect(m.val[12]).toBeCloseTo(10);
+			expect(m.val[13]).toBeCloseTo(20);
+		});
+
+		it("should produce same result as 16-arg equivalent", () => {
+			const m1 = new Matrix3d(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1, 0, 10, 20, 0, 1);
+			const m2 = new Matrix3d(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1, 0, 10, 20, 0, 1);
+			m1.transform(0.5, 0, 0, 0.5, 5, 10);
+			m2.transform(0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 1, 0, 5, 10, 0, 1);
+			for (let i = 0; i < 16; i++) {
+				expect(m1.val[i]).toBeCloseTo(m2.val[i]);
+			}
+		});
+
+		it("should handle combined scale + translate", () => {
+			const m = new Matrix3d();
+			m.transform(2, 0, 0, 3, 50, 100);
+			expect(m.val[0]).toBeCloseTo(2);
+			expect(m.val[5]).toBeCloseTo(3);
+			expect(m.val[12]).toBeCloseTo(50);
+			expect(m.val[13]).toBeCloseTo(100);
+		});
+
+		it("should handle zero scale", () => {
+			const m = new Matrix3d();
+			m.transform(0, 0, 0, 0, 0, 0);
+			expect(m.val[0]).toBeCloseTo(0);
+			expect(m.val[5]).toBeCloseTo(0);
+		});
+
+		it("should handle negative scale (flip)", () => {
+			const m = new Matrix3d();
+			m.transform(-1, 0, 0, -1, 0, 0);
+			expect(m.val[0]).toBeCloseTo(-1);
+			expect(m.val[5]).toBeCloseTo(-1);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Closes #1384 (Phase 1)

### ColorMatrix utility class
- Extends `Matrix3d` with chainable color adjustment methods
- `brightness()`, `contrast()`, `saturate()`, `hueRotate()`, `sepia()`, `invertColors()`
- Zero-allocation: uses `Matrix3d.transform()` internally — no temporary matrices created
- Composable: `new ColorMatrix().brightness(1.3).contrast(1.5).saturate(0.8)`

### ColorMatrixEffect shader effect
- Applies a `ColorMatrix` to any renderable or camera via the existing shader system
- Exposes the same chainable color methods that auto-push the GPU uniform
- `reset()` to clear back to identity
- `multiply()` and `transform()` for advanced use

```js
// simple usage
sprite.shader = new ColorMatrixEffect(renderer).saturate(0.0);

// combined transforms
camera.shader = new ColorMatrixEffect(renderer)
    .brightness(1.3)
    .contrast(1.5)
    .sepia(0.3);

// update dynamically
effect.reset().hueRotate(angle);
```

### Refactored effects
- `SepiaEffect`, `InvertEffect`, `DesaturateEffect` now extend `ColorMatrixEffect`
- Share a single color matrix shader (`mat4 * color`) instead of individual GLSL programs
- `setIntensity()` uses `reset()` + parent color method — no matrix allocation

### Matrix3d.transform()
- New method accepting 16 values (full 4x4) or 6 values (2D affine, promoted to 4x4)
- Mirrors `Matrix2d.transform()` API with aligned JSDoc
- Used by `ColorMatrix` for allocation-free matrix composition

## Test plan

- [x] 23 ColorMatrix tests (all methods, chaining, reset, edge cases)
- [x] 15 Matrix3d.transform() tests (6-arg and 16-arg forms)
- [x] 10 Matrix2d.transform() tests (aligned coverage)
- [x] 2597 total tests pass
- [ ] Existing SepiaEffect/InvertEffect/DesaturateEffect behavior unchanged
- [ ] ColorMatrixEffect works on sprites and cameras

🤖 Generated with [Claude Code](https://claude.com/claude-code)