### PR TITLE
feat: add state.freeze() for hit-stop / hit-pause effects

### DIFF
--- a/packages/examples/src/examples/whac-a-mole/ExampleWhacAMole.ts
+++ b/packages/examples/src/examples/whac-a-mole/ExampleWhacAMole.ts
@@ -1,6 +1,7 @@
 import { Application, audio, loader, save, state } from "melonjs";
 import { createExampleComponent } from "../utils";
 import { data } from "./data";
+import { setupViewportEffects } from "./effects";
 import { PlayScreen } from "./play";
 import { resources } from "./resources";
 
@@ -10,6 +11,9 @@ const createGame = () => {
 		parent: "screen",
 		scale: "auto",
 	});
+
+	// vignette (always on) + dormant chromatic aberration (burst on hit)
+	setupViewportEffects(_app.viewport, _app.renderer);
 
 	// initialize the "sound engine"
 	audio.init("mp3,ogg");

--- a/packages/examples/src/examples/whac-a-mole/effects.ts
+++ b/packages/examples/src/examples/whac-a-mole/effects.ts
@@ -2,41 +2,34 @@ import {
 	type Camera2d,
 	ChromaticAberrationEffect,
 	DropShadowEffect,
+	pool,
 	type Renderer,
 	type Sprite,
+	Tween,
 	VignetteEffect,
 	type WebGLRenderer,
 } from "melonjs";
 
 /**
  * Attach an always-on vignette to the viewport.
- * Skips silently if the renderer is not WebGL (post-effects are WebGL-only).
+ * Effects degrade gracefully on Canvas (ShaderEffect logs a warning and
+ * leaves `enabled = false`; all method calls become no-ops).
  */
 export function setupViewportEffects(
 	viewport: Camera2d,
 	renderer: Renderer,
 ): void {
-	if (!renderer.type.startsWith("WebGL")) {
-		return;
-	}
-	const r = renderer as WebGLRenderer;
-	viewport.addPostEffect(new VignetteEffect(r));
+	viewport.addPostEffect(new VignetteEffect(renderer as WebGLRenderer));
 }
 
 /**
  * Attach a dormant chromatic aberration effect to a sprite.
- * No-op on canvas renderer.
- * @returns the effect instance, or null if not attached
  */
 export function attachChromaticAberration(
 	sprite: Sprite,
 	renderer: Renderer,
-): ChromaticAberrationEffect | null {
-	if (!renderer.type.startsWith("WebGL")) {
-		return null;
-	}
-	const r = renderer as WebGLRenderer;
-	const fx = new ChromaticAberrationEffect(r, {
+): ChromaticAberrationEffect {
+	const fx = new ChromaticAberrationEffect(renderer as WebGLRenderer, {
 		offset: 0,
 		textureSize: [sprite.width, sprite.height],
 	});
@@ -46,15 +39,10 @@ export function attachChromaticAberration(
 
 /**
  * Attach a static drop shadow to a sprite, giving it weight on the scene.
- * No-op on canvas renderer.
  */
 export function attachDropShadow(sprite: Sprite, renderer: Renderer): void {
-	if (!renderer.type.startsWith("WebGL")) {
-		return;
-	}
-	const r = renderer as WebGLRenderer;
 	sprite.addPostEffect(
-		new DropShadowEffect(r, {
+		new DropShadowEffect(renderer as WebGLRenderer, {
 			offsetX: 2.0,
 			offsetY: 3.0,
 			color: [0.0, 0.0, 0.0],
@@ -66,34 +54,24 @@ export function attachDropShadow(sprite: Sprite, renderer: Renderer): void {
 
 /**
  * Trigger a brief chromatic-aberration burst on the given effect.
- * Decays in real-time using performance.now() so it animates *through* a freeze.
- * @param fx - the effect to drive (no-op if null)
+ * Uses a Tween with `updateWhenPaused = true` so the decay animates
+ * *through* a freeze.
+ * @param fx - the effect to drive
  * @param peak - peak offset in texels
- * @param durationMs - total duration of the burst (rise + decay)
+ * @param durationMs - total duration of the decay
  */
 export function triggerChromaticBurst(
-	fx: ChromaticAberrationEffect | null,
+	fx: ChromaticAberrationEffect,
 	peak = 8,
 	durationMs = 250,
 ): void {
-	if (fx === null) {
-		return;
-	}
-	const start = globalThis.performance.now();
-
 	fx.setOffset(peak);
-
-	const tick = (): void => {
-		const t = (globalThis.performance.now() - start) / durationMs;
-		if (t >= 1) {
-			fx.setOffset(0);
-			return;
-		}
-		// ease-out cubic from peak → 0
-		const eased = 1 - (1 - t) ** 3;
-		fx.setOffset(peak * (1 - eased));
-		globalThis.requestAnimationFrame(tick);
-	};
-
-	globalThis.requestAnimationFrame(tick);
+	const driver = { offset: peak };
+	const tween = pool.pull("me.Tween", driver) as Tween;
+	tween.updateWhenPaused = true;
+	tween
+		.to({ offset: 0 }, { duration: durationMs })
+		.easing(Tween.Easing.Cubic.Out)
+		.onUpdate(() => fx.setOffset(driver.offset))
+		.start();
 }

--- a/packages/examples/src/examples/whac-a-mole/effects.ts
+++ b/packages/examples/src/examples/whac-a-mole/effects.ts
@@ -1,0 +1,99 @@
+import {
+	type Camera2d,
+	ChromaticAberrationEffect,
+	DropShadowEffect,
+	type Renderer,
+	type Sprite,
+	VignetteEffect,
+	type WebGLRenderer,
+} from "melonjs";
+
+/**
+ * Attach an always-on vignette to the viewport.
+ * Skips silently if the renderer is not WebGL (post-effects are WebGL-only).
+ */
+export function setupViewportEffects(
+	viewport: Camera2d,
+	renderer: Renderer,
+): void {
+	if (!renderer.type.startsWith("WebGL")) {
+		return;
+	}
+	const r = renderer as WebGLRenderer;
+	viewport.addPostEffect(new VignetteEffect(r));
+}
+
+/**
+ * Attach a dormant chromatic aberration effect to a sprite.
+ * No-op on canvas renderer.
+ * @returns the effect instance, or null if not attached
+ */
+export function attachChromaticAberration(
+	sprite: Sprite,
+	renderer: Renderer,
+): ChromaticAberrationEffect | null {
+	if (!renderer.type.startsWith("WebGL")) {
+		return null;
+	}
+	const r = renderer as WebGLRenderer;
+	const fx = new ChromaticAberrationEffect(r, {
+		offset: 0,
+		textureSize: [sprite.width, sprite.height],
+	});
+	sprite.addPostEffect(fx);
+	return fx;
+}
+
+/**
+ * Attach a static drop shadow to a sprite, giving it weight on the scene.
+ * No-op on canvas renderer.
+ */
+export function attachDropShadow(sprite: Sprite, renderer: Renderer): void {
+	if (!renderer.type.startsWith("WebGL")) {
+		return;
+	}
+	const r = renderer as WebGLRenderer;
+	sprite.addPostEffect(
+		new DropShadowEffect(r, {
+			offsetX: 2.0,
+			offsetY: 3.0,
+			color: [0.0, 0.0, 0.0],
+			opacity: 0.2,
+			textureSize: [sprite.width, sprite.height],
+		}),
+	);
+}
+
+/**
+ * Trigger a brief chromatic-aberration burst on the given effect.
+ * Decays in real-time using performance.now() so it animates *through* a freeze.
+ * @param fx - the effect to drive (no-op if null)
+ * @param peak - peak offset in texels
+ * @param durationMs - total duration of the burst (rise + decay)
+ */
+export function triggerChromaticBurst(
+	fx: ChromaticAberrationEffect | null,
+	peak = 8,
+	durationMs = 250,
+): void {
+	if (fx === null) {
+		return;
+	}
+	const start = globalThis.performance.now();
+
+	fx.setOffset(peak);
+
+	const tick = (): void => {
+		const t = (globalThis.performance.now() - start) / durationMs;
+		if (t >= 1) {
+			fx.setOffset(0);
+			return;
+		}
+		// ease-out cubic from peak → 0
+		const eased = 1 - (1 - t) ** 3;
+		fx.setOffset(peak * (1 - eased));
+		globalThis.requestAnimationFrame(tick);
+	};
+
+	globalThis.requestAnimationFrame(tick);
+}

--- a/packages/examples/src/examples/whac-a-mole/mole.ts
+++ b/packages/examples/src/examples/whac-a-mole/mole.ts
@@ -1,5 +1,19 @@
-import { audio, input, pool, Sprite, save, Tween } from "melonjs";
+import {
+	audio,
+	type ChromaticAberrationEffect,
+	game,
+	input,
+	pool,
+	Sprite,
+	save,
+	Tween,
+} from "melonjs";
 import { data } from "./data";
+import {
+	attachChromaticAberration,
+	attachDropShadow,
+	triggerChromaticBurst,
+} from "./effects";
 
 /**
  * a mole entity
@@ -12,10 +26,18 @@ export class MoleEntity extends Sprite {
 	initialPos: number;
 	displayTween: Tween;
 	hideTween: Tween;
+	chromaticEffect: ChromaticAberrationEffect | null;
 
 	constructor(x: number, y: number) {
 		// call the constructor
 		super(x, y, { image: "mole", framewidth: 178, frameheight: 140 });
+
+		// per-mole shader effects:
+		// - drop shadow gives the mole weight against the hole
+		// - chromatic aberration bursts on hit
+		// shadow is added first so chromatic aberration applies on top
+		attachDropShadow(this, game.renderer);
+		this.chromaticEffect = attachChromaticAberration(this, game.renderer);
 
 		// idle animation
 		this.addAnimation("idle", [0]);
@@ -59,6 +81,13 @@ export class MoleEntity extends Sprite {
 			this.flicker(750);
 			// play ow FX
 			audio.play("ow");
+
+			// juice trifecta: shake + per-mole chromatic burst + hit-stop
+			// (start motion/burst first, then freeze — the chromatic decays in
+			// real-time *during* the freeze, making the impact feel punchy)
+			game.viewport.shake(8, 400);
+			triggerChromaticBurst(this.chromaticEffect, 8, 250);
+			game.freeze(150);
 
 			// add some points
 			data.score += 100;

--- a/packages/examples/src/examples/whac-a-mole/mole.ts
+++ b/packages/examples/src/examples/whac-a-mole/mole.ts
@@ -26,7 +26,7 @@ export class MoleEntity extends Sprite {
 	initialPos: number;
 	displayTween: Tween;
 	hideTween: Tween;
-	chromaticEffect: ChromaticAberrationEffect | null;
+	chromaticEffect: ChromaticAberrationEffect;
 
 	constructor(x: number, y: number) {
 		// call the constructor

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [19.2.0] (melonJS 2) - _unreleased_
 
 ### Added
+- State: `state.freeze(duration, music?)` — freeze the current stage for a fixed duration in milliseconds, then automatically resume. Returns a `Promise<void>` that resolves on unfreeze. Reentrant calls extend the freeze to whichever end-time is later (they do not stack). Useful for hit-stop / hit-pause effects on impact.
+- Application: `app.pause(music?)`, `app.resume(music?)`, `app.freeze(duration, music?)` — convenience proxy methods on the Application instance for the corresponding `state.*` methods.
 - Text: `visibleCharacters` and `visibleRatio` properties on Text and BitmapText for progressive text reveal and typewriter effects. Animate `visibleRatio` with Tween for character-by-character text display.
 - Tween: `repeatDelay(ms)` method and `repeatDelay` option in `to()` — adds a delay before each repeat cycle.
 - Camera: FBO-based post-processing pipeline — assign a `ShaderEffect` to any camera's `shader` property to apply full-screen post-effects (vignette, scanlines, desaturation, etc.). Works with multiple cameras independently (e.g. main camera + minimap with different effects). Renderer manages FBO lifecycle via `beginPostEffect()`/`endPostEffect()`/`blitEffect()` methods.

--- a/packages/melonjs/src/application/application.ts
+++ b/packages/melonjs/src/application/application.ts
@@ -552,6 +552,45 @@ export default class Application {
 		this.isDirty = true;
 	}
 
+	/**
+	 * Pause the current stage. Convenience proxy for {@link state.pause}.
+	 * @param [music=false] - also pause the current music track
+	 * @example
+	 * app.pause();        // pause game updates, keep music playing
+	 * app.pause(true);    // pause game updates and music
+	 */
+	pause(music: boolean = false): void {
+		state.pause(music);
+	}
+
+	/**
+	 * Resume the current stage. Convenience proxy for {@link state.resume}.
+	 * @param [music=false] - also resume the current music track
+	 */
+	resume(music: boolean = false): void {
+		state.resume(music);
+	}
+
+	/**
+	 * Freeze the current stage for a fixed duration, then automatically resume.
+	 * Useful for hit-stop / hit-pause effects on impact. Reentrant calls extend
+	 * the freeze to whichever end-time is later (they do not stack).
+	 * Convenience proxy for {@link state.freeze}.
+	 * @param duration - duration of the freeze in milliseconds
+	 * @param [music=false] - also pause the current music track during the freeze
+	 * @returns a Promise that resolves once the freeze ends
+	 * @example
+	 * // simple hit-stop on impact
+	 * app.freeze(80);
+	 *
+	 * // chain VFX after the freeze
+	 * await app.freeze(120);
+	 * spawnImpactParticles();
+	 */
+	freeze(duration: number, music: boolean = false): Promise<void> {
+		return state.freeze(duration, music);
+	}
+
 	/** @ignore */
 	_tick(time: number): void {
 		this.update(time);

--- a/packages/melonjs/src/state/state.ts
+++ b/packages/melonjs/src/state/state.ts
@@ -62,6 +62,12 @@ let _extraArgs: unknown[] | null = null;
 // store the elapsed time during pause/stop period
 let _pauseTime: number = 0;
 
+// freeze() bookkeeping
+let _freezeTimer: ReturnType<typeof setTimeout> | null = null;
+let _freezeEndsAt: number = 0;
+let _freezeMusic: boolean = false;
+let _freezeResolvers: Array<() => void> = [];
+
 /**
  * @ignore
  */
@@ -91,6 +97,21 @@ function _resumeRunLoop(): void {
 function _pauseRunLoop(): void {
 	// Set the paused boolean to stop updates on (most) entities
 	_isPaused = true;
+}
+
+/**
+ * End an active freeze: resume the run loop and resolve waiters.
+ * @ignore
+ */
+function _endFreeze(): void {
+	_freezeTimer = null;
+	_freezeEndsAt = 0;
+	state.resume(_freezeMusic);
+	const resolvers = _freezeResolvers;
+	_freezeResolvers = [];
+	for (const resolve of resolvers) {
+		resolve();
+	}
 }
 
 /**
@@ -326,6 +347,53 @@ const state = {
 			// publish the resume event
 			emit(STATE_RESUME, _pauseTime);
 		}
+	},
+
+	/**
+	 * Freeze the current stage for a fixed duration, then automatically resume.
+	 * Useful for hit-stop / hit-pause effects on impact.
+	 *
+	 * If `freeze()` is called again while a freeze is already active, the freeze
+	 * is *extended* to whichever end-time is later (calls do not stack). The
+	 * `music` flag from the initial call is preserved for the eventual resume.
+	 * @param duration - duration of the freeze in milliseconds
+	 * @param [music=false] - also pause the current music track during the freeze
+	 * @returns a Promise that resolves once the freeze ends
+	 * @example
+	 * // simple hit-stop on impact
+	 * state.freeze(80);
+	 *
+	 * // chain VFX after the freeze
+	 * await state.freeze(120);
+	 * spawnImpactParticles();
+	 */
+	freeze(duration: number, music: boolean = false): Promise<void> {
+		// guard against NaN, Infinity, and negative durations — silently no-op
+		// (mirrors how state.pause/resume quietly ignore invalid states)
+		if (!Number.isFinite(duration) || duration < 0) {
+			return Promise.resolve();
+		}
+		const now = globalThis.performance.now();
+		const newEndsAt = now + duration;
+
+		if (_freezeTimer !== null) {
+			// already frozen: only extend if the new end-time is later
+			if (newEndsAt > _freezeEndsAt) {
+				clearTimeout(_freezeTimer);
+				_freezeEndsAt = newEndsAt;
+				_freezeTimer = setTimeout(_endFreeze, newEndsAt - now);
+			}
+		} else {
+			// start a new freeze
+			_freezeMusic = music;
+			_freezeEndsAt = newEndsAt;
+			this.pause(music);
+			_freezeTimer = setTimeout(_endFreeze, duration);
+		}
+
+		return new Promise<void>((resolve) => {
+			_freezeResolvers.push(resolve);
+		});
 	},
 
 	/**

--- a/packages/melonjs/tests/application.spec.js
+++ b/packages/melonjs/tests/application.spec.js
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { game as gameFromModule } from "../src/application/application.ts";
 import {
 	Application,
@@ -6,6 +6,7 @@ import {
 	Container,
 	game,
 	Renderable,
+	state,
 	video,
 } from "../src/index.js";
 import { initialized } from "../src/system/bootstrap.ts";
@@ -236,6 +237,108 @@ describe("Application", () => {
 			expect(canvas.parentElement).not.toBeNull();
 			// clean up manually
 			canvas.parentElement.removeChild(canvas);
+		});
+	});
+
+	describe("pause / resume / freeze", () => {
+		beforeAll(() => {
+			boot();
+			video.init(800, 600, {
+				parent: "screen",
+				scale: "auto",
+				renderer: video.CANVAS,
+			});
+		});
+
+		afterEach(() => {
+			// always end with the game running for subsequent tests
+			if (state.isPaused()) {
+				state.resume();
+			}
+			vi.useRealTimers();
+		});
+
+		it("pause() should pause the underlying state", () => {
+			expect(state.isPaused()).toBe(false);
+			game.pause();
+			expect(state.isPaused()).toBe(true);
+			game.resume();
+			expect(state.isPaused()).toBe(false);
+		});
+
+		it("freeze() should pause immediately and resume after the duration", async () => {
+			vi.useFakeTimers();
+			expect(state.isPaused()).toBe(false);
+
+			const done = game.freeze(100);
+			expect(state.isPaused()).toBe(true);
+
+			await vi.advanceTimersByTimeAsync(100);
+			await done;
+
+			expect(state.isPaused()).toBe(false);
+		});
+
+		it("freeze() should return a Promise that resolves on unfreeze", async () => {
+			vi.useFakeTimers();
+			let resolved = false;
+			const done = game.freeze(50).then(() => {
+				resolved = true;
+			});
+
+			expect(resolved).toBe(false);
+			await vi.advanceTimersByTimeAsync(50);
+			await done;
+			expect(resolved).toBe(true);
+		});
+
+		it("freeze() should extend (not stack) when called again with a later end-time", async () => {
+			vi.useFakeTimers();
+			const first = game.freeze(100);
+
+			// at t=50, request another 100ms freeze (ends at t=150, later than t=100)
+			await vi.advanceTimersByTimeAsync(50);
+			const second = game.freeze(100);
+
+			// at t=120, the first freeze would have ended — but we extended, so still paused
+			await vi.advanceTimersByTimeAsync(70);
+			expect(state.isPaused()).toBe(true);
+
+			// at t=150, the extended freeze should end
+			await vi.advanceTimersByTimeAsync(30);
+			await Promise.all([first, second]);
+			expect(state.isPaused()).toBe(false);
+		});
+
+		it("freeze() should silently no-op for invalid durations (NaN/Infinity/negative)", async () => {
+			expect(state.isPaused()).toBe(false);
+
+			await game.freeze(Number.NaN);
+			expect(state.isPaused()).toBe(false);
+
+			await game.freeze(Number.POSITIVE_INFINITY);
+			expect(state.isPaused()).toBe(false);
+
+			await game.freeze(-100);
+			expect(state.isPaused()).toBe(false);
+		});
+
+		it("freeze() should NOT shorten when called with an earlier end-time", async () => {
+			vi.useFakeTimers();
+			const long = game.freeze(200);
+
+			// at t=10, request a shorter freeze — should be ignored
+			await vi.advanceTimersByTimeAsync(10);
+			const short = game.freeze(50);
+
+			// at t=80, short would have ended but long is still active
+			await vi.advanceTimersByTimeAsync(70);
+			expect(state.isPaused()).toBe(true);
+
+			// at t=200, long ends — both promises should resolve
+			await vi.advanceTimersByTimeAsync(120);
+			await Promise.all([long, short]);
+			expect(state.isPaused()).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
## Summary

- New `state.freeze(duration, music?)` primitive that pauses the stage for a fixed duration, then auto-resumes. Returns a `Promise<void>` that resolves on unfreeze. Reentrant calls **extend** to whichever end-time is later (they do not stack); invalid durations (`NaN` / `Infinity` / negative) silently no-op.
- Convenience proxies on `Application`: `app.pause(music?)`, `app.resume(music?)`, `app.freeze(duration, music?)`.
- Whac-a-mole example showcases the new API: per-mole drop shadow + chromatic-aberration burst on hit, viewport vignette, screen shake, and a 150ms freeze wired into `MoleEntity.onMouseDown`.

## Why

Hit-stop / hit-pause is the classic "freeze the world for a few frames on impact" effect used in fighting games, action games, and platformers. It's the single biggest contributor to making hits feel _crunchy_, and is usually paired with screen shake and a chromatic-aberration burst (the "juice trifecta"). Until now this required hand-rolling `state.pause()` + `setTimeout(() => state.resume())` with no extend/reentrancy support.

## API

```ts
// freeze for 80ms; resolves on unfreeze
await app.freeze(80);

// also pause the music track during the freeze
app.freeze(150, true);

// reentrant: second call extends end-time only if later
app.freeze(100);
app.freeze(200); // total freeze is now 200ms from second call
```

## Test plan

- [x] `pnpm --filter melonjs exec vitest run tests/application.spec.js` — 40/40 passing (5 new freeze tests)
- [x] `pnpm --filter melonjs exec tsc --noEmit` — clean
- [x] `pnpm --filter examples exec tsc --noEmit` — clean
- [x] Whac-a-mole example: clicking an "out" mole now produces a clearly perceptible hit-stop (visible mid-shake freeze) + chromatic burst + drop shadow

## Files changed

| File | Change |
| --- | --- |
| `src/state/state.ts` | New `freeze()` method + `_endFreeze()` helper |
| `src/application/application.ts` | `pause/resume/freeze` proxies |
| `tests/application.spec.js` | 5 new tests covering freeze, extend, no-shorten, invalid input |
| `CHANGELOG.md` | Entries under `19.2.0 _unreleased_` |
| `examples/whac-a-mole/effects.ts` (new) | Per-sprite shader helpers |
| `examples/whac-a-mole/{ExampleWhacAMole,mole}.ts` | Wire effects + freeze on hit |

🤖 Generated with [Claude Code](https://claude.com/claude-code)