### PR TITLE
docs: align CONTRIBUTING Node requirement with package engine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Please search [existing issues](https://github.com/melonjs/melonJS/issues) first
 
 Before you begin, make sure you have the following installed:
 
-- [Node.js](https://nodejs.org/) version 20 or higher
+- [Node.js](https://nodejs.org/) version 24 or higher
 - [pnpm](https://pnpm.io/installation) package manager
 
 You can install pnpm using any of these methods:


### PR DESCRIPTION
This small docs PR aligns the contributor prerequisite with the root `package.json` engine requirement.

`package.json` currently declares `"node": ">=24.0.0"`, while `CONTRIBUTING.md` still says Node.js version 20 or higher. Updating the contributor doc should help new contributors avoid setup/runtime mismatches.

No code changes.