### PR TITLE
fix(light2d): align gradient with cutout under centered anchor

### DIFF
--- a/packages/examples/src/examples/lights/ExampleLights.tsx
+++ b/packages/examples/src/examples/lights/ExampleLights.tsx
@@ -49,7 +49,7 @@ class PlayScreen extends Stage {
 		// ambient fill simultaneously.
 		const orangeLight = new Light2d(
 			game.viewport.width * 0.18,
-			game.viewport.height * 0.65,
+			game.viewport.height * 0.725,
 			140,
 			100,
 			"#ff8a3c",

--- a/packages/melonjs/src/renderable/light2d.js
+++ b/packages/melonjs/src/renderable/light2d.js
@@ -244,12 +244,6 @@ export default class Light2d extends Renderable {
 	 * @param {Camera2d} [viewport] - the viewport to (re)draw
 	 */
 	draw(renderer) {
-		// Draw at `pos` (Sprite-style): Renderable.preDraw has already
-		// applied the anchor offset (`translate(-w/2, -h/2)` for
-		// anchorPoint=(0.5, 0.5)), so the texture top-left lands at
-		// `(pos.x − r, pos.y − r)` and its gradient center at `(pos.x, pos.y)`.
-		// Using `getBounds().x/y` (which is `pos − r`) here would double-count
-		// the anchor offset and shift the bright spot by `(−r, −r)`.
 		renderer.drawImage(this.texture.canvas, this.pos.x, this.pos.y);
 	}
 

--- a/packages/melonjs/src/renderable/light2d.js
+++ b/packages/melonjs/src/renderable/light2d.js
@@ -244,11 +244,13 @@ export default class Light2d extends Renderable {
 	 * @param {Camera2d} [viewport] - the viewport to (re)draw
 	 */
 	draw(renderer) {
-		renderer.drawImage(
-			this.texture.canvas,
-			this.getBounds().x,
-			this.getBounds().y,
-		);
+		// Draw at `pos` (Sprite-style): Renderable.preDraw has already
+		// applied the anchor offset (`translate(-w/2, -h/2)` for
+		// anchorPoint=(0.5, 0.5)), so the texture top-left lands at
+		// `(pos.x − r, pos.y − r)` and its gradient center at `(pos.x, pos.y)`.
+		// Using `getBounds().x/y` (which is `pos − r`) here would double-count
+		// the anchor offset and shift the bright spot by `(−r, −r)`.
+		renderer.drawImage(this.texture.canvas, this.pos.x, this.pos.y);
 	}
 
 	/**

--- a/packages/melonjs/tests/lights.spec.js
+++ b/packages/melonjs/tests/lights.spec.js
@@ -818,6 +818,29 @@ describe("Light2d + Stage lighting", () => {
 			game.world.removeChildNow(light, true);
 		});
 
+		it("draw() places the gradient center at pos.x/pos.y (anchor-aware regression guard)", () => {
+			// The bug this catches: with anchorPoint=(0.5, 0.5),
+			// Renderable.preDraw already calls translate(-w/2, -h/2), so
+			// Light2d.draw must use LOCAL pos coords — using getBounds().x/y
+			// (which is pos − r post-anchor) would double-apply the offset
+			// and shift the bright spot by (−r, −r) on screen.
+			const light = spawn(150, 100, 30);
+			const drawImageCalls = [];
+			const stub = {
+				drawImage: (img, x, y) => {
+					drawImageCalls.push({ x, y });
+				},
+			};
+			light.draw(stub);
+			expect(drawImageCalls).toHaveLength(1);
+			// Texture top-left passed as drawImage args must equal pos
+			// (NOT pos − r, which would be getBounds().x/y).
+			expect(drawImageCalls[0].x).toBe(150);
+			expect(drawImageCalls[0].y).toBe(100);
+
+			game.world.removeChildNow(light, true);
+		});
+
 		it("transform around `pos` (regression guard): scale does NOT shift the visible center by half-the-bbox", () => {
 			// Concrete regression: with anchorPoint=(0,0) (or a forgotten
 			// anchor reset), a 2× scale would shift the center by

--- a/packages/melonjs/tests/lights.spec.js
+++ b/packages/melonjs/tests/lights.spec.js
@@ -818,12 +818,7 @@ describe("Light2d + Stage lighting", () => {
 			game.world.removeChildNow(light, true);
 		});
 
-		it("draw() places the gradient center at pos.x/pos.y (anchor-aware regression guard)", () => {
-			// The bug this catches: with anchorPoint=(0.5, 0.5),
-			// Renderable.preDraw already calls translate(-w/2, -h/2), so
-			// Light2d.draw must use LOCAL pos coords — using getBounds().x/y
-			// (which is pos − r post-anchor) would double-apply the offset
-			// and shift the bright spot by (−r, −r) on screen.
+		it("draw() passes pos.x/pos.y to drawImage (anchor-aware regression guard)", () => {
 			const light = spawn(150, 100, 30);
 			const drawImageCalls = [];
 			const stub = {
@@ -833,8 +828,6 @@ describe("Light2d + Stage lighting", () => {
 			};
 			light.draw(stub);
 			expect(drawImageCalls).toHaveLength(1);
-			// Texture top-left passed as drawImage args must equal pos
-			// (NOT pos − r, which would be getBounds().x/y).
 			expect(drawImageCalls[0].x).toBe(150);
 			expect(drawImageCalls[0].y).toBe(100);
 


### PR DESCRIPTION
## Summary

Regression fix for the anchor refactor in #1431. With \`anchorPoint=(0.5, 0.5)\`, \`Renderable.preDraw\` already translates the renderer by \`(-w/2, -h/2)\`. \`Light2d.draw\` was still using \`getBounds().x/y\` (which equals \`pos - r\` post-anchor) — that double-applied the offset and shifted the gradient by \`(-r, -r)\` on screen, while the ambient cutout (drawn outside the per-renderable transform stack) stayed at \`pos\`. Visible as a misaligned hole-vs-bright-spot in the lights example, screenshotted by @obiot.

Fix: \`drawImage\` at \`(this.pos.x, this.pos.y)\` (Sprite-style), letting preDraw's anchor offset handle the centering.

## Test plan

- [x] New unit test stubs \`drawImage\` and pins the contract that the call coords equal \`pos\` (not \`pos - r\`)
- [x] Visual: lights example WebGL + Canvas, both lights' bright centers now line up with their cutouts
- [x] \`pnpm exec vitest run\` — 84 / 2788 passing
- [x] \`pnpm lint\` — clean

Also re-tunes the example's orange light Y so it still clears the bottom of the viewport visually after the anchor change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)