### PR TITLE
chore(release): 19.4.0

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [19.4.0] (melonJS 2) - _unreleased_
+## [19.4.0] (melonJS 2) - _2026-05-12_
 
 **Highlights:** rendering-focused release. The headline is GPU-accelerated WebGL 2 tile rendering for orthogonal TMX maps: visible layers now render as a single quad through a fragment shader instead of one draw per tile. Combined with the new shader-wide uniform cache, the per-fragment fast path, and the flat `Uint16Array`-backed tile data, a typical 3-layer 800×600 game on mid-tier mobile reclaims roughly **1.5–3.5 ms per frame** (~10–20% of the 60 fps budget). Dense large maps should see ~5–8× speedups on the rendering portion.
 


### PR DESCRIPTION
## Summary

Release 19.4.0. CHANGELOG date set to 2026-05-12.

## Highlights

GPU-accelerated WebGL 2 tile rendering for orthogonal TMX maps (#1445), plus three real bug fixes:
- SAT ellipse sign error + TMX stale absolute bounds on centered levels (#1446)
- ImageLayer `repeat-x` / `repeat-y` / `no-repeat` Canvas/WebGL parity (#1447)

Plus engine-wide uniform value caching, GLSL ES 3.00 custom shader support, `TextureResource` / `BufferTextureResource` for synthesized textures, NPOT warning scoping, and `throttle<T>` generics.

See the [full CHANGELOG entry](https://github.com/melonjs/melonJS/blob/chore/release-19.4.0/packages/melonjs/CHANGELOG.md) for details.

## Test plan
- [x] All commits already merged to master via individual PRs
- [x] Full test suite (3062 tests) green on each
- [x] CHANGELOG cross-checked against `git log 19.3.0..master` — every user-facing change is captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)