### PR TITLE
chore(release): stamp debug-plugin 16.0.0 heading

### DIFF
--- a/packages/debug-plugin/CHANGELOG.md
+++ b/packages/debug-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 16.0.0 _unreleased_
+## 16.0.0
 
 ### Breaking Changes
 - Requires melonJS **19.5.0 or later** — the hitbox overlay now goes through the new `PhysicsAdapter.getBodyAABB` / `getBodyShapes` adapter API (and the velocity overlay through the existing `adapter.getVelocity`) rather than reading `renderable.body.*` directly. Older engines don't expose those methods and the plugin will refuse to load. 19.5 also moved the FPS estimate into `timer.update()` (was previously driven by this plugin's `timer.countFPS()` call) and removed the debug-only `Container.drawCount` field, both of which this version is aware of.


### PR DESCRIPTION
Drops the `_unreleased_` placeholder from the debug-plugin 16.0.0 heading. debug-plugin 16.0.0 ships alongside the 19.5.0 melonjs release; this is the last release-prep tidy before tagging.

Trivial CHANGELOG-only change.