### PR TITLE
fix(state): freeze() edge cases — manual pause/resume + window blur

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Rendering: `IndexBuffer` split into renderer-agnostic `IndexBuffer` base (data accumulation) and `WebGLIndexBuffer` (GL buffer bind/upload)
 
 ### Fixed
+- State: `state.freeze()` no longer leaves the game in inconsistent states when interacting with manual pause/resume or window blur. Specifically: (a) the freeze timer's auto-resume now respects whether the game was already paused when freeze started — won't unpause a manually-paused game on expiry; (b) calling `state.resume()` or `state.stop()` mid-freeze cancels the timer and resolves the freeze promise immediately; (c) window `BLUR` cancels the freeze (the visual "moment" is over by the time the user returns; regular `pauseOnBlur` keeps the game paused while away).
 - ParticleEmitter: constructor was using bitwise `|` instead of logical `||` for the `width`/`height` fallback, which silently rounded any provided value to the next odd number (e.g. `width: 16 → 17`, `width: 32 → 33`).
 - Canvas: `setMask(shape, true)` now uses `evenodd` clipping for proper inverted mask support (was using `destination-atop` composite which didn't clip subsequent draws)
 - Ellipse: `clone()` now uses the ellipse pool instead of `new Ellipse()` — consistent with `Polygon.clone()` which already uses its pool

--- a/packages/melonjs/src/application/application.ts
+++ b/packages/melonjs/src/application/application.ts
@@ -573,12 +573,15 @@ export default class Application {
 
 	/**
 	 * Freeze the current stage for a fixed duration, then automatically resume.
-	 * Useful for hit-stop / hit-pause effects on impact. Reentrant calls extend
-	 * the freeze to whichever end-time is later (they do not stack).
-	 * Convenience proxy for {@link state.freeze}.
+	 * Useful for hit-stop / hit-pause effects on impact.
+	 *
+	 * Convenience proxy for {@link state.freeze}; see that method's
+	 * documentation for the full behaviour matrix (extend-not-stack semantics,
+	 * interaction with manual `state.pause()` / `state.resume()`, automatic
+	 * cancellation on window blur, etc.).
 	 * @param duration - duration of the freeze in milliseconds
 	 * @param [music=false] - also pause the current music track during the freeze
-	 * @returns a Promise that resolves once the freeze ends
+	 * @returns a Promise that resolves once the freeze ends (or is cancelled)
 	 * @example
 	 * // simple hit-stop on impact
 	 * app.freeze(80);

--- a/packages/melonjs/src/state/state.ts
+++ b/packages/melonjs/src/state/state.ts
@@ -5,6 +5,7 @@ import MaskEffect from "../camera/effects/mask_effect.ts";
 import DefaultLoadingScreen from "./../loader/loadingscreen.js";
 import Stage from "./../state/stage.ts";
 import {
+	BLUR,
 	BOOT,
 	emit,
 	GAME_INIT,
@@ -66,6 +67,8 @@ let _pauseTime: number = 0;
 let _freezeTimer: ReturnType<typeof setTimeout> | null = null;
 let _freezeEndsAt: number = 0;
 let _freezeMusic: boolean = false;
+// whether freeze() itself performed the pause (vs. the game was already paused)
+let _freezeStartedPause: boolean = false;
 let _freezeResolvers: Array<() => void> = [];
 
 /**
@@ -100,17 +103,45 @@ function _pauseRunLoop(): void {
 }
 
 /**
- * End an active freeze: resume the run loop and resolve waiters.
+ * Drain and resolve any pending freeze() promises.
+ * @ignore
+ */
+function _resolveFreezeWaiters(): void {
+	const resolvers = _freezeResolvers;
+	_freezeResolvers = [];
+	for (const resolve of resolvers) {
+		resolve();
+	}
+}
+
+/**
+ * End an active freeze on timer expiry: optionally resume the run loop
+ * (only if freeze itself performed the pause), then resolve waiters.
  * @ignore
  */
 function _endFreeze(): void {
 	_freezeTimer = null;
 	_freezeEndsAt = 0;
-	state.resume(_freezeMusic);
-	const resolvers = _freezeResolvers;
-	_freezeResolvers = [];
-	for (const resolve of resolvers) {
-		resolve();
+	const wasOwnedPause = _freezeStartedPause;
+	_freezeStartedPause = false;
+	if (wasOwnedPause) {
+		state.resume(_freezeMusic);
+	}
+	_resolveFreezeWaiters();
+}
+
+/**
+ * Cancel any active freeze without auto-resuming (the caller is taking over
+ * pause/resume control). Clears the timer and resolves pending waiters.
+ * @ignore
+ */
+function _cancelFreeze(): void {
+	if (_freezeTimer !== null) {
+		clearTimeout(_freezeTimer);
+		_freezeTimer = null;
+		_freezeEndsAt = 0;
+		_freezeStartedPause = false;
+		_resolveFreezeWaiters();
 	}
 }
 
@@ -195,6 +226,13 @@ once(BOOT, () => {
 	once(VIDEO_INIT, () => {
 		state.change(state.DEFAULT, true);
 	});
+	// cancel any in-flight freeze when the window loses focus — the visual
+	// hit-stop is short enough that by the time the user comes back the
+	// "moment" is over. Application._onBlur still pauses the state via the
+	// regular pauseOnBlur path, so the game stays paused while away.
+	on(BLUR, () => {
+		_cancelFreeze();
+	});
 });
 
 /**
@@ -269,6 +307,8 @@ const state = {
 	stop(shouldPauseTrack: boolean = false): void {
 		// only stop when we are not loading stuff
 		if (_state !== this.LOADING && this.isRunning()) {
+			// caller is taking over — drop any in-flight freeze
+			_cancelFreeze();
 			// stop the main loop
 			_stopRunLoop();
 
@@ -334,6 +374,8 @@ const state = {
 	 */
 	resume(music: boolean = false): void {
 		if (this.isPaused()) {
+			// caller is taking over — drop any in-flight freeze
+			_cancelFreeze();
 			// resume the main loop
 			_resumeRunLoop();
 			// current music stop
@@ -353,12 +395,22 @@ const state = {
 	 * Freeze the current stage for a fixed duration, then automatically resume.
 	 * Useful for hit-stop / hit-pause effects on impact.
 	 *
-	 * If `freeze()` is called again while a freeze is already active, the freeze
-	 * is *extended* to whichever end-time is later (calls do not stack). The
-	 * `music` flag from the initial call is preserved for the eventual resume.
+	 * Behaviour notes:
+	 * - If `freeze()` is called again while a freeze is already active, the
+	 *   freeze is *extended* to whichever end-time is later (calls do not
+	 *   stack). The `music` flag from the initial call is preserved.
+	 * - If the game was already paused when `freeze()` was called, the freeze
+	 *   timer will *not* unpause it on expiry — the game stays paused.
+	 * - Calling `state.resume()` or `state.stop()` while a freeze is active
+	 *   cancels the timer and resolves the returned promise immediately.
+	 * - The freeze is also cancelled when the window loses focus (BLUR) since
+	 *   the hit-stop's "moment" is short enough that the user has missed it
+	 *   by the time they return. The regular `pauseOnBlur` behaviour still
+	 *   keeps the game paused while away.
+	 * - Negative, `NaN`, and `Infinity` durations silently no-op.
 	 * @param duration - duration of the freeze in milliseconds
 	 * @param [music=false] - also pause the current music track during the freeze
-	 * @returns a Promise that resolves once the freeze ends
+	 * @returns a Promise that resolves once the freeze ends (or is cancelled)
 	 * @example
 	 * // simple hit-stop on impact
 	 * state.freeze(80);
@@ -387,7 +439,12 @@ const state = {
 			// start a new freeze
 			_freezeMusic = music;
 			_freezeEndsAt = newEndsAt;
-			this.pause(music);
+			// only own the pause if the game wasn't already paused — that way
+			// _endFreeze() won't unpause a manually-paused game on timer expiry
+			_freezeStartedPause = !this.isPaused();
+			if (_freezeStartedPause) {
+				this.pause(music);
+			}
 			_freezeTimer = setTimeout(_endFreeze, duration);
 		}
 

--- a/packages/melonjs/tests/application.spec.js
+++ b/packages/melonjs/tests/application.spec.js
@@ -340,6 +340,91 @@ describe("Application", () => {
 			await Promise.all([long, short]);
 			expect(state.isPaused()).toBe(false);
 		});
+
+		it("freeze() should leave game paused on timeout if it was already paused", async () => {
+			vi.useFakeTimers();
+			state.pause();
+			expect(state.isPaused()).toBe(true);
+
+			const done = game.freeze(100);
+			expect(state.isPaused()).toBe(true);
+
+			await vi.advanceTimersByTimeAsync(100);
+			await done;
+
+			// freeze didn't own the pause — game must remain paused
+			expect(state.isPaused()).toBe(true);
+		});
+
+		it("manual state.resume() during freeze should cancel timer and resolve waiters", async () => {
+			vi.useFakeTimers();
+			let resolved = false;
+			const done = game.freeze(500).then(() => {
+				resolved = true;
+			});
+			expect(state.isPaused()).toBe(true);
+
+			// user resumes manually before the freeze timer fires
+			state.resume();
+			expect(state.isPaused()).toBe(false);
+
+			// freeze promise should resolve immediately (cancelled)
+			await done;
+			expect(resolved).toBe(true);
+
+			// no zombie timer — advancing time should not affect anything
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(state.isPaused()).toBe(false);
+		});
+
+		it("freeze() called after a manual resume should re-pause properly", async () => {
+			vi.useFakeTimers();
+			game.freeze(500);
+			expect(state.isPaused()).toBe(true);
+
+			state.resume();
+			expect(state.isPaused()).toBe(false);
+
+			// a new freeze must actually re-pause the game (not hit the
+			// "already frozen" extend branch because of a stale timer)
+			const done = game.freeze(100);
+			expect(state.isPaused()).toBe(true);
+
+			await vi.advanceTimersByTimeAsync(100);
+			await done;
+			expect(state.isPaused()).toBe(false);
+		});
+
+		it("window blur should cancel an in-flight freeze and resolve waiters", async () => {
+			vi.useFakeTimers();
+			let resolved = false;
+			const done = game.freeze(500).then(() => {
+				resolved = true;
+			});
+			expect(state.isPaused()).toBe(true);
+
+			// emit BLUR the same way device.js does on visibility loss —
+			// state.ts's listener cancels the freeze + resolves the promise
+			const { emit, BLUR } = await import("../src/system/event.ts");
+			emit(BLUR);
+
+			// freeze promise resolves immediately — no waiting for the 500ms
+			await done;
+			expect(resolved).toBe(true);
+
+			// state stays paused (Application._onBlur's regular pauseOnBlur path
+			// keeps it that way until focus returns) — but the freeze timer is
+			// gone, so a manual resume unpauses normally with no zombie timer.
+			state.resume();
+			expect(state.isPaused()).toBe(false);
+
+			// and a fresh freeze still works
+			const next = game.freeze(50);
+			expect(state.isPaused()).toBe(true);
+			await vi.advanceTimersByTimeAsync(50);
+			await next;
+			expect(state.isPaused()).toBe(false);
+		});
 	});
 
 	describe("parentApp", () => {


### PR DESCRIPTION
## Summary

Follow-up to #1421 fixing three bugs in `state.freeze()` that shipped with the original PR:

1. **Phantom unpause on timer expiry when game was already paused.** If `freeze()` was called while the game was already paused (manual `state.pause()` or `pauseOnBlur` handler), the freeze timer's auto-resume on expiry would incorrectly unpause the game.

2. **No cancellation hook for manual `resume()` / `stop()`.** If a user called `state.resume()` or `state.stop()` mid-freeze, the timer stayed armed:
   - the returned `Promise<void>` didn't resolve until the original timeout
   - a subsequent `freeze()` call hit the "already frozen" extend branch and skipped `this.pause()`, leaving the game running

3. **Window BLUR while freezing.** The browser throttles `setTimeout` to ~1Hz on unfocused windows, so a 150ms freeze timer would fire during the blur period and call `state.resume()` — putting `state._isPaused = false` while the window was still blurred. By the time focus returned, the game was "running" but RAF was throttled, so it was visually invisible but violated the `pauseOnBlur` invariant.

## Fix

- **`_freezeStartedPause`** flag tracks whether `freeze()` itself performed the pause. `_endFreeze()` only auto-resumes when the freeze owns the pause.
- **`_cancelFreeze()`** helper called from `state.resume()` and `state.stop()` clears the timer + resolves pending waiters. Restores predictable state when the user takes manual control.
- **BLUR listener** in `state.ts` calls `_cancelFreeze()` on window blur — the visual "moment" is short enough that the user has missed it by the time they return. `Application._onBlur` still pauses the state via the regular `pauseOnBlur` path, so the game stays paused while away.

## Tests

4 new tests in `application.spec.js`:
- `freeze() should leave game paused on timeout if it was already paused`
- `manual state.resume() during freeze should cancel timer and resolve waiters`
- `freeze() called after a manual resume should re-pause properly`
- `window blur should cancel an in-flight freeze and resolve waiters`

All 2725 tests pass (4 new), build clean, no unhandled errors.

## Docs

- `state.freeze` JSDoc spells out the full behaviour matrix (extend semantics, manual-pause interaction, blur cancellation, invalid durations).
- `Application.freeze` JSDoc points to `state.freeze` for details.
- `CHANGELOG.md` entry under `19.2.0 _unreleased_` → `Fixed`.

## Test plan

- [x] `pnpm --filter melonjs exec vitest run` — 2725/2725 passing
- [x] `pnpm --filter melonjs exec tsc --noEmit` — clean
- [x] `pnpm --filter melonjs build` — clean (lint passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)