### PR TITLE
chore(spine-plugin): bump Spine runtimes to ^4.2.114, release 2.2.1

### DIFF
--- a/packages/spine-plugin/CHANGELOG.md
+++ b/packages/spine-plugin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.1 - 2026-05-11
+
+### Changed
+- Bump bundled Spine runtimes (`@esotericsoftware/spine-canvas`, `spine-core`, `spine-webgl`) range from `^4.2.109` to `^4.2.114`. Picks up the empty-atlas hang fix in `AssetManagerBase` (4.2.113) — `loadTextureAtlas` no longer waits forever on an atlas with zero pages. No plugin API change.
+
 ## 2.2.0 - 2026-04-15
 
 ### Added

--- a/packages/spine-plugin/CHANGELOG.md
+++ b/packages/spine-plugin/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.2.1 - 2026-05-11
 
 ### Changed
-- Bump bundled Spine runtimes (`@esotericsoftware/spine-canvas`, `spine-core`, `spine-webgl`) range from `^4.2.109` to `^4.2.114`. Picks up the empty-atlas hang fix in `AssetManagerBase` (4.2.113) — `loadTextureAtlas` no longer waits forever on an atlas with zero pages. No plugin API change.
+- Bump bundled Spine runtimes (`@esotericsoftware/spine-canvas`, `@esotericsoftware/spine-core`, `@esotericsoftware/spine-webgl`) range from `^4.2.109` to `^4.2.114`. Picks up the empty-atlas hang fix in `AssetManagerBase` (4.2.113) — `loadTextureAtlas` no longer waits forever on an atlas with zero pages. No plugin API change.
 
 ## 2.2.0 - 2026-04-15
 

--- a/packages/spine-plugin/package.json
+++ b/packages/spine-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@melonjs/spine-plugin",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "melonJS Spine plugin",
 	"homepage": "https://www.npmjs.com/package/@melonjs/spine-plugin",
 	"type": "module",
@@ -50,9 +50,9 @@
 		"melonjs": ">=18.3.0"
 	},
 	"dependencies": {
-		"@esotericsoftware/spine-canvas": "^4.2.109",
-		"@esotericsoftware/spine-core": "^4.2.109",
-		"@esotericsoftware/spine-webgl": "^4.2.109"
+		"@esotericsoftware/spine-canvas": "^4.2.114",
+		"@esotericsoftware/spine-core": "^4.2.114",
+		"@esotericsoftware/spine-webgl": "^4.2.114"
 	},
 	"devDependencies": {
 		"concurrently": "^9.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,14 +218,14 @@ importers:
   packages/spine-plugin:
     dependencies:
       '@esotericsoftware/spine-canvas':
-        specifier: ^4.2.109
-        version: 4.2.109
+        specifier: ^4.2.114
+        version: 4.2.114
       '@esotericsoftware/spine-core':
-        specifier: ^4.2.109
-        version: 4.2.109
+        specifier: ^4.2.114
+        version: 4.2.114
       '@esotericsoftware/spine-webgl':
-        specifier: ^4.2.109
-        version: 4.2.109
+        specifier: ^4.2.114
+        version: 4.2.114
     devDependencies:
       concurrently:
         specifier: ^9.2.1
@@ -568,14 +568,14 @@ packages:
     resolution: {integrity: sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@esotericsoftware/spine-canvas@4.2.109':
-    resolution: {integrity: sha512-7tE5QbQgsxBAUUVCfEqK8MC2neUgnr7NwPOfYrqiNH1ooVjdchZxf2Nx+pIcX2CUh/FXbThpS1jfFxvVKaADVQ==}
+  '@esotericsoftware/spine-canvas@4.2.114':
+    resolution: {integrity: sha512-S3dCXYfp5188n9JXLQQWBHfDxmBLWZlyEBZ2SXm3EIq6CSOzs8U+BT0iMCJOe1qRcNdysOxbCsOJsGOtIknjuw==}
 
-  '@esotericsoftware/spine-core@4.2.109':
-    resolution: {integrity: sha512-Olr7p+qcy7ahWJoqwU8JsAPH0I54Pi7LjpJ512tLIgd0GkCi45Jh6N2JLPMAUZ6O+V77cpu+W1qyQ73W4nILeQ==}
+  '@esotericsoftware/spine-core@4.2.114':
+    resolution: {integrity: sha512-YB5DFjRXbvS6pusY1XNPFurgp8mGsS9ii7lqpIzi3LgNQt8H6+br8l/zqOzHjeY38aAXQfaDdvUNOES2KHrOPg==}
 
-  '@esotericsoftware/spine-webgl@4.2.109':
-    resolution: {integrity: sha512-pQXkfM7ayiBjvpJAHzY6dvBRWOFyK+sSQ8V2TQeD4RcfDKpBtkKIGstCfIZNYrMe18OMMLWO8q5Xu8/9xfnKvw==}
+  '@esotericsoftware/spine-webgl@4.2.114':
+    resolution: {integrity: sha512-cD3twxmPNnuYCCk5vVFELOHdY4rkd8j7OtfYqB9pkEoi32V00fUh8qQFF5gC0lgefMTdid0dL8FPIkW/swmcLg==}
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
@@ -2376,15 +2376,15 @@ snapshots:
       '@eslint/core': 1.2.0
       levn: 0.4.1
 
-  '@esotericsoftware/spine-canvas@4.2.109':
+  '@esotericsoftware/spine-canvas@4.2.114':
     dependencies:
-      '@esotericsoftware/spine-core': 4.2.109
+      '@esotericsoftware/spine-core': 4.2.114
 
-  '@esotericsoftware/spine-core@4.2.109': {}
+  '@esotericsoftware/spine-core@4.2.114': {}
 
-  '@esotericsoftware/spine-webgl@4.2.109':
+  '@esotericsoftware/spine-webgl@4.2.114':
     dependencies:
-      '@esotericsoftware/spine-core': 4.2.109
+      '@esotericsoftware/spine-core': 4.2.114
 
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:


### PR DESCRIPTION
## Summary

Bumps the bundled Spine runtimes — `@esotericsoftware/spine-canvas`, `spine-core`, `spine-webgl` — from `^4.2.109` to `^4.2.114` (latest on the 4.2 line, published 2026-04-30). Releases the plugin as `2.2.1`.

## What's actually different upstream (4.2.109 → 4.2.114)

| Version | Change | Relevant to us? |
|---|---|---|
| 4.2.110, 111, 112, 114 | Phaser v3 / v4 ESM mixin + camera-viewport fixes | ❌ Phaser-specific |
| 4.2.113 | **`AssetManagerBase` — fix infinite loop on atlases with zero pages** | ✅ Lands transparently in our `loadTextureAtlas` |
| 4.2.113 | WebGL `SceneRenderer.resize()` — clamp DPR | ❌ We use `SkeletonRenderer` directly, not `SceneRenderer` |

No new public APIs, no breaking changes, no performance changes that touch our usage. The only behavior change that reaches our users is the empty-atlas hang fix — `loadTextureAtlas` no longer waits forever if it's handed a malformed atlas with zero pages.

## Plugin code changes

None. Pure dependency bump.

## Test plan

- [x] `pnpm install` — lockfile resolves all three Spine packages to `4.2.114`.
- [x] `pnpm --filter @melonjs/spine-plugin build` — clean.
- [x] `pnpm lint` — 0 errors.

To be published as `@melonjs/spine-plugin@2.2.1` immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)