### PR TITLE
Add multi-pass post-effect chaining with renderer-agnostic RenderTarget architecture

### DIFF
--- a/packages/examples/src/examples/platformer/entities/coin.ts
+++ b/packages/examples/src/examples/platformer/entities/coin.ts
@@ -60,7 +60,7 @@ export class CoinEntity extends Collectable {
 				event.on(event.GAME_UPDATE, coinUpdateHandler);
 			}
 			coinShaderRefCount++;
-			this.shader = coinShader;
+			this.addPostEffect(coinShader);
 		});
 	}
 

--- a/packages/examples/src/examples/platformer/entities/minimap.ts
+++ b/packages/examples/src/examples/platformer/entities/minimap.ts
@@ -26,7 +26,7 @@ export class MinimapCamera extends Camera2d {
 		event.on(event.CANVAS_ONRESIZE, this.boundOnResize);
 
 		// apply subtle vignette post-process effect on the minimap
-		this.shader = new VignetteEffect(game.renderer);
+		this.addPostEffect(new VignetteEffect(game.renderer));
 
 		const currentLevel = level.getCurrentLevel();
 		if (currentLevel) {

--- a/packages/examples/src/examples/platformer/play.ts
+++ b/packages/examples/src/examples/platformer/play.ts
@@ -1,6 +1,7 @@
 import {
 	type Application,
 	audio,
+	ColorMatrixEffect,
 	device,
 	level,
 	plugin,
@@ -45,8 +46,11 @@ export class PlayScreen extends Stage {
 			app.world.addChild(this.virtualJoypad);
 		}
 
-		// apply subtle vignette post-process effect on the camera
-		app.viewport.shader = new VignetteEffect(app.renderer as any);
+		// multi-pass post-effects: vignette + HDR-like color grading
+		app.viewport.addPostEffect(new VignetteEffect(app.renderer as any));
+		app.viewport.addPostEffect(
+			new ColorMatrixEffect(app.renderer as any).contrast(1.1).saturate(1.1),
+		);
 
 		// play some music
 		audio.playTrack("dst-gameforest");

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Added
 - Camera: FBO-based post-processing pipeline — assign a `ShaderEffect` to any camera's `shader` property to apply full-screen post-effects (vignette, scanlines, desaturation, etc.). Works with multiple cameras independently (e.g. main camera + minimap with different effects). Renderer manages FBO lifecycle via `beginPostEffect()`/`endPostEffect()`/`blitEffect()` methods.
+- Renderable: multi-pass post-effect chaining — `postEffects` array replaces single `shader` property. Multiple effects are applied in sequence via FBO ping-pong (e.g. `sprite.addPostEffect(new DesaturateEffect(r)); sprite.addPostEffect(new InvertEffect(r));`). Single-effect renderables use a zero-overhead `customShader` fast path (no FBO). Camera manages its own FBO lifecycle; per-sprite effects use a separate FBO pair.
+- Renderable: `addPostEffect(effect)`, `getPostEffect(EffectClass?)`, `removePostEffect(effect)`, `clearPostEffects()` — manage post-processing shader effects on any renderable
+- Renderable: `shader` getter/setter — backward-compatible access to `postEffects[0]` (deprecated)
+- Rendering: `RenderTarget` abstract base class — renderer-agnostic interface for offscreen render targets (`bind`, `unbind`, `resize`, `clear`, `destroy`, `getImageData`, `toBlob`, `toImageBitmap`, `toDataURL`). Concrete implementations: `WebGLRenderTarget` (FBO) and `CanvasRenderTarget` (canvas surface). Designed for future WebGPU support.
+- Rendering: `RenderTargetPool` — renderer-agnostic pool for post-effect ping-pong render targets. Uses a factory function provided by the renderer, no GL dependency. Camera effects use pool indices 0+1, sprite effects use indices 2+3.
+- Renderer: `setViewport()`, `clearRenderTarget()`, `enableScissor()`, `disableScissor()`, `setBlendEnabled()` — renderer-agnostic state methods on the base Renderer (no-ops for Canvas), implemented on WebGLRenderer. Eliminates direct GL calls from the post-effect pipeline.
 - WebGL: `VignetteEffect` built-in shader effect — darkens screen edges to draw focus to the center, with configurable `strength` and `size` parameters
-- WebGL: `WebGLRenderTarget` class — reusable FBO wrapper (framebuffer + color texture + depth/stencil renderbuffer) with bind/unbind/resize/destroy lifecycle
-- Renderer: `beginPostEffect(camera)`, `endPostEffect(camera)`, and `blitEffect(source, x, y, w, h, shader)` methods on the base Renderer (no-op for Canvas) and WebGLRenderer
 - RenderState: `currentShader` is now part of the save/restore stack — custom shaders are properly scoped per-renderable without leaking to siblings or parent cameras
 - Camera: extensible camera effect system — `CameraEffect` base class with `update(dt)`, `draw(renderer, w, h)`, `destroy()` lifecycle. Add/get/remove effects via `addCameraEffect()`, `getCameraEffect(EffectClass)`, `removeCameraEffect(effect)` on any Camera2d.
 - Camera: `ShakeEffect` — extracted shake logic into a standalone camera effect class with `intensity`, `duration`, `axis`, and `onComplete` support. Multiple shakes can coexist.
@@ -22,11 +26,16 @@
 - Camera: `shake()`, `fadeIn()`, `fadeOut()` are now convenience wrappers that create `ShakeEffect`/`FadeEffect` instances — same signatures, fully backward compatible
 - Trigger: internally uses `FadeEffect`/`MaskEffect` instead of `viewport.fadeIn()`/`viewport.fadeOut()`, with both hide and reveal effects
 - WebGL: `SepiaEffect`, `InvertEffect`, `DesaturateEffect` now extend `ColorMatrixEffect` — share a single color matrix shader instead of individual GLSL shaders
+- Rendering: `WebGLRenderTarget` and `CanvasRenderTarget` now extend the abstract `RenderTarget` base class
+- Rendering: FBO pool refactored from WebGL-specific `FBOPool` to renderer-agnostic `RenderTargetPool` with factory pattern
+- Canvas: `CanvasRenderTarget` save/restore now properly syncs `customShader` with the render state stack (mirrors WebGLRenderer behavior)
 
 ### Fixed
 - Canvas: `setMask(shape, true)` now uses `evenodd` clipping for proper inverted mask support (was using `destination-atop` composite which didn't clip subsequent draws)
 - Ellipse: `clone()` now uses the ellipse pool instead of `new Ellipse()` — consistent with `Polygon.clone()` which already uses its pool
 - TMXObjectFactory: override warning now uses `console.warn()` instead of the deprecation `warning()` function (was showing "deprecated since version undefined")
+- WebGL: `WebGLRenderTarget` constructor and `resize()` now explicitly use `TEXTURE0` to avoid corrupting the multi-texture batcher's texture unit bindings
+- WebGL: post-effect pipeline now explicitly sets viewport on every FBO bind and saves/restores the projection matrix, fixing rendering issues after canvas resize
 
 
 ## [19.1.0] (melonJS 2) - _2026-04-16_

--- a/packages/melonjs/src/camera/camera2d.ts
+++ b/packages/melonjs/src/camera/camera2d.ts
@@ -228,6 +228,9 @@ export default class Camera2d extends Renderable {
 		// enable event detection on the camera
 		this.isKinematic = false;
 
+		// camera manages its own FBO lifecycle in draw()
+		this._postEffectManaged = true;
+
 		this.bounds.setMinMax(minX, minY, maxX, maxY);
 
 		// update the projection matrix
@@ -856,7 +859,7 @@ export default class Camera2d extends Renderable {
 		const translateX = this.pos.x + this.offset.x + containerOffsetX;
 		const translateY = this.pos.y + this.offset.y + containerOffsetY;
 
-		// post-effect: bind FBO if a shader effect is set (WebGL only)
+		// post-effect: bind FBO if shader effects are set (WebGL only)
 		const usePostEffect = r.beginPostEffect(this);
 
 		// translate the world coordinates by default to screen coordinates

--- a/packages/melonjs/src/index.ts
+++ b/packages/melonjs/src/index.ts
@@ -62,6 +62,7 @@ import { Gradient } from "./video/gradient.js";
 import Renderer from "./video/renderer.js";
 import RenderState from "./video/renderstate.js";
 import CanvasRenderTarget from "./video/rendertarget/canvasrendertarget.js";
+import RenderTarget from "./video/rendertarget/rendertarget.ts";
 import { TextureAtlas } from "./video/texture/atlas.js";
 import { Batcher } from "./video/webgl/batchers/batcher.js";
 import PrimitiveBatcher from "./video/webgl/batchers/primitive_batcher.js";
@@ -177,6 +178,7 @@ export {
 	Renderable,
 	Renderer,
 	RenderState,
+	RenderTarget,
 	ScanlineEffect,
 	SepiaEffect,
 	ShaderEffect,

--- a/packages/melonjs/src/renderable/renderable.js
+++ b/packages/melonjs/src/renderable/renderable.js
@@ -237,45 +237,27 @@ export default class Renderable extends Rect {
 		this.mask = undefined;
 
 		/**
-		 * an optional shader, to be used instead of the default built-in one, when drawing this renderable (WebGL only).
-		 * Use {@link ShaderEffect} for a custom fragment `apply()` function,
-		 * or one of the built-in effect presets:
-		 * - {@link FlashEffect} — flash the sprite with a solid color (hit feedback)
-		 * - {@link OutlineEffect} — colored outline around the sprite (selection, hover)
-		 * - {@link GlowEffect} — soft colored glow around the sprite (power-ups, magic)
-		 * - {@link DesaturateEffect} — partial or full grayscale (disabled, death)
-		 * - {@link PixelateEffect} — progressive pixelation (teleport, retro)
-		 * - {@link BlurEffect} — box blur (defocus, backdrop)
-		 * - {@link ChromaticAberrationEffect} — RGB channel offset (impact, glitch)
-		 * - {@link DissolveEffect} — noise-based dissolve (death, spawn)
-		 * - {@link DropShadowEffect} — offset shadow beneath the sprite
-		 * - {@link ScanlineEffect} — horizontal scanlines with optional CRT curvature and vignette
-		 * - {@link TintPulseEffect} — pulsing color overlay (poison, freeze, fire)
-		 * - {@link WaveEffect} — sine wave distortion (underwater, heat haze)
-		 * - {@link InvertEffect} — color inversion (negative image, X-ray)
-		 * - {@link SepiaEffect} — warm vintage photo tone
-		 * - {@link HologramEffect} — flickering holographic projection (sci-fi)
-		 *
-		 * Use {@link GLShader} for full control over vertex and fragment shaders.
+		 * the list of post-processing shader effects applied to this renderable (WebGL only).
+		 * Effects are applied in order. Use {@link addPostEffect}, {@link getPostEffect},
+		 * and {@link removePostEffect} to manage effects, or assign directly.
 		 * In Canvas mode, this property is ignored.
-		 * @type {GLShader|ShaderEffect}
-		 * @default undefined
+		 * @type {Array<GLShader|ShaderEffect>}
+		 * @default []
 		 * @example
-		 * // apply a built-in effect
-		 * mySprite.shader = new FlashEffect(renderer, { intensity: 1.0 });
+		 * // add effects via helper methods
+		 * mySprite.addPostEffect(new DesaturateEffect(renderer));
+		 * mySprite.addPostEffect(new VignetteEffect(renderer));
 		 * @example
-		 * // custom shader effect
-		 * mySprite.shader = new ShaderEffect(renderer, `
-		 *     vec4 apply(vec4 color, vec2 uv) {
-		 *         float gray = dot(color.rgb, vec3(0.299, 0.587, 0.114));
-		 *         return vec4(vec3(gray), color.a);
-		 *     }
-		 * `);
-		 * @example
-		 * // to remove a custom shader
-		 * mySprite.shader = undefined;
+		 * // assign directly
+		 * mySprite.postEffects = [new SepiaEffect(renderer), new VignetteEffect(renderer)];
 		 */
-		this.shader = undefined;
+		this.postEffects = [];
+
+		/**
+		 * whether this renderable manages its own FBO lifecycle (e.g. Camera2d)
+		 * @ignore
+		 */
+		this._postEffectManaged = false;
 
 		/**
 		 * the blend mode to be applied to this renderable (see renderer setBlendMode for available blend mode)
@@ -417,6 +399,89 @@ export default class Renderable extends Rect {
 			this._inViewport = value;
 			if (typeof this.onVisibilityChange === "function") {
 				this.onVisibilityChange.call(this, value);
+			}
+		}
+	}
+
+	/**
+	 * @deprecated since 19.2.0 — use {@link addPostEffect} / {@link getPostEffect} / {@link removePostEffect} instead
+	 * @type {GLShader|ShaderEffect|undefined}
+	 */
+	get shader() {
+		return this.postEffects[0];
+	}
+
+	set shader(value) {
+		// destroy existing effects before replacing
+		for (const effect of this.postEffects) {
+			if (typeof effect.destroy === "function") {
+				effect.destroy();
+			}
+		}
+		if (typeof value === "undefined") {
+			this.postEffects.length = 0;
+		} else {
+			this.postEffects = [value];
+		}
+	}
+
+	/**
+	 * Add a post-processing shader effect to this renderable.
+	 * @param {GLShader|ShaderEffect} effect - the effect to add
+	 * @returns {GLShader|ShaderEffect} the added effect
+	 * @example
+	 * mySprite.addPostEffect(new DesaturateEffect(renderer));
+	 */
+	addPostEffect(effect) {
+		this.postEffects.push(effect);
+		return effect;
+	}
+
+	/**
+	 * Get post-processing shader effects.
+	 * When called with a class, returns the first effect matching the given class.
+	 * When called without arguments, returns the full effects array.
+	 * @param {Function} [effectClass] - the effect class to search for
+	 * @returns {GLShader|ShaderEffect|Array|undefined} the matching effect, the effects array, or undefined
+	 * @example
+	 * const desat = sprite.getPostEffect(DesaturateEffect);
+	 * const allEffects = sprite.getPostEffect();
+	 */
+	getPostEffect(effectClass) {
+		if (typeof effectClass === "undefined") {
+			return this.postEffects;
+		}
+		return this.postEffects.find((fx) => {
+			return fx instanceof effectClass;
+		});
+	}
+
+	/**
+	 * Remove all post-processing shader effects.
+	 * @example
+	 * sprite.clearPostEffects();
+	 */
+	clearPostEffects() {
+		for (const effect of this.postEffects) {
+			if (typeof effect.destroy === "function") {
+				effect.destroy();
+			}
+		}
+		this.postEffects.length = 0;
+	}
+
+	/**
+	 * Remove a specific post-processing shader effect.
+	 * @param {GLShader|ShaderEffect} effect - the effect to remove
+	 * @example
+	 * sprite.removePostEffect(effect);
+	 */
+	removePostEffect(effect) {
+		const idx = this.postEffects.indexOf(effect);
+		if (idx !== -1) {
+			this.postEffects.splice(idx, 1);
+			if (typeof effect.destroy === "function") {
+				effect.destroy();
 			}
 		}
 	}
@@ -749,8 +814,11 @@ export default class Renderable extends Rect {
 			renderer.translate(-this.pos.x, -this.pos.y);
 		}
 
-		// set the custom shader for this renderable (undefined clears it)
-		renderer.customShader = this.shader;
+		// delegate post-effect setup to the renderer.
+		// Camera manages its own FBO lifecycle in draw().
+		if (!this._postEffectManaged) {
+			renderer.beginPostEffect(this);
+		}
 
 		if (this.autoTransform === true && !this.currentTransform.isIdentity()) {
 			// apply the renderable transformation matrix
@@ -802,6 +870,11 @@ export default class Renderable extends Rect {
 		// clear the mask if set
 		if (this.mask) {
 			renderer.clearMask();
+		}
+
+		// finalize post-effects (renderer decides what to do)
+		if (!this._postEffectManaged) {
+			renderer.endPostEffect(this);
 		}
 
 		// restore the context (also restores customShader)
@@ -891,11 +964,13 @@ export default class Renderable extends Rect {
 		// call the user defined destroy method
 		this.onDestroyEvent.apply(this, arguments);
 
-		// destroy any shader object if not done by the user through onDestroyEvent()
-		if (this.shader && typeof this.shader.destroy === "function") {
-			this.shader.destroy();
-			this.shader = undefined;
+		// destroy any shader effects if not done by the user through onDestroyEvent()
+		for (const effect of this.postEffects) {
+			if (typeof effect.destroy === "function") {
+				effect.destroy();
+			}
 		}
+		this.postEffects.length = 0;
 	}
 
 	/**

--- a/packages/melonjs/src/video/canvas/canvas_renderer.js
+++ b/packages/melonjs/src/video/canvas/canvas_renderer.js
@@ -893,6 +893,8 @@ export default class CanvasRenderer extends Renderer {
 		if (result !== null) {
 			this.setBlendMode(result.blendMode);
 		}
+		// sync customShader from renderState (mirrors WebGLRenderer.restore)
+		this.customShader = this.renderState.currentShader;
 		// re-sync from the native context (which is authoritative for Canvas)
 		// fillStyle may be a CanvasGradient/CanvasPattern — only sync if it's a color string
 		if (typeof context.fillStyle === "string") {
@@ -921,6 +923,7 @@ export default class CanvasRenderer extends Renderer {
 	 */
 	save() {
 		this.getContext().save();
+		this.renderState.currentShader = this.customShader;
 		this.renderState.save();
 	}
 

--- a/packages/melonjs/src/video/renderer.js
+++ b/packages/melonjs/src/video/renderer.js
@@ -284,6 +284,8 @@ export default class Renderer {
 		});
 		if (effects.length === 1) {
 			this.customShader = effects[0];
+		} else {
+			this.customShader = undefined;
 		}
 		return false;
 	}

--- a/packages/melonjs/src/video/renderer.js
+++ b/packages/melonjs/src/video/renderer.js
@@ -8,6 +8,10 @@ import RenderState from "./renderstate.js";
 import CanvasRenderTarget from "./rendertarget/canvasrendertarget.js";
 
 /**
+ * @import RenderTargetPool from "./rendertarget/render_target_pool.js";
+ */
+
+/**
  * @import {Rect} from "./../geometries/rectangle.ts";
  * @import {RoundRect} from "./../geometries/roundrect.ts";
  * @import {Polygon} from "../geometries/polygon.ts";
@@ -78,8 +82,17 @@ export default class Renderer {
 		 * Set by a renderable's preDraw when a shader is assigned.
 		 * (WebGL only, ignored by Canvas renderer)
 		 * @type {GLShader|ShaderEffect|undefined}
+		 * @ignore
 		 */
 		this.customShader = undefined;
+
+		/**
+		 * The render target pool for post-effect processing (ping-pong FBOs).
+		 * Initialized by GPU renderers (WebGL, WebGPU). Null on Canvas renderer.
+		 * @type {RenderTargetPool|null}
+		 * @ignore
+		 */
+		this._renderTargetPool = null;
 
 		/**
 		 * The Path2D instance used by the renderer to draw primitives
@@ -260,24 +273,30 @@ export default class Renderer {
 	 * Begin capturing rendering to an offscreen buffer for post-effect processing.
 	 * Call endPostEffect() after rendering to blit the result to the screen.
 	 * No-op on Canvas renderer.
-	 * @param {Camera2d} camera - the camera requesting post-effect processing
+	 * @param {Renderable} renderable - the renderable with postEffects to apply
 	 * @returns {boolean} false (Canvas renderer does not support post-effect processing)
 	 * @ignore
 	 */
-	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-	beginPostEffect(camera) {
+	beginPostEffect(renderable) {
+		// on Canvas, only set customShader for single-effect fast path
+		const effects = renderable.postEffects.filter((fx) => {
+			return fx.enabled !== false;
+		});
+		if (effects.length === 1) {
+			this.customShader = effects[0];
+		}
 		return false;
 	}
 
 	/**
 	 * End post-effect capture and blit the offscreen buffer to the screen
-	 * through the camera's shader effect.
+	 * through the renderable's post-effects.
 	 * No-op on Canvas renderer.
-	 * @param {Camera2d} camera - the camera with shader, screen position, and dimensions
+	 * @param {Renderable} renderable - the renderable with postEffects to apply
 	 * @ignore
 	 */
 	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-	endPostEffect(camera) {}
+	endPostEffect(renderable) {}
 
 	/**
 	 * Blit a texture to the screen through a shader effect.
@@ -290,9 +309,54 @@ export default class Renderer {
 	 * @param {number} width - destination width
 	 * @param {number} height - destination height
 	 * @param {ShaderEffect} shader - the shader effect to apply
+	 * @param {boolean} [keepBlend=false] - if true, keep current blend mode (for sprite compositing)
 	 */
 	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-	blitEffect(source, x, y, width, height, shader) {}
+	blitEffect(source, x, y, width, height, shader, keepBlend) {}
+
+	/**
+	 * Sets the viewport for the renderer.
+	 * Defines the affine transformation from normalized device coordinates to window coordinates.
+	 * No-op on Canvas renderer.
+	 * @param {number} [x=0] - x coordinate of the viewport origin
+	 * @param {number} [y=0] - y coordinate of the viewport origin
+	 * @param {number} [w] - width of the viewport (defaults to canvas width)
+	 * @param {number} [h] - height of the viewport (defaults to canvas height)
+	 */
+	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+	setViewport(x = 0, y = 0, w, h) {}
+
+	/**
+	 * Clear the current render target to transparent black (color + stencil).
+	 * Used to prepare FBOs for post-effect capture.
+	 * No-op on Canvas renderer.
+	 */
+	clearRenderTarget() {}
+
+	/**
+	 * Enable the scissor test with the given rectangle.
+	 * No-op on Canvas renderer.
+	 * @param {number} x - x coordinate of the scissor rectangle
+	 * @param {number} y - y coordinate of the scissor rectangle
+	 * @param {number} width - width of the scissor rectangle
+	 * @param {number} height - height of the scissor rectangle
+	 */
+	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+	enableScissor(x, y, width, height) {}
+
+	/**
+	 * Disable the scissor test, allowing rendering to the full viewport.
+	 * No-op on Canvas renderer.
+	 */
+	disableScissor() {}
+
+	/**
+	 * Enable or disable alpha blending.
+	 * No-op on Canvas renderer (Canvas always blends).
+	 * @param {boolean} enable - true to enable blending, false to disable
+	 */
+	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+	setBlendEnabled(enable) {}
 
 	/**
 	 * returns the current blend mode for this renderer

--- a/packages/melonjs/src/video/rendertarget/canvasrendertarget.js
+++ b/packages/melonjs/src/video/rendertarget/canvasrendertarget.js
@@ -1,6 +1,7 @@
 import { clamp } from "../../math/math.ts";
 import { setPrefixed } from "../../utils/agent.ts";
 import { createCanvas } from "../video.js";
+import RenderTarget from "./rendertarget.ts";
 
 /**
  * additional import for TypeScript
@@ -77,10 +78,13 @@ function createContext(canvas, attributes) {
 }
 
 /**
- * CanvasRenderTarget is 2D render target which exposes a Canvas interface.
+ * A 2D canvas render target for offscreen texture generation.
+ * Used by Text, Gradient, Light2d and Particle systems to render into
+ * a canvas that is then uploaded as a WebGL texture.
+ * @augments RenderTarget
  * @category Rendering
  */
-class CanvasRenderTarget {
+class CanvasRenderTarget extends RenderTarget {
 	/**
 	 * @param {number} width - the desired width of the canvas
 	 * @param {number} height - the desired height of the canvas
@@ -93,17 +97,7 @@ class CanvasRenderTarget {
 	 * @param {boolean} [attributes.antiAlias=false] - Whether to enable anti-aliasing, use false (default) for a pixelated effect.
 	 */
 	constructor(width, height, attributes = defaultAttributes) {
-		/**
-		 * the canvas created for this CanvasRenderTarget
-		 * @type {HTMLCanvasElement|OffscreenCanvas}
-		 */
-		// this.canvas;
-
-		/**
-		 * the rendering context of this CanvasRenderTarget
-		 * @type {CanvasRenderingContext2D|WebGLRenderingContext}
-		 */
-		// this.context;
+		super();
 		// clean up the given attributes
 		this.attributes = Object.assign({}, defaultAttributes, attributes);
 
@@ -206,65 +200,40 @@ class CanvasRenderTarget {
 	}
 
 	/**
-	 * creates a Blob object representing the image contained in this canvas texture
+	 * Returns a data URL directly from the canvas (avoids the getImageData/Blob round-trip).
+	 * Note: not supported by OffscreenCanvas — falls back to the base implementation.
 	 * @param {string} [type="image/png"] - A string indicating the image format
-	 * @param {number} [quality] - A Number between 0 and 1 indicating the image quality to be used when creating images using file formats that support lossy compression (such as image/jpeg or image/webp). A user agent will use its default quality value if this option is not specified, or if the number is outside the allowed range.
-	 * @returns {Promise} A Promise returning a Blob object representing the image contained in this canvas texture
-	 * @example
-	 * renderTarget.convertToBlob().then((blob) => console.log(blob));
+	 * @param {number} [quality] - A number between 0 and 1 for lossy formats (image/jpeg, image/webp)
+	 * @returns {Promise<string>} A Promise resolving to a data URL string
+	 */
+	toDataURL(type = "image/png", quality) {
+		if (typeof this.canvas.toDataURL === "function") {
+			return Promise.resolve(this.canvas.toDataURL(type, quality));
+		}
+		// OffscreenCanvas doesn't have toDataURL — use base implementation
+		return super.toDataURL(type, quality);
+	}
+
+	/**
+	 * Creates a Blob directly from the canvas (avoids the getImageData round-trip).
+	 * @param {string} [type="image/png"] - A string indicating the image format
+	 * @param {number} [quality] - A number between 0 and 1 for lossy formats (image/jpeg, image/webp)
+	 * @returns {Promise<Blob>} A Promise resolving to a Blob
 	 */
 	toBlob(type = "image/png", quality) {
 		if (typeof this.canvas.convertToBlob === "function") {
+			// OffscreenCanvas path
 			return this.canvas.convertToBlob({ type, quality });
-		} else {
-			return new Promise((resolve) => {
-				this.canvas.toBlob(
-					(blob) => {
-						resolve(blob);
-					},
-					type,
-					quality,
-				);
-			});
 		}
-	}
-
-	/**
-	 * creates an ImageBitmap object from the most recently rendered image of this canvas texture
-	 * @param {string} [type="image/png"] - A string indicating the image format
-	 * @param {number} [quality] - A Number between 0 and 1 indicating the image quality to be used when creating images using file formats that support lossy compression (such as image/jpeg or image/webp). A user agent will use its default quality value if this option is not specified, or if the number is outside the allowed range.
-	 * @returns {Promise} A Promise returning an ImageBitmap.
-	 * @example
-	 * renderTarget.transferToImageBitmap().then((bitmap) => console.log(bitmap));
-	 */
-	toImageBitmap(type = "image/png", quality) {
+		// HTMLCanvasElement path
 		return new Promise((resolve) => {
-			if (typeof this.canvas.transferToImageBitmap === "function") {
-				resolve(this.canvas.transferToImageBitmap());
-			} else {
-				const image = new Image();
-				image.src = this.canvas.toDataURL(type, quality);
-				image.onload = () => {
-					globalThis.createImageBitmap(image).then((bitmap) => {
-						return resolve(bitmap);
-					});
-				};
-			}
-		});
-	}
-
-	/**
-	 * returns a data URL containing a representation of the most recently rendered image of this canvas texture
-	 * (not supported by OffscreenCanvas)
-	 * @param {string} [type="image/png"] - A string indicating the image format
-	 * @param {number} [quality] - A Number between 0 and 1 indicating the image quality to be used when creating images using file formats that support lossy compression (such as image/jpeg or image/webp). A user agent will use its default quality value if this option is not specified, or if the number is outside the allowed range.
-	 * @returns {Promise} A Promise returning a string containing the requested data URL.
-	 * @example
-	 * renderer.toDataURL().then((dataURL) => console.log(dataURL));
-	 */
-	toDataURL(type = "image/png", quality) {
-		return new Promise((resolve) => {
-			resolve(this.canvas.toDataURL(type, quality));
+			this.canvas.toBlob(
+				(blob) => {
+					resolve(blob);
+				},
+				type,
+				quality,
+			);
 		});
 	}
 

--- a/packages/melonjs/src/video/rendertarget/canvasrendertarget.js
+++ b/packages/melonjs/src/video/rendertarget/canvasrendertarget.js
@@ -226,15 +226,27 @@ class CanvasRenderTarget extends RenderTarget {
 			return this.canvas.convertToBlob({ type, quality });
 		}
 		// HTMLCanvasElement path
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			this.canvas.toBlob(
 				(blob) => {
-					resolve(blob);
+					if (blob) {
+						resolve(blob);
+					} else {
+						reject(new Error(`toBlob failed for type "${type}"`));
+					}
 				},
 				type,
 				quality,
 			);
 		});
+	}
+
+	/**
+	 * Creates an ImageBitmap directly from the canvas (avoids the getImageData round-trip).
+	 * @returns {Promise<ImageBitmap>} A Promise resolving to an ImageBitmap
+	 */
+	toImageBitmap() {
+		return globalThis.createImageBitmap(this.canvas);
 	}
 
 	/**

--- a/packages/melonjs/src/video/rendertarget/render_target_pool.js
+++ b/packages/melonjs/src/video/rendertarget/render_target_pool.js
@@ -53,8 +53,13 @@ export default class RenderTargetPool {
 	 * @returns {RenderTarget} the capture target (ready to bind)
 	 */
 	begin(isCamera, effectCount, width, height) {
+		const newBase = isCamera ? 0 : 2;
+		// guard against nested sprite post-effect passes (not yet supported)
+		if (!isCamera && this._activeBase === newBase) {
+			return this.get(this._activeBase, width, height);
+		}
 		this._previousBase = this._activeBase;
-		this._activeBase = isCamera ? 0 : 2;
+		this._activeBase = newBase;
 		const rt = this.get(this._activeBase, width, height);
 		if (effectCount > 1) {
 			this.get(this._activeBase + 1, width, height);
@@ -121,5 +126,7 @@ export default class RenderTargetPool {
 			}
 		}
 		this._pool.length = 0;
+		this._activeBase = -1;
+		this._previousBase = -1;
 	}
 }

--- a/packages/melonjs/src/video/rendertarget/render_target_pool.js
+++ b/packages/melonjs/src/video/rendertarget/render_target_pool.js
@@ -1,0 +1,125 @@
+/**
+ * @import RenderTarget from "./rendertarget.ts";
+ */
+
+/**
+ * Manages a pool of {@link RenderTarget} instances for post-effect processing.
+ * Renderer-agnostic — the actual RenderTarget creation is delegated to a
+ * factory function provided by the renderer (WebGL, WebGPU, etc.).
+ *
+ * Camera effects use pool indices 0 and 1 (capture + ping-pong),
+ * sprite effects use indices 2 and 3.
+ * Render targets are lazily created and resized to match the required dimensions.
+ * @ignore
+ */
+export default class RenderTargetPool {
+	/**
+	 * @param {function(number, number): RenderTarget} factory - creates a RenderTarget with the given width and height
+	 */
+	constructor(factory) {
+		/** @type {function(number, number): RenderTarget} */
+		this._factory = factory;
+		/** @type {RenderTarget[]} */
+		this._pool = [];
+		/** @type {number} */
+		this._activeBase = -1;
+		/** @type {number} */
+		this._previousBase = -1;
+	}
+
+	/**
+	 * Get or create a render target at the given pool index, resized to the given dimensions.
+	 * @param {number} index - pool index
+	 * @param {number} width - desired width in pixels
+	 * @param {number} height - desired height in pixels
+	 * @returns {RenderTarget} the render target
+	 */
+	get(index, width, height) {
+		if (!this._pool[index]) {
+			this._pool[index] = this._factory(width, height);
+		} else {
+			this._pool[index].resize(width, height);
+		}
+		return this._pool[index];
+	}
+
+	/**
+	 * Prepare render targets for a post-effect pass.
+	 * Allocates/resizes the capture target and optionally the ping-pong target.
+	 * @param {boolean} isCamera - true for camera effects (indices 0+1), false for sprite (indices 2+3)
+	 * @param {number} effectCount - number of enabled effects
+	 * @param {number} width - target width in pixels
+	 * @param {number} height - target height in pixels
+	 * @returns {RenderTarget} the capture target (ready to bind)
+	 */
+	begin(isCamera, effectCount, width, height) {
+		this._previousBase = this._activeBase;
+		this._activeBase = isCamera ? 0 : 2;
+		const rt = this.get(this._activeBase, width, height);
+		if (effectCount > 1) {
+			this.get(this._activeBase + 1, width, height);
+		}
+		return rt;
+	}
+
+	/**
+	 * Get the capture render target for the current active pass.
+	 * @returns {RenderTarget|undefined} the capture target, or undefined if no active pass
+	 */
+	getCaptureTarget() {
+		if (this._activeBase < 0) {
+			return undefined;
+		}
+		return this._pool[this._activeBase];
+	}
+
+	/**
+	 * Get the ping-pong render target for the current active pass.
+	 * @returns {RenderTarget|undefined} the ping-pong target, or undefined if no active pass
+	 */
+	getPingPongTarget() {
+		if (this._activeBase < 0) {
+			return undefined;
+		}
+		return this._pool[this._activeBase + 1];
+	}
+
+	/**
+	 * End the current pass and restore the previous active base.
+	 * Returns the parent render target to rebind (or null for screen).
+	 * @returns {RenderTarget|null} the parent target, or null if returning to screen
+	 */
+	end() {
+		this._activeBase = this._previousBase;
+		this._previousBase = -1;
+		if (this._activeBase >= 0 && this._pool[this._activeBase]) {
+			return this._pool[this._activeBase];
+		}
+		return null;
+	}
+
+	/**
+	 * Resize all existing render targets in the pool to the given dimensions.
+	 * @param {number} width - new width in pixels
+	 * @param {number} height - new height in pixels
+	 */
+	resizeAll(width, height) {
+		for (const rt of this._pool) {
+			if (rt) {
+				rt.resize(width, height);
+			}
+		}
+	}
+
+	/**
+	 * Destroy all render targets and clear the pool.
+	 */
+	destroy() {
+		for (const rt of this._pool) {
+			if (rt) {
+				rt.destroy();
+			}
+		}
+		this._pool.length = 0;
+	}
+}

--- a/packages/melonjs/src/video/rendertarget/rendertarget.ts
+++ b/packages/melonjs/src/video/rendertarget/rendertarget.ts
@@ -90,10 +90,14 @@ export default abstract class RenderTarget {
 		canvas.height = this.height;
 		const ctx = canvas.getContext("2d")!;
 		ctx.putImageData(imageData, 0, 0);
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			canvas.toBlob(
 				(blob) => {
-					resolve(blob!);
+					if (blob) {
+						resolve(blob);
+					} else {
+						reject(new Error(`toBlob failed for type "${type}"`));
+					}
 				},
 				type,
 				quality,

--- a/packages/melonjs/src/video/rendertarget/rendertarget.ts
+++ b/packages/melonjs/src/video/rendertarget/rendertarget.ts
@@ -1,0 +1,130 @@
+/**
+ * Abstract base class for offscreen render targets.
+ * Provides a renderer-agnostic interface for binding, clearing, resizing,
+ * and reading back pixel data from an offscreen surface.
+ * Concrete implementations:
+ * - {@link WebGLRenderTarget} — WebGL framebuffer object (FBO) for post-processing
+ * - {@link CanvasRenderTarget} — 2D canvas surface for texture generation
+ *
+ * A future WebGPU implementation would extend this class with
+ * GPUTexture / GPURenderPassDescriptor management.
+ * @category Rendering
+ */
+export default abstract class RenderTarget {
+	/**
+	 * The width of this render target in pixels.
+	 */
+	declare width: number;
+
+	/**
+	 * The height of this render target in pixels.
+	 */
+	declare height: number;
+
+	/**
+	 * Bind this render target as the active draw destination.
+	 * All subsequent draw calls will render into this target until {@link unbind} is called.
+	 * No-op by default — subclasses override for GPU render targets (e.g. WebGL FBOs).
+	 */
+	bind(): void {}
+
+	/**
+	 * Unbind this render target, restoring the default (screen) output.
+	 * No-op by default — subclasses override for GPU render targets.
+	 */
+	unbind(): void {}
+
+	/**
+	 * Resize the render target's backing storage to the given dimensions.
+	 * @param width - new width in pixels
+	 * @param height - new height in pixels
+	 */
+	abstract resize(width: number, height: number): void;
+
+	/**
+	 * Clear the render target contents.
+	 */
+	abstract clear(): void;
+
+	/**
+	 * Release all resources held by this render target.
+	 * The target must not be used after calling destroy.
+	 */
+	abstract destroy(): void;
+
+	/**
+	 * Read back pixel data from this render target.
+	 * @param x - x coordinate of the top-left corner (default 0)
+	 * @param y - y coordinate of the top-left corner (default 0)
+	 * @param width - width of the area to read (default full width)
+	 * @param height - height of the area to read (default full height)
+	 * @returns an ImageData object containing the pixel data
+	 */
+	abstract getImageData(
+		x?: number,
+		y?: number,
+		width?: number,
+		height?: number,
+	): ImageData;
+
+	/**
+	 * Creates a Blob object representing the image contained in this render target.
+	 * @param type - a string indicating the image format (default "image/png")
+	 * @param quality - a number between 0 and 1 for lossy formats (e.g. image/jpeg)
+	 * @returns a Promise resolving to a Blob
+	 */
+	toBlob(type = "image/png", quality?: number): Promise<Blob> {
+		const imageData = this.getImageData();
+		if (typeof OffscreenCanvas !== "undefined") {
+			const canvas = new OffscreenCanvas(this.width, this.height);
+			const ctx = canvas.getContext("2d")!;
+			ctx.putImageData(imageData, 0, 0);
+			const options: { type: string; quality?: number } = { type };
+			if (typeof quality !== "undefined") {
+				options.quality = quality;
+			}
+			return canvas.convertToBlob(options);
+		}
+		const canvas = document.createElement("canvas");
+		canvas.width = this.width;
+		canvas.height = this.height;
+		const ctx = canvas.getContext("2d")!;
+		ctx.putImageData(imageData, 0, 0);
+		return new Promise((resolve) => {
+			canvas.toBlob(
+				(blob) => {
+					resolve(blob!);
+				},
+				type,
+				quality,
+			);
+		});
+	}
+
+	/**
+	 * Creates an ImageBitmap object from the current contents of this render target.
+	 * @returns a Promise resolving to an ImageBitmap
+	 */
+	toImageBitmap(): Promise<ImageBitmap> {
+		const imageData = this.getImageData();
+		return globalThis.createImageBitmap(imageData);
+	}
+
+	/**
+	 * Returns a data URL containing a representation of the current contents.
+	 * @param type - a string indicating the image format (default "image/png")
+	 * @param quality - a number between 0 and 1 for lossy formats (e.g. image/jpeg)
+	 * @returns a Promise resolving to a data URL string
+	 */
+	toDataURL(type = "image/png", quality?: number): Promise<string> {
+		return this.toBlob(type, quality).then((blob) => {
+			const reader = new FileReader();
+			return new Promise<string>((resolve) => {
+				reader.onloadend = () => {
+					resolve(reader.result as string);
+				};
+				reader.readAsDataURL(blob);
+			});
+		});
+	}
+}

--- a/packages/melonjs/src/video/rendertarget/webglrendertarget.js
+++ b/packages/melonjs/src/video/rendertarget/webglrendertarget.js
@@ -1,16 +1,20 @@
+import RenderTarget from "./rendertarget.ts";
+
 /**
  * A WebGL Framebuffer Object (FBO) render target for offscreen rendering.
  * Used by the post-processing pipeline to render a camera's output to a texture,
  * which can then be drawn to the screen through a post-process shader.
+ * @augments RenderTarget
  * @ignore
  */
-export default class WebGLRenderTarget {
+export default class WebGLRenderTarget extends RenderTarget {
 	/**
 	 * @param {WebGLRenderingContext|WebGL2RenderingContext} gl - the WebGL context
 	 * @param {number} width - initial width in pixels
 	 * @param {number} height - initial height in pixels
 	 */
 	constructor(gl, width, height) {
+		super();
 		this.gl = gl;
 		this.width = width;
 		this.height = height;
@@ -18,8 +22,10 @@ export default class WebGLRenderTarget {
 		// create framebuffer
 		this.framebuffer = gl.createFramebuffer();
 
-		// create color texture
+		// create color texture — use TEXTURE0 explicitly to avoid corrupting
+		// other texture units that the multi-texture batcher may have active
 		this.texture = gl.createTexture();
+		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, this.texture);
 		gl.texImage2D(
 			gl.TEXTURE_2D,
@@ -119,7 +125,9 @@ export default class WebGLRenderTarget {
 		this.width = width;
 		this.height = height;
 
-		// resize color texture
+		// resize color texture — use TEXTURE0 explicitly to avoid corrupting
+		// other texture units that the multi-texture batcher may have active
+		gl.activeTexture(gl.TEXTURE0);
 		gl.bindTexture(gl.TEXTURE_2D, this.texture);
 		gl.texImage2D(
 			gl.TEXTURE_2D,
@@ -144,6 +152,17 @@ export default class WebGLRenderTarget {
 
 		gl.bindTexture(gl.TEXTURE_2D, null);
 		gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+	}
+
+	/**
+	 * Clear the FBO contents to transparent black.
+	 */
+	clear() {
+		const gl = this.gl;
+		this.bind();
+		gl.clearColor(0, 0, 0, 0);
+		gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+		this.unbind();
 	}
 
 	/**
@@ -176,75 +195,6 @@ export default class WebGLRenderTarget {
 			pixels.set(temp, bottomOffset);
 		}
 		return new ImageData(pixels, width, height);
-	}
-
-	/**
-	 * Creates a Blob object representing the image contained in this render target.
-	 * @param {string} [type="image/png"] - A string indicating the image format
-	 * @param {number} [quality] - A number between 0 and 1 for lossy formats (image/jpeg, image/webp)
-	 * @returns {Promise<Blob>} A Promise resolving to a Blob
-	 */
-	toBlob(type = "image/png", quality) {
-		const imageData = this.getImageData();
-		if (typeof OffscreenCanvas !== "undefined") {
-			const canvas = new OffscreenCanvas(this.width, this.height);
-			const ctx = canvas.getContext("2d");
-			ctx.putImageData(imageData, 0, 0);
-			return canvas.convertToBlob({ type, quality });
-		}
-		// fallback for environments without OffscreenCanvas
-		const canvas = document.createElement("canvas");
-		canvas.width = this.width;
-		canvas.height = this.height;
-		const ctx = canvas.getContext("2d");
-		ctx.putImageData(imageData, 0, 0);
-		return new Promise((resolve) => {
-			canvas.toBlob(
-				(blob) => {
-					resolve(blob);
-				},
-				type,
-				quality,
-			);
-		});
-	}
-
-	/**
-	 * Creates an ImageBitmap object from the current contents of this render target.
-	 * @returns {Promise<ImageBitmap>} A Promise resolving to an ImageBitmap
-	 */
-	toImageBitmap() {
-		const imageData = this.getImageData();
-		return globalThis.createImageBitmap(imageData);
-	}
-
-	/**
-	 * Returns a data URL containing a representation of the current contents of this render target.
-	 * @param {string} [type="image/png"] - A string indicating the image format
-	 * @param {number} [quality] - A number between 0 and 1 for lossy formats (image/jpeg, image/webp)
-	 * @returns {Promise<string>} A Promise resolving to a data URL string
-	 */
-	toDataURL(type = "image/png", quality) {
-		return this.toBlob(type, quality).then((blob) => {
-			const reader = new FileReader();
-			return new Promise((resolve) => {
-				reader.onloadend = () => {
-					resolve(reader.result);
-				};
-				reader.readAsDataURL(blob);
-			});
-		});
-	}
-
-	/**
-	 * Clear the FBO contents to transparent black.
-	 */
-	clear() {
-		const gl = this.gl;
-		this.bind();
-		gl.clearColor(0, 0, 0, 0);
-		gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
-		this.unbind();
 	}
 
 	/**

--- a/packages/melonjs/src/video/webgl/webgl_renderer.js
+++ b/packages/melonjs/src/video/webgl/webgl_renderer.js
@@ -497,6 +497,7 @@ export default class WebGLRenderer extends Renderer {
 			return fx.enabled !== false;
 		});
 		if (effects.length === 0) {
+			this.customShader = undefined;
 			return false;
 		}
 		// single effect on non-managed renderable: fast path via customShader (no FBO)
@@ -504,6 +505,9 @@ export default class WebGLRenderer extends Renderer {
 			this.customShader = effects[0];
 			return false;
 		}
+
+		// multi-pass FBO path: clear customShader so children render with default shader
+		this.customShader = undefined;
 
 		const isCamera = renderable._postEffectManaged;
 		const canvas = this.getCanvas();

--- a/packages/melonjs/src/video/webgl/webgl_renderer.js
+++ b/packages/melonjs/src/video/webgl/webgl_renderer.js
@@ -11,7 +11,8 @@ import {
 } from "../../system/event.ts";
 import { Gradient } from "../gradient.js";
 import Renderer from "./../renderer.js";
-import WebGLRenderTarget from "./../rendertarget/webglrendertarget.js";
+import RenderTargetPool from "../rendertarget/render_target_pool.js";
+import WebGLRenderTarget from "../rendertarget/webglrendertarget.js";
 import { createAtlas, TextureAtlas } from "./../texture/atlas.js";
 import TextureCache from "./../texture/cache.js";
 import { dashPath, dashSegments } from "../utils/dash.js";
@@ -86,7 +87,17 @@ export default class WebGLRenderer extends Renderer {
 		 * @type {WebGLRenderTarget|null}
 		 * @ignore
 		 */
-		this.currentEffectFBO = null;
+		// initialize the render target pool with a WebGL factory
+		this._renderTargetPool = new RenderTargetPool((w, h) => {
+			return new WebGLRenderTarget(this.gl, w, h);
+		});
+
+		/**
+		 * Saved projection matrix for begin/endPostEffect.
+		 * @type {Matrix3d}
+		 * @ignore
+		 */
+		this._savedEffectProjection = new Matrix3d();
 
 		/**
 		 * sets or returns the thickness of lines for shape drawing
@@ -236,6 +247,7 @@ export default class WebGLRenderer extends Renderer {
 		on(CANVAS_ONRESIZE, (width, height) => {
 			this.flush();
 			this.setViewport(0, 0, width, height);
+			// FBOs are lazily resized in beginPostEffect via get() → resize()
 		});
 	}
 
@@ -351,11 +363,8 @@ export default class WebGLRenderer extends Renderer {
 		this.gl.disable(this.gl.SCISSOR_TEST);
 		this._scissorActive = false;
 
-		// release post-process FBO (will be recreated on demand)
-		if (this.currentEffectFBO) {
-			this.currentEffectFBO.destroy();
-			this.currentEffectFBO = null;
-		}
+		// release post-process FBOs (will be recreated on demand)
+		this._renderTargetPool.destroy();
 	}
 
 	/**
@@ -478,66 +487,142 @@ export default class WebGLRenderer extends Renderer {
 
 	/**
 	 * Begin capturing rendering to an offscreen FBO for post-effect processing.
-	 * Returns true if post-effect processing is active (camera has a valid shader).
-	 * @param {Camera2d} camera - the camera requesting post-effect processing
+	 * @param {Renderable} renderable - the renderable requesting post-effect processing
 	 * @returns {boolean} true if FBO capture started, false if skipped
 	 * @ignore
 	 */
-	beginPostEffect(camera) {
-		if (!camera.shader || camera.shader.enabled === false) {
+	beginPostEffect(renderable) {
+		// filter to only enabled effects
+		const effects = renderable.postEffects.filter((fx) => {
+			return fx.enabled !== false;
+		});
+		if (effects.length === 0) {
 			return false;
 		}
-		const canvas = this.getCanvas();
-		if (!this.currentEffectFBO) {
-			this.currentEffectFBO = new WebGLRenderTarget(
-				this.gl,
-				canvas.width,
-				canvas.height,
-			);
-		} else {
-			this.currentEffectFBO.resize(canvas.width, canvas.height);
+		// single effect on non-managed renderable: fast path via customShader (no FBO)
+		if (effects.length === 1 && !renderable._postEffectManaged) {
+			this.customShader = effects[0];
+			return false;
 		}
+
+		const isCamera = renderable._postEffectManaged;
+		const canvas = this.getCanvas();
+		const w = canvas.width;
+		const h = canvas.height;
+
+		// flush pending draws BEFORE creating/resizing FBOs,
+		// since FBO construction temporarily changes GL framebuffer bindings
 		this.flush();
-		// save renderer state before modifying it for FBO rendering
 		this.save();
-		this.currentEffectFBO.bind();
-		this.gl.disable(this.gl.SCISSOR_TEST);
-		this._scissorActive = false;
+		// save the current projection (not part of the render state stack)
+		this._savedEffectProjection.copy(this.projectionMatrix);
+
+		const rt = this._renderTargetPool.begin(isCamera, effects.length, w, h);
+		// FBO creation/resize uses TEXTURE0 — invalidate the batcher's cache for that unit
+		if (this.currentBatcher && this.currentBatcher.boundTextures) {
+			delete this.currentBatcher.boundTextures[0];
+		}
+		rt.bind();
+		this.setViewport(0, 0, w, h);
+		this.disableScissor();
 		this.setGlobalAlpha(1.0);
 		this.setBlendMode("normal");
-		this.clear();
+
+		if (isCamera) {
+			this.clear();
+		} else {
+			this.clearRenderTarget();
+		}
 		return true;
 	}
 
 	/** @ignore */
-	endPostEffect(camera) {
-		if (!camera.shader || camera.shader.enabled === false) {
+	endPostEffect(renderable) {
+		// filter to only enabled effects
+		const effects = renderable.postEffects.filter((fx) => {
+			return fx.enabled !== false;
+		});
+		if (effects.length === 0) {
 			return;
 		}
+		// single effect on non-managed renderable used customShader — no FBO to unbind
+		if (effects.length === 1 && !renderable._postEffectManaged) {
+			return;
+		}
+
+		const isCamera = renderable._postEffectManaged;
+		const rt1 = this._renderTargetPool.getCaptureTarget();
+		const rt2 = this._renderTargetPool.getPingPongTarget();
+		const keepBlend = !isCamera;
+		const canvas = this.getCanvas();
+		const w = canvas.width;
+		const h = canvas.height;
+
 		this.flush();
-		this.currentEffectFBO.unbind();
-		if (!camera.isDefault) {
+		rt1.unbind();
+
+		// get parent render target for rebinding after blits
+		const parentRT = this._renderTargetPool.end();
+
+		// clip to camera viewport for non-default cameras
+		if (isCamera && renderable.isDefault === false) {
 			this.clipRect(
-				camera.screenX,
-				camera.screenY,
-				camera.width,
-				camera.height,
+				renderable.screenX,
+				renderable.screenY,
+				renderable.width,
+				renderable.height,
 			);
 		}
-		this.blitEffect(
-			this.currentEffectFBO.texture,
-			0,
-			0,
-			this.width,
-			this.height,
-			camera.shader,
-		);
-		if (!camera.isDefault) {
-			this.gl.disable(this.gl.SCISSOR_TEST);
-			this._scissorActive = false;
+
+		// rebind parent render target (or screen) and restore viewport
+		if (parentRT) {
+			parentRT.bind();
 		}
-		// restore renderer state saved in beginPostEffect
+		this.setViewport(0, 0, w, h);
+
+		if (effects.length === 1) {
+			this.blitEffect(rt1.texture, 0, 0, w, h, effects[0], keepBlend);
+		} else {
+			// multi-pass: ping-pong between two render targets
+			let src = rt1;
+			let dst = rt2;
+
+			for (let i = 0; i < effects.length - 1; i++) {
+				dst.bind();
+				this.setViewport(0, 0, w, h);
+				this.clearRenderTarget();
+				this.blitEffect(src.texture, 0, 0, w, h, effects[i]);
+				dst.unbind();
+				const tmp = src;
+				src = dst;
+				dst = tmp;
+			}
+
+			// rebind parent for final blit
+			if (parentRT) {
+				parentRT.bind();
+			}
+			this.setViewport(0, 0, w, h);
+
+			this.blitEffect(
+				src.texture,
+				0,
+				0,
+				w,
+				h,
+				effects[effects.length - 1],
+				keepBlend,
+			);
+		}
+
+		if (isCamera && renderable.isDefault === false) {
+			this.disableScissor();
+		}
+
+		// restore renderer state and projection saved in beginPostEffect
 		this.restore();
+		this.projectionMatrix.copy(this._savedEffectProjection);
+		this.currentBatcher.setProjection(this.projectionMatrix);
 	}
 
 	/**
@@ -550,10 +635,9 @@ export default class WebGLRenderer extends Renderer {
 	 * @param {number} width - destination width
 	 * @param {number} height - destination height
 	 * @param {ShaderEffect} shader - the shader effect to apply
+	 * @param {boolean} [keepBlend=false] - if true, keep current blend mode (for sprite compositing)
 	 */
-	blitEffect(source, x, y, width, height, shader) {
-		const gl = this.gl;
-
+	blitEffect(source, x, y, width, height, shader, keepBlend = false) {
 		// flush any pending draws
 		this.flush();
 
@@ -567,11 +651,15 @@ export default class WebGLRenderer extends Renderer {
 		this.projectionMatrix.ortho(0, width, height, 0, -1, 1);
 		batcher.setProjection(this.projectionMatrix);
 
-		// blit the FBO without alpha blending — the FBO already contains
-		// the fully composited scene (particles, additive blend, etc.)
-		gl.disable(gl.BLEND);
+		// disable blending for camera blits (render target is fully composited).
+		// keep blending for per-sprite blits (transparent areas must not overwrite scene).
+		if (!keepBlend) {
+			this.setBlendEnabled(false);
+		}
 		batcher.blitTexture(source, x, y, width, height, shader);
-		gl.enable(gl.BLEND);
+		if (!keepBlend) {
+			this.setBlendEnabled(true);
+		}
 
 		// restore state
 		this.currentTransform.copy(_savedTransform);
@@ -604,6 +692,59 @@ export default class WebGLRenderer extends Renderer {
 		h = this.getCanvas().height,
 	) {
 		this.gl.viewport(x, y, w, h);
+	}
+
+	/**
+	 * Clear the current render target to transparent black (color + stencil).
+	 */
+	clearRenderTarget() {
+		const gl = this.gl;
+		gl.clearColor(0, 0, 0, 0);
+		gl.clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+	}
+
+	/**
+	 * Enable the scissor test with the given rectangle.
+	 * @param {number} x - x coordinate of the scissor rectangle
+	 * @param {number} y - y coordinate of the scissor rectangle
+	 * @param {number} width - width of the scissor rectangle
+	 * @param {number} height - height of the scissor rectangle
+	 */
+	enableScissor(x, y, width, height) {
+		const gl = this.gl;
+		this.flush();
+		gl.enable(gl.SCISSOR_TEST);
+		this._scissorActive = true;
+		gl.scissor(
+			x + this.currentTransform.tx,
+			this.getCanvas().height - height - y - this.currentTransform.ty,
+			width,
+			height,
+		);
+		this.currentScissor[0] = x;
+		this.currentScissor[1] = y;
+		this.currentScissor[2] = width;
+		this.currentScissor[3] = height;
+	}
+
+	/**
+	 * Disable the scissor test, allowing rendering to the full viewport.
+	 */
+	disableScissor() {
+		this.gl.disable(this.gl.SCISSOR_TEST);
+		this._scissorActive = false;
+	}
+
+	/**
+	 * Enable or disable alpha blending.
+	 * @param {boolean} enable - true to enable blending, false to disable
+	 */
+	setBlendEnabled(enable) {
+		if (enable) {
+			this.gl.enable(this.gl.BLEND);
+		} else {
+			this.gl.disable(this.gl.BLEND);
+		}
 	}
 
 	/**

--- a/packages/melonjs/tests/renderTarget.spec.js
+++ b/packages/melonjs/tests/renderTarget.spec.js
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { boot, video } from "../src/index.js";
+import CanvasRenderTarget from "../src/video/rendertarget/canvasrendertarget.js";
+import RenderTarget from "../src/video/rendertarget/rendertarget.ts";
+import WebGLRenderTarget from "../src/video/rendertarget/webglrendertarget.js";
+
+describe("RenderTarget", () => {
+	describe("CanvasRenderTarget", () => {
+		it("should extend RenderTarget", () => {
+			const rt = new CanvasRenderTarget(100, 100);
+			expect(rt).toBeInstanceOf(RenderTarget);
+			expect(rt).toBeInstanceOf(CanvasRenderTarget);
+		});
+
+		it("should have correct width and height", () => {
+			const rt = new CanvasRenderTarget(200, 150);
+			expect(rt.width).toEqual(200);
+			expect(rt.height).toEqual(150);
+		});
+
+		it("should resize", () => {
+			const rt = new CanvasRenderTarget(100, 100);
+			rt.resize(300, 200);
+			expect(rt.width).toEqual(300);
+			expect(rt.height).toEqual(200);
+		});
+
+		it("should clear without error", () => {
+			const rt = new CanvasRenderTarget(100, 100);
+			expect(() => {
+				rt.clear();
+			}).not.toThrow();
+		});
+
+		it("bind and unbind should be no-ops", () => {
+			const rt = new CanvasRenderTarget(100, 100);
+			expect(() => {
+				rt.bind();
+				rt.unbind();
+			}).not.toThrow();
+		});
+
+		it("should return valid ImageData from getImageData", () => {
+			const rt = new CanvasRenderTarget(50, 50);
+			const data = rt.getImageData(0, 0, 50, 50);
+			expect(data).toBeInstanceOf(ImageData);
+			expect(data.width).toEqual(50);
+			expect(data.height).toEqual(50);
+		});
+
+		it("should destroy without error", () => {
+			const rt = new CanvasRenderTarget(100, 100);
+			expect(() => {
+				rt.destroy();
+			}).not.toThrow();
+			expect(rt.canvas).toBeUndefined();
+			expect(rt.context).toBeUndefined();
+		});
+	});
+
+	describe("WebGLRenderTarget", () => {
+		let gl;
+
+		beforeEach(() => {
+			boot();
+			video.init(100, 100, {
+				parent: "screen",
+				scale: "auto",
+				renderer: video.WEBGL,
+			});
+			gl = video.renderer.gl;
+		});
+
+		it("should extend RenderTarget", () => {
+			if (!gl) {
+				return;
+			}
+			const rt = new WebGLRenderTarget(gl, 100, 100);
+			expect(rt).toBeInstanceOf(RenderTarget);
+			expect(rt).toBeInstanceOf(WebGLRenderTarget);
+			rt.destroy();
+		});
+
+		it("should have correct width and height", () => {
+			if (!gl) {
+				return;
+			}
+			const rt = new WebGLRenderTarget(gl, 200, 150);
+			expect(rt.width).toEqual(200);
+			expect(rt.height).toEqual(150);
+			rt.destroy();
+		});
+
+		it("should create valid framebuffer and texture", () => {
+			if (!gl) {
+				return;
+			}
+			const rt = new WebGLRenderTarget(gl, 100, 100);
+			expect(rt.framebuffer).toBeDefined();
+			expect(rt.texture).toBeDefined();
+			expect(rt.depthStencilBuffer).toBeDefined();
+			rt.destroy();
+		});
+
+		it("should bind and unbind", () => {
+			if (!gl) {
+				return;
+			}
+			const rt = new WebGLRenderTarget(gl, 100, 100);
+			rt.bind();
+			expect(gl.getParameter(gl.FRAMEBUFFER_BINDING)).toBe(rt.framebuffer);
+			rt.unbind();
+			expect(gl.getParameter(gl.FRAMEBUFFER_BINDING)).toBeNull();
+			rt.destroy();
+		});
+
+		it("should resize", () => {
+			if (!gl) {
+				return;
+			}
+			const rt = new WebGLRenderTarget(gl, 100, 100);
+			rt.resize(200, 200);
+			expect(rt.width).toEqual(200);
+			expect(rt.height).toEqual(200);
+			rt.destroy();
+		});
+
+		it("should skip resize when dimensions unchanged", () => {
+			if (!gl) {
+				return;
+			}
+			const rt = new WebGLRenderTarget(gl, 100, 100);
+			const texture = rt.texture;
+			rt.resize(100, 100);
+			// texture should be the same object (no reallocation)
+			expect(rt.texture).toBe(texture);
+			rt.destroy();
+		});
+
+		it("should clear without error", () => {
+			if (!gl) {
+				return;
+			}
+			const rt = new WebGLRenderTarget(gl, 100, 100);
+			expect(() => {
+				rt.clear();
+			}).not.toThrow();
+			rt.destroy();
+		});
+
+		it("should return valid ImageData from getImageData", () => {
+			if (!gl) {
+				return;
+			}
+			const rt = new WebGLRenderTarget(gl, 50, 50);
+			const data = rt.getImageData(0, 0, 50, 50);
+			expect(data).toBeInstanceOf(ImageData);
+			expect(data.width).toEqual(50);
+			expect(data.height).toEqual(50);
+			rt.destroy();
+		});
+
+		it("should destroy and null out resources", () => {
+			if (!gl) {
+				return;
+			}
+			const rt = new WebGLRenderTarget(gl, 100, 100);
+			rt.destroy();
+			expect(rt.framebuffer).toBeNull();
+			expect(rt.texture).toBeNull();
+			expect(rt.depthStencilBuffer).toBeNull();
+		});
+	});
+});

--- a/packages/melonjs/tests/renderTargetPool.spec.js
+++ b/packages/melonjs/tests/renderTargetPool.spec.js
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { boot, video } from "../src/index.js";
+
+import RenderTargetPool from "../src/video/rendertarget/render_target_pool.js";
+import WebGLRenderTarget from "../src/video/rendertarget/webglrendertarget.js";
+
+describe("RenderTargetPool", () => {
+	let pool;
+
+	// simple mock factory for unit tests (no GL context needed)
+	const mockFactory = (w, h) => {
+		return {
+			width: w,
+			height: h,
+			resize(nw, nh) {
+				this.width = nw;
+				this.height = nh;
+			},
+			destroy() {},
+		};
+	};
+
+	beforeEach(() => {
+		pool = new RenderTargetPool(mockFactory);
+	});
+
+	describe("constructor", () => {
+		it("should start with an empty pool", () => {
+			expect(pool._pool).toHaveLength(0);
+		});
+
+		it("should default activeBase to -1", () => {
+			expect(pool._activeBase).toEqual(-1);
+		});
+	});
+
+	describe("begin()", () => {
+		it("should set activeBase to 0 for camera", () => {
+			pool.begin(true, 1, 100, 100);
+			expect(pool._activeBase).toEqual(0);
+		});
+
+		it("should set activeBase to 2 for sprites", () => {
+			pool.begin(false, 1, 100, 100);
+			expect(pool._activeBase).toEqual(2);
+		});
+
+		it("should create render target via factory", () => {
+			const rt = pool.begin(true, 1, 200, 150);
+			expect(rt).toBeDefined();
+			expect(rt.width).toEqual(200);
+			expect(rt.height).toEqual(150);
+		});
+
+		it("should create ping-pong target when effectCount > 1", () => {
+			pool.begin(true, 2, 100, 100);
+			expect(pool.getCaptureTarget()).toBeDefined();
+			expect(pool.getPingPongTarget()).toBeDefined();
+			expect(pool.getPingPongTarget()).not.toBe(pool.getCaptureTarget());
+		});
+
+		it("should not create ping-pong target for single effect", () => {
+			pool.begin(true, 1, 100, 100);
+			expect(pool.getCaptureTarget()).toBeDefined();
+			expect(pool.getPingPongTarget()).toBeUndefined();
+		});
+	});
+
+	describe("getCaptureTarget / getPingPongTarget", () => {
+		it("should return undefined when no active pass", () => {
+			expect(pool.getCaptureTarget()).toBeUndefined();
+			expect(pool.getPingPongTarget()).toBeUndefined();
+		});
+
+		it("should return the correct pool index for camera", () => {
+			pool._activeBase = 0;
+			pool._pool[0] = { id: "capture-cam" };
+			pool._pool[1] = { id: "pingpong-cam" };
+
+			expect(pool.getCaptureTarget()).toEqual({ id: "capture-cam" });
+			expect(pool.getPingPongTarget()).toEqual({ id: "pingpong-cam" });
+		});
+
+		it("should return the correct pool index for sprite", () => {
+			pool._activeBase = 2;
+			pool._pool[2] = { id: "capture-sprite" };
+			pool._pool[3] = { id: "pingpong-sprite" };
+
+			expect(pool.getCaptureTarget()).toEqual({ id: "capture-sprite" });
+			expect(pool.getPingPongTarget()).toEqual({ id: "pingpong-sprite" });
+		});
+
+		it("camera and sprite targets should be independent", () => {
+			pool._pool[0] = { id: "cam0" };
+			pool._pool[1] = { id: "cam1" };
+			pool._pool[2] = { id: "spr0" };
+			pool._pool[3] = { id: "spr1" };
+
+			pool._activeBase = 0;
+			expect(pool.getCaptureTarget().id).toEqual("cam0");
+
+			pool._activeBase = 2;
+			expect(pool.getCaptureTarget().id).toEqual("spr0");
+
+			// camera targets still intact
+			pool._activeBase = 0;
+			expect(pool.getCaptureTarget().id).toEqual("cam0");
+		});
+	});
+
+	describe("end()", () => {
+		it("should restore previous activeBase", () => {
+			pool.begin(true, 1, 100, 100);
+			pool.begin(false, 1, 100, 100);
+			expect(pool._activeBase).toEqual(2);
+
+			const parent = pool.end();
+			expect(pool._activeBase).toEqual(0);
+			expect(parent).toBe(pool._pool[0]);
+		});
+
+		it("should return null when no parent", () => {
+			pool.begin(true, 1, 100, 100);
+			const parent = pool.end();
+			expect(parent).toBeNull();
+		});
+	});
+
+	describe("destroy()", () => {
+		it("should call destroy on all targets", () => {
+			let destroyCount = 0;
+			pool._pool = [
+				{
+					destroy() {
+						destroyCount++;
+					},
+				},
+				{
+					destroy() {
+						destroyCount++;
+					},
+				},
+				null,
+				{
+					destroy() {
+						destroyCount++;
+					},
+				},
+			];
+
+			pool.destroy();
+			expect(destroyCount).toEqual(3);
+			expect(pool._pool).toHaveLength(0);
+		});
+
+		it("should handle empty pool", () => {
+			pool.destroy();
+			expect(pool._pool).toHaveLength(0);
+		});
+	});
+
+	describe("with WebGL context", () => {
+		it("should work with WebGLRenderTarget factory", () => {
+			boot();
+			video.init(100, 100, {
+				parent: "screen",
+				scale: "auto",
+				renderer: video.WEBGL,
+			});
+
+			if (!video.renderer.gl) {
+				return;
+			}
+
+			const gl = video.renderer.gl;
+			const glPool = new RenderTargetPool((w, h) => {
+				return new WebGLRenderTarget(gl, w, h);
+			});
+
+			const capture = glPool.begin(true, 2, 100, 100);
+			expect(capture).toBeDefined();
+			expect(capture.width).toEqual(100);
+			expect(capture.framebuffer).toBeDefined();
+			expect(glPool.getCaptureTarget()).toBe(capture);
+			expect(glPool.getPingPongTarget()).toBeDefined();
+			expect(glPool.getPingPongTarget()).not.toBe(capture);
+
+			glPool.destroy();
+		});
+
+		it("should reuse target on subsequent get at same index", () => {
+			boot();
+			video.init(100, 100, {
+				parent: "screen",
+				scale: "auto",
+				renderer: video.WEBGL,
+			});
+
+			if (!video.renderer.gl) {
+				return;
+			}
+
+			const gl = video.renderer.gl;
+			const glPool = new RenderTargetPool((w, h) => {
+				return new WebGLRenderTarget(gl, w, h);
+			});
+
+			const rt1 = glPool.get(0, 100, 100);
+			const rt2 = glPool.get(0, 100, 100);
+			expect(rt2).toBe(rt1);
+
+			glPool.destroy();
+		});
+
+		it("should resize target when dimensions change", () => {
+			boot();
+			video.init(100, 100, {
+				parent: "screen",
+				scale: "auto",
+				renderer: video.WEBGL,
+			});
+
+			if (!video.renderer.gl) {
+				return;
+			}
+
+			const gl = video.renderer.gl;
+			const glPool = new RenderTargetPool((w, h) => {
+				return new WebGLRenderTarget(gl, w, h);
+			});
+
+			const rt = glPool.get(0, 100, 100);
+			expect(rt.width).toEqual(100);
+
+			glPool.get(0, 200, 200);
+			expect(rt.width).toEqual(200);
+			expect(rt.height).toEqual(200);
+
+			glPool.destroy();
+		});
+	});
+});

--- a/packages/melonjs/tests/renderable.spec.js
+++ b/packages/melonjs/tests/renderable.spec.js
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { Container, Renderable } from "../src/index.js";
+import { boot, Container, Renderable, video } from "../src/index.js";
 
 describe("Renderable", () => {
 	describe("bounds updates", () => {
@@ -113,6 +113,285 @@ describe("Renderable", () => {
 			childContainer.floating = false;
 			renderable.floating = true;
 			expect(renderable.isFloating).toEqual(true);
+		});
+	});
+
+	describe("postEffects", () => {
+		let renderable;
+		beforeEach(() => {
+			renderable = new Renderable(0, 0, 100, 100);
+		});
+
+		it("should start with an empty postEffects array", () => {
+			expect(renderable.postEffects).toEqual([]);
+		});
+
+		it("addPostEffect should add and return the effect", () => {
+			const effect = { enabled: true };
+			const result = renderable.addPostEffect(effect);
+			expect(result).toBe(effect);
+			expect(renderable.postEffects).toHaveLength(1);
+			expect(renderable.postEffects[0]).toBe(effect);
+		});
+
+		it("addPostEffect should support multiple effects", () => {
+			const a = { enabled: true };
+			const b = { enabled: true };
+			renderable.addPostEffect(a);
+			renderable.addPostEffect(b);
+			expect(renderable.postEffects).toHaveLength(2);
+			expect(renderable.postEffects[0]).toBe(a);
+			expect(renderable.postEffects[1]).toBe(b);
+		});
+
+		it("getPostEffect with class should find by instanceof", () => {
+			class EffectA {
+				constructor() {
+					this.enabled = true;
+				}
+			}
+			class EffectB {
+				constructor() {
+					this.enabled = true;
+				}
+			}
+			const a = new EffectA();
+			const b = new EffectB();
+			renderable.addPostEffect(a);
+			renderable.addPostEffect(b);
+			expect(renderable.getPostEffect(EffectA)).toBe(a);
+			expect(renderable.getPostEffect(EffectB)).toBe(b);
+		});
+
+		it("getPostEffect with class should return undefined if not found", () => {
+			class EffectA {
+				constructor() {
+					this.enabled = true;
+				}
+			}
+			expect(renderable.getPostEffect(EffectA)).toBeUndefined();
+		});
+
+		it("getPostEffect without args should return the full array", () => {
+			const a = { enabled: true };
+			renderable.addPostEffect(a);
+			const result = renderable.getPostEffect();
+			expect(result).toBe(renderable.postEffects);
+			expect(result).toHaveLength(1);
+		});
+
+		it("removePostEffect should remove the effect", () => {
+			const a = { enabled: true };
+			const b = { enabled: true };
+			renderable.addPostEffect(a);
+			renderable.addPostEffect(b);
+			renderable.removePostEffect(a);
+			expect(renderable.postEffects).toHaveLength(1);
+			expect(renderable.postEffects[0]).toBe(b);
+		});
+
+		it("removePostEffect should call destroy if available", () => {
+			let destroyed = false;
+			const effect = {
+				enabled: true,
+				destroy() {
+					destroyed = true;
+				},
+			};
+			renderable.addPostEffect(effect);
+			renderable.removePostEffect(effect);
+			expect(destroyed).toEqual(true);
+		});
+
+		it("removePostEffect should be a no-op for unknown effects", () => {
+			const a = { enabled: true };
+			const b = { enabled: true };
+			renderable.addPostEffect(a);
+			renderable.removePostEffect(b);
+			expect(renderable.postEffects).toHaveLength(1);
+		});
+
+		it("direct array assignment should work", () => {
+			const a = { enabled: true };
+			const b = { enabled: true };
+			renderable.postEffects = [a, b];
+			expect(renderable.postEffects).toHaveLength(2);
+			expect(renderable.postEffects[0]).toBe(a);
+		});
+	});
+
+	describe("shader (deprecated getter/setter)", () => {
+		let renderable;
+		beforeEach(() => {
+			renderable = new Renderable(0, 0, 100, 100);
+		});
+
+		it("shader getter should return postEffects[0]", () => {
+			const effect = { enabled: true };
+			renderable.postEffects = [effect];
+			expect(renderable.shader).toBe(effect);
+		});
+
+		it("shader getter should return undefined when no effects", () => {
+			expect(renderable.shader).toBeUndefined();
+		});
+
+		it("shader setter should set postEffects to [value]", () => {
+			const effect = { enabled: true };
+			renderable.shader = effect;
+			expect(renderable.postEffects).toHaveLength(1);
+			expect(renderable.postEffects[0]).toBe(effect);
+		});
+
+		it("shader setter with undefined should clear postEffects", () => {
+			renderable.addPostEffect({ enabled: true });
+			renderable.addPostEffect({ enabled: true });
+			renderable.shader = undefined;
+			expect(renderable.postEffects).toHaveLength(0);
+		});
+
+		it("shader setter should replace all existing effects", () => {
+			renderable.addPostEffect({ enabled: true, id: 1 });
+			renderable.addPostEffect({ enabled: true, id: 2 });
+			const newEffect = { enabled: true, id: 3 };
+			renderable.shader = newEffect;
+			expect(renderable.postEffects).toHaveLength(1);
+			expect(renderable.postEffects[0]).toBe(newEffect);
+		});
+	});
+
+	describe("destroy cleans up postEffects", () => {
+		it("should destroy all effects on renderable destroy", () => {
+			const renderable = new Renderable(0, 0, 100, 100);
+			let destroyCount = 0;
+			renderable.addPostEffect({
+				enabled: true,
+				destroy() {
+					destroyCount++;
+				},
+			});
+			renderable.addPostEffect({
+				enabled: true,
+				destroy() {
+					destroyCount++;
+				},
+			});
+			renderable.destroy();
+			expect(destroyCount).toEqual(2);
+			expect(renderable.postEffects).toHaveLength(0);
+		});
+	});
+
+	describe("postEffect pipeline integration", () => {
+		const setup = () => {
+			boot();
+			video.init(800, 600, {
+				parent: "screen",
+				scale: "auto",
+				renderer: video.CANVAS,
+			});
+		};
+
+		it("preDraw with single effect should set customShader", () => {
+			setup();
+			const renderer = video.renderer;
+			const renderable = new Renderable(0, 0, 100, 100);
+			const effect = { enabled: true };
+			renderable.addPostEffect(effect);
+
+			renderable.preDraw(renderer);
+			expect(renderer.customShader).toBe(effect);
+			renderable.postDraw(renderer);
+		});
+
+		it("preDraw with no effects should not set customShader", () => {
+			setup();
+			const renderer = video.renderer;
+			const renderable = new Renderable(0, 0, 100, 100);
+
+			renderable.preDraw(renderer);
+			expect(renderer.customShader).toBeUndefined();
+			renderable.postDraw(renderer);
+		});
+
+		it("preDraw/postDraw should not leak customShader state", () => {
+			setup();
+			const renderer = video.renderer;
+			const renderable = new Renderable(0, 0, 100, 100);
+			const effect = { enabled: true };
+			renderable.addPostEffect(effect);
+
+			renderable.preDraw(renderer);
+			// during draw, customShader should be set (single-effect fast path)
+			expect(renderer.customShader).toBe(effect);
+			renderable.postDraw(renderer);
+			// after postDraw's restore(), customShader should be cleared
+			expect(renderer.customShader).toBeUndefined();
+		});
+
+		it("disabled single effect should not be set as customShader", () => {
+			setup();
+			const renderer = video.renderer;
+			const renderable = new Renderable(0, 0, 100, 100);
+			renderable.addPostEffect({ enabled: false });
+
+			renderable.preDraw(renderer);
+			// disabled effect should not set customShader
+			expect(renderer.customShader).toBeUndefined();
+			renderable.postDraw(renderer);
+			expect(renderer.customShader).toBeUndefined();
+		});
+
+		it("_postEffectManaged flag should prevent preDraw from calling beginPostEffect", () => {
+			setup();
+			const renderer = video.renderer;
+			const renderable = new Renderable(0, 0, 100, 100);
+			renderable.addPostEffect({ enabled: true });
+			renderable.addPostEffect({ enabled: true });
+
+			// simulate camera-managed mode
+			renderable._postEffectManaged = true;
+			renderable.preDraw(renderer);
+			// managed mode: beginPostEffect is NOT called from preDraw,
+			// so customShader should not be set
+			expect(renderer.customShader).toBeUndefined();
+			renderable.postDraw(renderer);
+			expect(renderer.customShader).toBeUndefined();
+			renderable._postEffectManaged = false;
+		});
+
+		it("multiple effects on renderable should trigger beginPostEffect", () => {
+			setup();
+			const renderer = video.renderer;
+			const renderable = new Renderable(0, 0, 100, 100);
+			renderable.addPostEffect({ enabled: true });
+			renderable.addPostEffect({ enabled: true });
+
+			// on Canvas renderer, beginPostEffect returns false (no-op)
+			// but the code path should be exercised without error
+			renderable.preDraw(renderer);
+			renderable.postDraw(renderer);
+		});
+
+		it("clearPostEffects should remove all and destroy", () => {
+			setup();
+			const renderable = new Renderable(0, 0, 100, 100);
+			let count = 0;
+			renderable.addPostEffect({
+				enabled: true,
+				destroy() {
+					count++;
+				},
+			});
+			renderable.addPostEffect({
+				enabled: true,
+				destroy() {
+					count++;
+				},
+			});
+			renderable.clearPostEffects();
+			expect(renderable.postEffects).toHaveLength(0);
+			expect(count).toEqual(2);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- **Multi-pass post-effects**: Replace the single `shader` property on Renderable with a `postEffects` array. Multiple effects are applied in sequence via FBO ping-pong. Single-effect renderables use a zero-overhead `customShader` fast path (no FBO). New API: `addPostEffect()`, `getPostEffect()`, `removePostEffect()`, `clearPostEffects()`. Backward-compatible `shader` getter/setter (deprecated).

- **RenderTarget abstraction**: Abstract `RenderTarget` base class with `WebGLRenderTarget` (FBO) and `CanvasRenderTarget` implementations. Renderer-agnostic `RenderTargetPool` using a factory pattern — ready for future WebGPU support.

- **Renderer-agnostic state methods**: `setViewport()`, `clearRenderTarget()`, `enableScissor()`, `disableScissor()`, `setBlendEnabled()` on the base Renderer (no-ops for Canvas), eliminating direct GL calls from the post-effect pipeline.

- **Bug fixes**: WebGL texture unit corruption during FBO resize (explicit TEXTURE0), projection matrix save/restore across effect passes, Canvas renderer customShader sync in save/restore.

Closes #1396. Per-sprite multi-pass UV issue tracked in #1407.

## Test plan

- [x] `vitest` — 196 tests pass (renderTarget, renderTargetPool, renderable, camera)
- [x] Platformer example: camera multi-pass (vignette + contrast/saturation), minimap vignette, coin glow shader, resize handling
- [x] State transitions (level reload) — FBO cleanup on GAME_RESET
- [x] CodeRabbit review — all findings addressed
- [ ] Visual regression check on other examples (lights, benchmark, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)