### PR TITLE
chore: bump melonjs to 19.3.0 for next dev cycle

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [19.3.0] (melonJS 2) - _unreleased_
+
 ## [19.2.0] (melonJS 2) - _2026-04-29_
 
 ### Added

--- a/packages/melonjs/package.json
+++ b/packages/melonjs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "melonjs",
-	"version": "19.2.0",
+	"version": "19.3.0",
 	"description": "melonJS Game Engine",
 	"homepage": "http://www.melonjs.org/",
 	"type": "module",


### PR DESCRIPTION
Open the 19.3.0 development cycle.

- `packages/melonjs/package.json`: `19.2.0` → `19.3.0`
- `CHANGELOG.md`: prepend a fresh `## [19.3.0] (melonJS 2) - _unreleased_` block so new entries can land cleanly during the cycle

Touches one non-md file (`package.json`), so CI should run normally — no admin-merge needed.