### PR TITLE
chore(ci): teach publish.yml to publish @melonjs/capacitor-plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ on:
           - debug-plugin
           - tiled-inflate-plugin
           - spine-plugin
+          - capacitor-plugin
           - create-melonjs
       dry-run:
         description: "Dry run (skip actual publish)"
@@ -64,6 +65,9 @@ jobs:
             echo "build_cmd=pnpm clean && pnpm build" >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.package }}" = "spine-plugin" ]; then
             echo "dir=packages/spine-plugin" >> "$GITHUB_OUTPUT"
+            echo "build_cmd=pnpm clean && pnpm build" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.package }}" = "capacitor-plugin" ]; then
+            echo "dir=packages/capacitor-plugin" >> "$GITHUB_OUTPUT"
             echo "build_cmd=pnpm clean && pnpm build" >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.package }}" = "create-melonjs" ]; then
             echo "dir=packages/create-melonjs" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Adds `capacitor-plugin` to the publish workflow so the new package can be released the same way as the existing plugins.

Two-line change:
- New entry in the `workflow_dispatch.inputs.package` choice list.
- New `elif` branch in the `Set package directory` step, pointing at `packages/capacitor-plugin` with `pnpm clean && pnpm build` (mirrors the existing plugins' build command).

## Notes

- `npm publish --access=public --provenance` works identically for the new scoped package — no flow changes required.
- One-time prerequisite: npmjs.com needs a trusted-publisher entry for `@melonjs/capacitor-plugin` (or the `@melonjs` scope config has to cover it). If the first publish fails on missing trust config, configure a "pending publisher" entry under the `melonjs` npm user's package settings and re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)