### PR TITLE
revert(create-melonjs): drop --template flag

### DIFF
--- a/packages/create-melonjs/CHANGELOG.md
+++ b/packages/create-melonjs/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## 1.1.0
-
-### New Features
-- `--template <name>` (alias `-t`) flag to pick a starter template. `default` (current behavior, points at `melonjs/typescript-boilerplate`) and `capacitor` (points at `melonjs/typescript-boilerplate-capacitor` for iOS/Android wrapping via Capacitor) are recognized; any other value errors out with the list of known templates. Output now reports which template was used and prints template-specific next-step instructions (capacitor includes `cap add` / `cap copy` / `cap open`).
-
 ## 1.0.1
 
 ### Bug Fixes

--- a/packages/create-melonjs/README.md
+++ b/packages/create-melonjs/README.md
@@ -18,19 +18,6 @@ This downloads the [melonJS TypeScript boilerplate](https://github.com/melonjs/t
 - [Vite](https://vitejs.dev) — fast dev server and bundler
 - [Debug plugin](https://github.com/melonjs/debug-plugin) — auto-loaded in development mode
 
-## Templates
-
-Pick a different starter with `--template <name>` (or `-t`):
-
-```bash
-npm create melonjs my-game --template capacitor
-```
-
-| name | source | description |
-| --- | --- | --- |
-| `default` | [`melonjs/typescript-boilerplate`](https://github.com/melonjs/typescript-boilerplate) | Plain TypeScript + Vite (used when no `--template` flag is passed). |
-| `capacitor` | [`melonjs/typescript-boilerplate-capacitor`](https://github.com/melonjs/typescript-boilerplate-capacitor) | TypeScript + Vite + [Capacitor](https://capacitorjs.com/) wrapper for iOS / Android, pre-wired with [`@melonjs/capacitor-plugin`](https://github.com/melonjs/melonJS/tree/master/packages/capacitor-plugin). |
-
 ## Links
 
 - [melonJS Documentation](https://melonjs.github.io/melonJS/)

--- a/packages/create-melonjs/bin/create-melonjs.js
+++ b/packages/create-melonjs/bin/create-melonjs.js
@@ -5,61 +5,26 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-const TEMPLATES = {
-	default: "melonjs/typescript-boilerplate",
-	capacitor: "melonjs/typescript-boilerplate-capacitor",
-};
+const REPO = "melonjs/typescript-boilerplate";
 const BRANCH = "main";
 
 const green = (text) => `\x1b[32m${text}\x1b[0m`;
 const bold = (text) => `\x1b[1m${text}\x1b[0m`;
 const dim = (text) => `\x1b[2m${text}\x1b[0m`;
 
-function parseArgs(argv) {
-	const args = { positional: [], template: "default" };
-	for (let i = 0; i < argv.length; i++) {
-		const token = argv[i];
-		if (token === "--template" || token === "-t") {
-			args.template = argv[++i];
-		} else if (token?.startsWith("--template=")) {
-			args.template = token.slice("--template=".length);
-		} else if (token?.startsWith("-")) {
-			console.error(`\nError: unknown flag "${token}".\n`);
-			process.exit(1);
-		} else {
-			args.positional.push(token);
-		}
-	}
-	return args;
-}
-
 function main() {
-	const { positional, template } = parseArgs(process.argv.slice(2));
-	const projectName = positional[0];
+	const projectName = process.argv[2];
 
 	if (!projectName) {
 		console.log(`
-${bold("Usage:")} npm create melonjs ${dim("<project-name>")} ${dim("[--template <name>]")}
+${bold("Usage:")} npm create melonjs ${dim("<project-name>")}
 
-${bold("Templates:")}
-  ${dim("default")}    Plain TypeScript + Vite boilerplate (default)
-  ${dim("capacitor")}  TypeScript + Vite + Capacitor wrapper for iOS/Android
-
-${bold("Examples:")}
+${bold("Example:")}
   npm create melonjs my-game
-  npm create melonjs my-game --template capacitor
   cd my-game
   npm install
   npm run dev
 `);
-		process.exit(1);
-	}
-
-	const repo = TEMPLATES[template];
-	if (!repo) {
-		console.error(
-			`\nError: unknown template "${template}". Known templates: ${Object.keys(TEMPLATES).join(", ")}.\n`,
-		);
 		process.exit(1);
 	}
 
@@ -70,15 +35,13 @@ ${bold("Examples:")}
 		process.exit(1);
 	}
 
-	console.log(
-		`\nCreating a new melonJS game in ${green(targetDir)} (template: ${bold(template)})...\n`,
-	);
+	console.log(`\nCreating a new melonJS game in ${green(targetDir)}...\n`);
 
 	// download the boilerplate
 	// try degit first (fast, no git history)
 	const degitResult = spawnSync(
 		"npx",
-		["--yes", "degit", `${repo}#${BRANCH}`, targetDir],
+		["--yes", "degit", `${REPO}#${BRANCH}`, targetDir],
 		{
 			stdio: "inherit",
 			shell: process.platform === "win32",
@@ -96,7 +59,7 @@ ${bold("Examples:")}
 				"1",
 				"-b",
 				BRANCH,
-				`https://github.com/${repo}.git`,
+				`https://github.com/${REPO}.git`,
 				targetDir,
 			],
 			{ stdio: "inherit" },
@@ -120,25 +83,14 @@ ${bold("Examples:")}
 		writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 	}
 
-	const nextSteps =
-		template === "capacitor"
-			? `  ${dim("$")} cd ${projectName}
-  ${dim("$")} npm install
-  ${dim("$")} npm run dev          ${dim("# develop in the browser")}
-  ${dim("$")} npm run build
-  ${dim("$")} npx cap add ios      ${dim("# or: npx cap add android")}
-  ${dim("$")} npx cap copy
-  ${dim("$")} npx cap open ios     ${dim("# build & run from Xcode / Android Studio")}`
-			: `  ${dim("$")} cd ${projectName}
-  ${dim("$")} npm install
-  ${dim("$")} npm run dev`;
-
 	console.log(`
 ${green("Done!")} Created ${bold(projectName)}.
 
 Next steps:
 
-${nextSteps}
+  ${dim("$")} cd ${projectName}
+  ${dim("$")} npm install
+  ${dim("$")} npm run dev
 
 Happy game making! ${green("🍈")}
 `);

--- a/packages/create-melonjs/package.json
+++ b/packages/create-melonjs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-melonjs",
-	"version": "1.1.0",
+	"version": "1.0.1",
 	"description": "Create a new melonJS game project",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Walks back the `--template <name>` / `-t` flag added to `create-melonjs` in #1439. Aligns with how the other plugins (`@melonjs/spine-plugin`, `@melonjs/tiled-inflate-plugin`, `@melonjs/debug-plugin`) work today — users scaffold the default boilerplate and `npm install` the plugin themselves.

The Capacitor wiki page (draft at `/tmp/Capacitor.md`) documents the manual steps. No new boilerplate repo or subfolder needed.

## Why revert

Two undesirable downstream costs of the flag:

1. **Maintaining a Capacitor-flavored boilerplate** — either a separate `typescript-boilerplate-capacitor` repo (drift on every melonJS / `@melonjs/*` bump) or a `capacitor/` subfolder of the existing repo (cleaner but still extra surface).
2. **Or patching the default scaffold mid-install** — the alternative without a separate boilerplate, but couples `create-melonjs` to the boilerplate's source layout (regex/AST edits to `src/main.ts`, `package.json` merges, etc.).

Neither is worth it. The Capacitor plugin is just `npm install` + a single `plugin.register(...)` call, same as the existing plugins.

## Files

- `packages/create-melonjs/bin/create-melonjs.js` — back to 99 lines, no flag parsing.
- `packages/create-melonjs/package.json` — version stays at 1.0.1 (the 1.1.0 bump was never published).
- `packages/create-melonjs/CHANGELOG.md` — 1.1.0 entry removed.
- `packages/create-melonjs/README.md` — templates table removed.

The `@melonjs/capacitor-plugin` package itself is unaffected; this is `create-melonjs`-only.

## Test plan

- [x] `pnpm lint` — 0 errors.
- [x] `node bin/create-melonjs.js` — usage banner is back to the original (no `--template` mention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)