### PR TITLE
Add visible character control to Text and BitmapText

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Graphics
 - 3D mesh rendering with OBJ/MTL model loading, perspective projection and hardware depth testing
 - Built-in shader effects (Flash, Outline, Glow, Dissolve, CRT, Hologram, etc.) and custom shader support via `ShaderEffect` for per-sprite fragment effects (WebGL)
 - Trail renderable for fading, tapering ribbons behind moving objects (speed lines, sword slashes, magic trails)
-- System & Bitmap Text
+- System & Bitmap Text with built-in typewriter effect
 - Video sprite playback
 
 Sound

--- a/packages/examples/src/examples/text/text.ts
+++ b/packages/examples/src/examples/text/text.ts
@@ -5,6 +5,7 @@ import {
 	Renderable,
 	Stage,
 	Text,
+	Tween,
 } from "melonjs";
 
 /**
@@ -123,19 +124,29 @@ export class TextScreen extends Stage {
 			1,
 		);
 
-		// ---- Multiline text (right aligned) ----
-		app.world.addChild(
-			new Text(165, 290, {
-				font: "Arial",
-				size: 14,
-				fillStyle: "white",
-				textAlign: "right",
-				textBaseline: "top",
-				lineHeight: 1.1,
-				text: "this is another web font \nwith right alignment\nand it still works!",
-			}),
-			1,
-		);
+		// ---- Multiline text (right aligned) with typewriter ----
+		const rightText = new Text(165, 290, {
+			font: "Arial",
+			size: 14,
+			fillStyle: "white",
+			textAlign: "right",
+			textBaseline: "top",
+			lineHeight: 1.1,
+			text: "this is another web font \nwith right alignment\nusing typewriter effect!",
+		});
+		rightText.visibleCharacters = 0;
+		app.world.addChild(rightText, 1);
+
+		new Tween(rightText)
+			.to(
+				{ visibleRatio: 1.0 },
+				{
+					duration: 5000,
+					repeat: Infinity,
+					repeatDelay: 1500,
+				},
+			)
+			.start();
 
 		// ---- Fancy BitmapText multiline with word wrap ----
 		const fancy = new BitmapText(620, 230, {
@@ -151,15 +162,27 @@ export class TextScreen extends Stage {
 		);
 		app.world.addChild(fancy, 1);
 
-		// ---- BitmapText multiline centered ----
+		// ---- BitmapText multiline centered with typewriter effect ----
 		const bMulti = new BitmapText(w / 2, 400, {
 			font: "xolo12",
-			size: 2.5,
+			size: 1.5,
 			textAlign: "center",
 			textBaseline: "top",
-			text: "THIS IS A MULTILINE\n BITMAP TEXT WITH MELONJS\nAND IT WORKS",
+			text: "THIS IS A MULTILINE BITMAP TEXT\n USING TYPEWRITER EFFECT",
 		});
+		bMulti.visibleCharacters = 0;
 		app.world.addChild(bMulti, 1);
+
+		new Tween(bMulti)
+			.to(
+				{ visibleRatio: 1.0 },
+				{
+					duration: 5000,
+					repeat: Infinity,
+					repeatDelay: 1500,
+				},
+			)
+			.start();
 
 		// ---- BitmapText baseline test (y=375) ----
 		xPos = 0;

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [19.2.0] (melonJS 2) - _unreleased_
 
 ### Added
+- Text: `visibleCharacters` and `visibleRatio` properties on Text and BitmapText for progressive text reveal and typewriter effects. Animate `visibleRatio` with Tween for character-by-character text display.
+- Tween: `repeatDelay(ms)` method and `repeatDelay` option in `to()` — adds a delay before each repeat cycle.
 - Camera: FBO-based post-processing pipeline — assign a `ShaderEffect` to any camera's `shader` property to apply full-screen post-effects (vignette, scanlines, desaturation, etc.). Works with multiple cameras independently (e.g. main camera + minimap with different effects). Renderer manages FBO lifecycle via `beginPostEffect()`/`endPostEffect()`/`blitEffect()` methods.
 - Renderable: multi-pass post-effect chaining — `postEffects` array replaces single `shader` property. Multiple effects are applied in sequence via FBO ping-pong (e.g. `sprite.addPostEffect(new DesaturateEffect(r)); sprite.addPostEffect(new InvertEffect(r));`). Single-effect renderables use a zero-overhead `customShader` fast path (no FBO). Camera manages its own FBO lifecycle; per-sprite effects use a separate FBO pair.
 - Renderable: `addPostEffect(effect)`, `getPostEffect(EffectClass?)`, `removePostEffect(effect)`, `clearPostEffects()` — manage post-processing shader effects on any renderable

--- a/packages/melonjs/src/renderable/text/bitmaptext.js
+++ b/packages/melonjs/src/renderable/text/bitmaptext.js
@@ -134,20 +134,9 @@ export default class BitmapText extends Renderable {
 		}
 
 		/**
-		 * the number of characters to display (use -1 to show all).
-		 * Useful for typewriter effects combined with Tween.
-		 * @public
-		 * @type {number}
-		 * @default -1
-		 * @see BitmapText#visibleRatio
-		 * @example
-		 * // show only the first 5 characters
-		 * bitmapText.visibleCharacters = 5;
-		 * // typewriter effect
-		 * bitmapText.visibleCharacters = 0;
-		 * new Tween(bitmapText).to({ visibleRatio: 1.0 }, { duration: 2000 }).start();
+		 * @ignore
 		 */
-		this.visibleCharacters = -1;
+		this._visibleCharacters = -1;
 
 		// instance to text metrics functions
 		this.metrics = new TextMetrics(this);
@@ -205,29 +194,55 @@ export default class BitmapText extends Renderable {
 	}
 
 	/**
+	 * the number of characters to display (use -1 to show all).
+	 * Useful for typewriter effects combined with Tween.
+	 * @public
+	 * @type {number}
+	 * @default -1
+	 * @see BitmapText#visibleRatio
+	 * @example
+	 * // show only the first 5 characters
+	 * bitmapText.visibleCharacters = 5;
+	 * // typewriter effect
+	 * bitmapText.visibleCharacters = 0;
+	 * new Tween(bitmapText).to({ visibleRatio: 1.0 }, { duration: 2000 }).start();
+	 */
+	get visibleCharacters() {
+		return this._visibleCharacters;
+	}
+
+	set visibleCharacters(value) {
+		if (this._visibleCharacters !== value) {
+			this._visibleCharacters = value;
+			this.isDirty = true;
+		}
+	}
+
+	/**
 	 * the ratio of visible characters (0.0 to 1.0).
 	 * Setting this automatically updates {@link visibleCharacters}.
 	 * @public
 	 * @type {number}
 	 */
 	get visibleRatio() {
-		if (this.visibleCharacters === -1) {
+		if (this._visibleCharacters === -1) {
 			return 1.0;
 		}
 		const total = this._text.reduce((sum, line) => {
 			return sum + line.length;
 		}, 0);
-		return total > 0 ? this.visibleCharacters / total : 1.0;
+		return total > 0 ? this._visibleCharacters / total : 1.0;
 	}
 
 	set visibleRatio(value) {
-		if (value >= 1.0) {
+		const clamped = Math.max(0, Math.min(1, isFinite(value) ? value : 1));
+		if (clamped >= 1.0) {
 			this.visibleCharacters = -1;
 		} else {
 			const total = this._text.reduce((sum, line) => {
 				return sum + line.length;
 			}, 0);
-			this.visibleCharacters = Math.floor(value * total);
+			this.visibleCharacters = Math.floor(clamped * total);
 		}
 	}
 

--- a/packages/melonjs/src/renderable/text/bitmaptext.js
+++ b/packages/melonjs/src/renderable/text/bitmaptext.js
@@ -26,13 +26,13 @@ export default class BitmapText extends Renderable {
 	 * @param {number} [settings.wordWrapWidth] - the maximum length in CSS pixel for a single segment of text
 	 * @param {(string|string[])} [settings.text] - a string, or an array of strings
 	 * @example
-	 * // Use me.loader.preload or me.loader.load to load assets
-	 * me.loader.preload([
-	 *     { name: "arial", type: "binary" src: "data/font/arial.fnt" },
-	 *     { name: "arial", type: "image" src: "data/font/arial.png" },
+	 * // Use loader.preload or loader.load to load assets
+	 * loader.preload([
+	 *     { name: "arial", type: "binary", src: "data/font/arial.fnt" },
+	 *     { name: "arial", type: "image", src: "data/font/arial.png" },
 	 * ])
 	 * // Then create an instance of your bitmap font:
-	 * let myFont = new me.BitmapText(x, y, {font:"arial", text:"Hello"});
+	 * let myFont = new BitmapText(x, y, {font:"arial", text:"Hello"});
 	 * // two possibilities for using "myFont"
 	 * // either call the draw function from your Renderable draw function
 	 * myFont.draw(renderer, "Hello!", 0, 0);
@@ -133,6 +133,22 @@ export default class BitmapText extends Renderable {
 			this.anchorPoint.set(0, 0);
 		}
 
+		/**
+		 * the number of characters to display (use -1 to show all).
+		 * Useful for typewriter effects combined with Tween.
+		 * @public
+		 * @type {number}
+		 * @default -1
+		 * @see BitmapText#visibleRatio
+		 * @example
+		 * // show only the first 5 characters
+		 * bitmapText.visibleCharacters = 5;
+		 * // typewriter effect
+		 * bitmapText.visibleCharacters = 0;
+		 * new Tween(bitmapText).to({ visibleRatio: 1.0 }, { duration: 2000 }).start();
+		 */
+		this.visibleCharacters = -1;
+
 		// instance to text metrics functions
 		this.metrics = new TextMetrics(this);
 
@@ -186,6 +202,33 @@ export default class BitmapText extends Renderable {
 		this.updateBounds();
 
 		return this;
+	}
+
+	/**
+	 * the ratio of visible characters (0.0 to 1.0).
+	 * Setting this automatically updates {@link visibleCharacters}.
+	 * @public
+	 * @type {number}
+	 */
+	get visibleRatio() {
+		if (this.visibleCharacters === -1) {
+			return 1.0;
+		}
+		const total = this._text.reduce((sum, line) => {
+			return sum + line.length;
+		}, 0);
+		return total > 0 ? this.visibleCharacters / total : 1.0;
+	}
+
+	set visibleRatio(value) {
+		if (value >= 1.0) {
+			this.visibleCharacters = -1;
+		} else {
+			const total = this._text.reduce((sum, line) => {
+				return sum + line.length;
+			}, 0);
+			this.visibleCharacters = Math.floor(value * total);
+		}
 	}
 
 	/**
@@ -314,6 +357,10 @@ export default class BitmapText extends Renderable {
 				break;
 		}
 
+		// running character counter for visibleCharacters
+		let charCount = 0;
+		const maxChars = this.visibleCharacters;
+
 		for (let i = 0; i < this._text.length; i++) {
 			x = lX;
 			const string = this._text[i].trimEnd();
@@ -335,6 +382,11 @@ export default class BitmapText extends Renderable {
 			// draw the string
 			let lastGlyph = null;
 			for (let c = 0, len = string.length; c < len; c++) {
+				// stop drawing when visibleCharacters limit is reached
+				if (maxChars !== -1 && charCount >= maxChars) {
+					return;
+				}
+
 				// calculate the char index
 				const ch = string.charCodeAt(c);
 				const glyph = this.fontData.glyphs[ch];
@@ -371,6 +423,8 @@ export default class BitmapText extends Renderable {
 						"BitmapText: no defined Glyph in for " + String.fromCharCode(ch),
 					);
 				}
+
+				charCount++;
 			}
 			// increment line
 			y += stringHeight;

--- a/packages/melonjs/src/renderable/text/text.js
+++ b/packages/melonjs/src/renderable/text/text.js
@@ -38,7 +38,7 @@ export default class Text extends Renderable {
 	 * @param {number} [settings.wordWrapWidth] - the maximum length in CSS pixel for a single segment of text
 	 * @param {(string|string[])} [settings.text=""] - a string, or an array of strings
 	 * @example
-	 * let font = new me.Text(0, 0, {font: "Arial", size: 8, fillStyle: this.color});
+	 * let font = new Text(0, 0, {font: "Arial", size: 8, fillStyle: this.color});
 	 */
 	constructor(x, y, settings) {
 		// call the parent constructor
@@ -179,6 +179,20 @@ export default class Text extends Renderable {
 			offscreenCanvas: false,
 		});
 
+		/**
+		 * the number of characters to display (use -1 to show all).
+		 * Useful for typewriter effects combined with Tween.
+		 * @public
+		 * @type {number}
+		 * @default -1
+		 * @see Text#visibleRatio
+		 * @example
+		 * // typewriter effect
+		 * text.visibleCharacters = 0;
+		 * new Tween(text).to({ visibleRatio: 1.0 }, { duration: 2000 }).start();
+		 */
+		this.visibleCharacters = -1;
+
 		// instance to text metrics functions
 		this.metrics = new TextMetrics(this);
 
@@ -318,6 +332,34 @@ export default class Text extends Renderable {
 	}
 
 	/**
+	 * the ratio of visible characters (0.0 to 1.0).
+	 * Setting this automatically updates {@link visibleCharacters}.
+	 * @public
+	 * @type {number}
+	 */
+	get visibleRatio() {
+		if (this.visibleCharacters === -1) {
+			return 1.0;
+		}
+		const total = this._text.reduce((sum, line) => {
+			return sum + line.length;
+		}, 0);
+		return total > 0 ? this.visibleCharacters / total : 1.0;
+	}
+
+	set visibleRatio(value) {
+		if (value >= 1.0) {
+			this.visibleCharacters = -1;
+		} else {
+			const total = this._text.reduce((sum, line) => {
+				return sum + line.length;
+			}, 0);
+			this.visibleCharacters = Math.floor(value * total);
+		}
+		this.isDirty = true;
+	}
+
+	/**
 	 * update the bounding box for this Text, accounting for textAlign and textBaseline.
 	 * @param {boolean} [absolute=true] - update in absolute coordinates
 	 * @returns {Bounds} this renderable's bounding box
@@ -382,6 +424,18 @@ export default class Text extends Renderable {
 	 * @param {CanvasRenderer|WebGLRenderer} renderer - Reference to the destination renderer instance
 	 */
 	draw(renderer) {
+		// re-render the canvas texture when visibleCharacters changes
+		if (this.isDirty && this.visibleCharacters !== -1) {
+			this.canvasTexture.invalidate(renderer);
+			this.canvasTexture.clear();
+			this._drawFont(
+				this.canvasTexture.context,
+				this._text,
+				this.pos.x - this.metrics.x,
+				this.pos.y - this.metrics.y,
+			);
+		}
+
 		// adjust x,y position based on the bounding box
 		let x = this.metrics.x;
 		let y = this.metrics.y;
@@ -402,8 +456,20 @@ export default class Text extends Renderable {
 	_drawFont(context, text, x, y) {
 		setContextStyle(context, this);
 
+		let remaining = this.visibleCharacters;
+
 		for (let i = 0; i < text.length; i++) {
-			const string = text[i].trimEnd();
+			let string = text[i].trimEnd();
+
+			// limit visible characters if needed
+			if (remaining !== -1) {
+				if (remaining <= 0) {
+					break;
+				}
+				string = string.substring(0, remaining);
+				remaining -= string.length;
+			}
+
 			// draw the string
 			if (this.fillStyle.alpha > 0) {
 				context.fillText(string, x, y);

--- a/packages/melonjs/src/renderable/text/text.js
+++ b/packages/melonjs/src/renderable/text/text.js
@@ -180,18 +180,9 @@ export default class Text extends Renderable {
 		});
 
 		/**
-		 * the number of characters to display (use -1 to show all).
-		 * Useful for typewriter effects combined with Tween.
-		 * @public
-		 * @type {number}
-		 * @default -1
-		 * @see Text#visibleRatio
-		 * @example
-		 * // typewriter effect
-		 * text.visibleCharacters = 0;
-		 * new Tween(text).to({ visibleRatio: 1.0 }, { duration: 2000 }).start();
+		 * @ignore
 		 */
-		this.visibleCharacters = -1;
+		this._visibleCharacters = -1;
 
 		// instance to text metrics functions
 		this.metrics = new TextMetrics(this);
@@ -332,31 +323,54 @@ export default class Text extends Renderable {
 	}
 
 	/**
+	 * the number of characters to display (use -1 to show all).
+	 * Useful for typewriter effects combined with Tween.
+	 * @public
+	 * @type {number}
+	 * @default -1
+	 * @see Text#visibleRatio
+	 * @example
+	 * // typewriter effect
+	 * text.visibleCharacters = 0;
+	 * new Tween(text).to({ visibleRatio: 1.0 }, { duration: 2000 }).start();
+	 */
+	get visibleCharacters() {
+		return this._visibleCharacters;
+	}
+
+	set visibleCharacters(value) {
+		if (this._visibleCharacters !== value) {
+			this._visibleCharacters = value;
+			this.isDirty = true;
+		}
+	}
+
+	/**
 	 * the ratio of visible characters (0.0 to 1.0).
 	 * Setting this automatically updates {@link visibleCharacters}.
 	 * @public
 	 * @type {number}
 	 */
 	get visibleRatio() {
-		if (this.visibleCharacters === -1) {
+		if (this._visibleCharacters === -1) {
 			return 1.0;
 		}
 		const total = this._text.reduce((sum, line) => {
 			return sum + line.length;
 		}, 0);
-		return total > 0 ? this.visibleCharacters / total : 1.0;
+		return total > 0 ? this._visibleCharacters / total : 1.0;
 	}
 
 	set visibleRatio(value) {
-		if (value >= 1.0) {
+		const clamped = Math.max(0, Math.min(1, isFinite(value) ? value : 1));
+		if (clamped >= 1.0) {
 			this.visibleCharacters = -1;
 		} else {
 			const total = this._text.reduce((sum, line) => {
 				return sum + line.length;
 			}, 0);
-			this.visibleCharacters = Math.floor(value * total);
+			this.visibleCharacters = Math.floor(clamped * total);
 		}
-		this.isDirty = true;
 	}
 
 	/**
@@ -424,8 +438,8 @@ export default class Text extends Renderable {
 	 * @param {CanvasRenderer|WebGLRenderer} renderer - Reference to the destination renderer instance
 	 */
 	draw(renderer) {
-		// re-render the canvas texture when visibleCharacters changes
-		if (this.isDirty && this.visibleCharacters !== -1) {
+		// re-render the canvas texture when dirty (e.g. visibleCharacters changed)
+		if (this.isDirty) {
 			this.canvasTexture.invalidate(renderer);
 			this.canvasTexture.clear();
 			this._drawFont(

--- a/packages/melonjs/src/tweens/tween.ts
+++ b/packages/melonjs/src/tweens/tween.ts
@@ -61,7 +61,7 @@ export default class Tween {
 	_yoyo: boolean;
 	_reversed: boolean;
 	_delayTime: number;
-	_repeatDelayTime: number;
+	_repeatDelayTime: number | undefined;
 	_startTime: number | null;
 	_easingFunction: EasingFunction;
 	_interpolationFunction: InterpolationFunction;
@@ -118,7 +118,7 @@ export default class Tween {
 		this._yoyo = false;
 		this._reversed = false;
 		this._delayTime = 0;
-		this._repeatDelayTime = 0;
+		this._repeatDelayTime = undefined;
 		this._startTime = null;
 		this._easingFunction = Easing.Linear.None;
 		this._interpolationFunction = Interpolation.Linear;
@@ -524,7 +524,7 @@ export default class Tween {
 					this._reversed = !this._reversed;
 				}
 
-				this._startTime = time + (this._repeatDelayTime || this._delayTime);
+				this._startTime = time + (this._repeatDelayTime ?? this._delayTime);
 
 				return true;
 			} else {

--- a/packages/melonjs/src/tweens/tween.ts
+++ b/packages/melonjs/src/tweens/tween.ts
@@ -61,6 +61,7 @@ export default class Tween {
 	_yoyo: boolean;
 	_reversed: boolean;
 	_delayTime: number;
+	_repeatDelayTime: number;
 	_startTime: number | null;
 	_easingFunction: EasingFunction;
 	_interpolationFunction: InterpolationFunction;
@@ -117,6 +118,7 @@ export default class Tween {
 		this._yoyo = false;
 		this._reversed = false;
 		this._delayTime = 0;
+		this._repeatDelayTime = 0;
 		this._startTime = null;
 		this._easingFunction = Easing.Linear.None;
 		this._interpolationFunction = Interpolation.Linear;
@@ -224,6 +226,7 @@ export default class Tween {
 	 * @param [options.delay] - delay before starting, in milliseconds
 	 * @param [options.yoyo] - bounce back to original values when finished (use with `repeat`)
 	 * @param [options.repeat] - number of times to repeat (use `Infinity` for endless loops)
+	 * @param [options.repeatDelay] - delay in milliseconds before each repeat cycle
 	 * @param [options.interpolation] - interpolation function for array values
 	 * @param [options.autoStart] - start the tween immediately without calling `start()`
 	 * @returns this instance for object chaining
@@ -236,6 +239,7 @@ export default class Tween {
 			yoyo?: boolean | undefined;
 			repeat?: number | undefined;
 			delay?: number | undefined;
+			repeatDelay?: number | undefined;
 			interpolation?: InterpolationFunction | undefined;
 			autoStart?: boolean | undefined;
 		},
@@ -257,6 +261,9 @@ export default class Tween {
 			}
 			if (options.delay !== undefined) {
 				this.delay(options.delay);
+			}
+			if (options.repeatDelay !== undefined) {
+				this.repeatDelay(options.repeatDelay);
 			}
 			if (options.interpolation !== undefined) {
 				this.interpolation(options.interpolation);
@@ -344,6 +351,16 @@ export default class Tween {
 	 */
 	repeat(times: number) {
 		this._repeat = times;
+		return this;
+	}
+
+	/**
+	 * Set a delay before each repeat.
+	 * @param amount - delay in milliseconds before each repeat cycle
+	 * @returns this instance for object chaining
+	 */
+	repeatDelay(amount: number) {
+		this._repeatDelayTime = amount;
 		return this;
 	}
 
@@ -507,7 +524,7 @@ export default class Tween {
 					this._reversed = !this._reversed;
 				}
 
-				this._startTime = time + this._delayTime;
+				this._startTime = time + (this._repeatDelayTime || this._delayTime);
 
 				return true;
 			} else {

--- a/packages/melonjs/tests/textVisibility.spec.js
+++ b/packages/melonjs/tests/textVisibility.spec.js
@@ -1,0 +1,116 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { boot, Text, video } from "../src/index.js";
+
+describe("Text visible characters", () => {
+	beforeAll(() => {
+		boot();
+		video.init(100, 100, {
+			parent: "screen",
+			scale: "auto",
+			renderer: video.CANVAS,
+		});
+	});
+
+	describe("Text", () => {
+		it("visibleCharacters should default to -1", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			expect(t.visibleCharacters).toEqual(-1);
+		});
+
+		it("visibleRatio should default to 1.0", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			expect(t.visibleRatio).toEqual(1.0);
+		});
+
+		it("setting visibleRatio should update visibleCharacters", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello World",
+			});
+			t.visibleRatio = 0.5;
+			// "Hello World" = 11 chars, 0.5 * 11 = 5
+			expect(t.visibleCharacters).toEqual(5);
+		});
+
+		it("setting visibleRatio to 1.0 should reset to -1", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleRatio = 0.5;
+			expect(t.visibleCharacters).not.toEqual(-1);
+			t.visibleRatio = 1.0;
+			expect(t.visibleCharacters).toEqual(-1);
+		});
+
+		it("visibleRatio should reflect visibleCharacters", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "1234567890",
+			});
+			t.visibleCharacters = 5;
+			expect(t.visibleRatio).toBeCloseTo(0.5);
+		});
+
+		it("setting visibleRatio should mark isDirty", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.isDirty = false;
+			t.visibleRatio = 0.5;
+			expect(t.isDirty).toBe(true);
+		});
+
+		it("multiline should count characters across lines", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "AB\nCD\nEF",
+			});
+			// 3 lines: "AB", "CD", "EF" = 6 chars total
+			t.visibleRatio = 0.5;
+			expect(t.visibleCharacters).toEqual(3);
+		});
+
+		it("visibleCharacters = 0 should show nothing", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleCharacters = 0;
+			expect(t.visibleRatio).toEqual(0);
+		});
+
+		it("empty text should handle visibleRatio gracefully", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "",
+			});
+			expect(t.visibleRatio).toEqual(1.0);
+			t.visibleRatio = 0.5;
+			// no chars → visibleCharacters = 0
+			expect(t.visibleCharacters).toEqual(0);
+		});
+	});
+
+	// BitmapText tests require font data loaded via the loader,
+	// which isn't available in the unit test environment.
+	// The visibleCharacters/visibleRatio logic is identical to Text
+	// and is validated through the Text tests above.
+	// BitmapText-specific draw behavior is tested visually in the text example.
+});

--- a/packages/melonjs/tests/textVisibility.spec.js
+++ b/packages/melonjs/tests/textVisibility.spec.js
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
-import { boot, Text, video } from "../src/index.js";
+import { BitmapText, boot, loader, Text, video } from "../src/index.js";
 
 describe("Text visible characters", () => {
 	beforeAll(() => {
@@ -63,6 +63,17 @@ describe("Text visible characters", () => {
 			expect(t.visibleRatio).toBeCloseTo(0.5);
 		});
 
+		it("setting visibleCharacters should mark isDirty", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.isDirty = false;
+			t.visibleCharacters = 3;
+			expect(t.isDirty).toBe(true);
+		});
+
 		it("setting visibleRatio should mark isDirty", () => {
 			const t = new Text(0, 0, {
 				font: "Arial",
@@ -72,6 +83,18 @@ describe("Text visible characters", () => {
 			t.isDirty = false;
 			t.visibleRatio = 0.5;
 			expect(t.isDirty).toBe(true);
+		});
+
+		it("setting same visibleCharacters should not mark isDirty", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleCharacters = 3;
+			t.isDirty = false;
+			t.visibleCharacters = 3;
+			expect(t.isDirty).toBe(false);
 		});
 
 		it("multiline should count characters across lines", () => {
@@ -103,14 +126,299 @@ describe("Text visible characters", () => {
 			});
 			expect(t.visibleRatio).toEqual(1.0);
 			t.visibleRatio = 0.5;
-			// no chars → visibleCharacters = 0
+			// no chars -> visibleCharacters = 0
 			expect(t.visibleCharacters).toEqual(0);
+		});
+
+		it("visibleRatio should clamp negative values to 0", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleRatio = -0.5;
+			expect(t.visibleCharacters).toEqual(0);
+			expect(t.visibleRatio).toEqual(0);
+		});
+
+		it("visibleRatio should clamp values above 1.0", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleRatio = 1.5;
+			expect(t.visibleCharacters).toEqual(-1);
+			expect(t.visibleRatio).toEqual(1.0);
+		});
+
+		it("visibleRatio should handle NaN gracefully", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleRatio = NaN;
+			// NaN is not finite -> treated as 1.0
+			expect(t.visibleCharacters).toEqual(-1);
+		});
+
+		it("visibleRatio should handle Infinity gracefully", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleRatio = Infinity;
+			expect(t.visibleCharacters).toEqual(-1);
+		});
+
+		it("visibleRatio should handle -Infinity gracefully", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleRatio = -Infinity;
+			// -Infinity is not finite, treated as 1.0 (show all)
+			expect(t.visibleCharacters).toEqual(-1);
+		});
+
+		it("single line should count characters correctly", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleCharacters = 3;
+			expect(t.visibleRatio).toBeCloseTo(0.6);
+		});
+
+		it("visibleCharacters larger than text length should not crash", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hi",
+			});
+			t.visibleCharacters = 100;
+			expect(t.visibleRatio).toBeGreaterThan(1.0);
+		});
+
+		it("changing text should adjust visibleRatio", () => {
+			const t = new Text(0, 0, {
+				font: "Arial",
+				size: 16,
+				text: "Hello",
+			});
+			t.visibleCharacters = 3;
+			expect(t.visibleRatio).toBeCloseTo(0.6); // 3/5
+			t.setText("Hello World");
+			// visibleCharacters stays 3, but ratio changes (3/11)
+			expect(t.visibleCharacters).toEqual(3);
+			expect(t.visibleRatio).toBeCloseTo(3 / 11);
 		});
 	});
 
-	// BitmapText tests require font data loaded via the loader,
-	// which isn't available in the unit test environment.
-	// The visibleCharacters/visibleRatio logic is identical to Text
-	// and is validated through the Text tests above.
-	// BitmapText-specific draw behavior is tested visually in the text example.
+	describe("BitmapText", () => {
+		beforeAll(async () => {
+			await new Promise((resolve) => {
+				loader.preload(
+					[
+						{
+							name: "xolo12",
+							type: "image",
+							src: "/data/fnt/xolo12.png",
+						},
+						{
+							name: "xolo12",
+							type: "binary",
+							src: "/data/fnt/xolo12.fnt",
+						},
+					],
+					resolve,
+				);
+			});
+		});
+
+		it("visibleCharacters should default to -1", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			expect(b.visibleCharacters).toEqual(-1);
+		});
+
+		it("visibleRatio should default to 1.0", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			expect(b.visibleRatio).toEqual(1.0);
+		});
+
+		it("setting visibleRatio should update visibleCharacters", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO WORLD",
+			});
+			b.visibleRatio = 0.5;
+			expect(b.visibleCharacters).toEqual(5);
+		});
+
+		it("setting visibleRatio to 1.0 should reset to -1", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleRatio = 0.5;
+			expect(b.visibleCharacters).not.toEqual(-1);
+			b.visibleRatio = 1.0;
+			expect(b.visibleCharacters).toEqual(-1);
+		});
+
+		it("visibleRatio should reflect visibleCharacters", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "1234567890",
+			});
+			b.visibleCharacters = 5;
+			expect(b.visibleRatio).toBeCloseTo(0.5);
+		});
+
+		it("setting visibleCharacters should mark isDirty", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.isDirty = false;
+			b.visibleCharacters = 3;
+			expect(b.isDirty).toBe(true);
+		});
+
+		it("setting visibleRatio should mark isDirty", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.isDirty = false;
+			b.visibleRatio = 0.5;
+			expect(b.isDirty).toBe(true);
+		});
+
+		it("setting same visibleCharacters should not mark isDirty", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleCharacters = 3;
+			b.isDirty = false;
+			b.visibleCharacters = 3;
+			expect(b.isDirty).toBe(false);
+		});
+
+		it("visibleCharacters = 0 should show nothing", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleCharacters = 0;
+			expect(b.visibleRatio).toEqual(0);
+		});
+
+		it("empty text should handle visibleRatio gracefully", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "",
+			});
+			expect(b.visibleRatio).toEqual(1.0);
+			b.visibleRatio = 0.5;
+			expect(b.visibleCharacters).toEqual(0);
+		});
+
+		it("multiline should count characters across lines", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "AB\nCD\nEF",
+			});
+			b.visibleRatio = 0.5;
+			expect(b.visibleCharacters).toEqual(3);
+		});
+
+		it("visibleRatio should clamp negative values", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleRatio = -0.5;
+			expect(b.visibleCharacters).toEqual(0);
+		});
+
+		it("visibleRatio should clamp values above 1.0", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleRatio = 1.5;
+			expect(b.visibleCharacters).toEqual(-1);
+		});
+
+		it("visibleRatio should handle NaN gracefully", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleRatio = NaN;
+			expect(b.visibleCharacters).toEqual(-1);
+		});
+
+		it("visibleRatio should handle Infinity gracefully", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleRatio = Infinity;
+			expect(b.visibleCharacters).toEqual(-1);
+		});
+
+		it("visibleRatio should handle -Infinity gracefully", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleRatio = -Infinity;
+			// -Infinity is not finite, treated as 1.0 (show all)
+			expect(b.visibleCharacters).toEqual(-1);
+		});
+
+		it("single line should count characters correctly", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleCharacters = 3;
+			expect(b.visibleRatio).toBeCloseTo(0.6);
+		});
+
+		it("visibleCharacters larger than text length should not crash", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HI",
+			});
+			b.visibleCharacters = 100;
+			expect(b.visibleRatio).toBeGreaterThan(1.0);
+		});
+
+		it("changing text should adjust visibleRatio", () => {
+			const b = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "HELLO",
+			});
+			b.visibleCharacters = 3;
+			expect(b.visibleRatio).toBeCloseTo(0.6); // 3/5
+			b.setText("HELLO WORLD");
+			// visibleCharacters stays 3, but ratio changes (3/11)
+			expect(b.visibleCharacters).toEqual(3);
+			expect(b.visibleRatio).toBeCloseTo(3 / 11);
+		});
+	});
 });

--- a/packages/melonjs/tests/tween.spec.ts
+++ b/packages/melonjs/tests/tween.spec.ts
@@ -258,6 +258,58 @@ describe("Tween", () => {
 		});
 	});
 
+	// --- repeatDelay ---
+
+	describe("repeatDelay()", () => {
+		it("delays before each repeat cycle", () => {
+			let completeCount = 0;
+			tween
+				.to({ x: 100 }, { duration: 100, repeat: 1, repeatDelay: 50 })
+				.onComplete(() => {
+					completeCount++;
+				});
+			tween.start(0);
+
+			// first pass completes at t=100
+			tween.update(100);
+			expect(obj.x).toBeCloseTo(100, 0);
+			expect(completeCount).toEqual(0);
+
+			// during repeat delay, not yet complete
+			tween.update(25);
+			expect(completeCount).toEqual(0);
+
+			// after delay (50ms) + second pass (100ms) = 150ms more
+			tween.update(125);
+			expect(obj.x).toBeCloseTo(100, 0);
+			expect(completeCount).toEqual(1);
+		});
+
+		it("repeatDelay: 0 should not use delay value", () => {
+			tween.to(
+				{ x: 100 },
+				{ duration: 100, repeat: 1, delay: 50, repeatDelay: 0 },
+			);
+			tween.start(0);
+
+			// initial delay of 50ms
+			tween.update(50);
+			expect(obj.x).toBeCloseTo(0, 0);
+
+			// first pass
+			tween.update(100);
+			expect(obj.x).toBeCloseTo(100, 0);
+
+			// repeat should start immediately (repeatDelay: 0, not delay: 50)
+			tween.update(100);
+			expect(obj.x).toBeCloseTo(100, 0);
+		});
+
+		it("returns this for chaining", () => {
+			expect(tween.repeatDelay(100)).toBe(tween);
+		});
+	});
+
 	// --- yoyo ---
 
 	describe("yoyo()", () => {


### PR DESCRIPTION
## Summary

- **`visibleCharacters`** and **`visibleRatio`** properties on both Text and BitmapText for progressive text reveal and typewriter effects
- Animate `visibleRatio` with Tween for character-by-character text display
- **`repeatDelay`** added to Tween — delay before each repeat cycle
- Clean up outdated `me.` references in Text/BitmapText JSDoc examples

```js
// typewriter effect
text.visibleCharacters = 0;
new Tween(text).to({ visibleRatio: 1.0 }, {
    duration: 3000,
    repeat: Infinity,
    repeatDelay: 1500,
}).start();
```

Closes #1411.

## Test plan

- [x] 9 unit tests for Text visibility (defaults, ratio sync, multiline, edge cases)
- [x] Text example: typewriter effect on system font (right-aligned multiline) and BitmapText (centered multiline)
- [x] `visibleCharacters = -1` shows all text (zero overhead)
- [x] Build passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)