### PR TITLE
chore(types): remove `as unknown as` casts where they can be (#1466)

### DIFF
--- a/packages/melonjs/src/application/application.ts
+++ b/packages/melonjs/src/application/application.ts
@@ -551,9 +551,13 @@ export default class Application {
 		// the feature they enabled isn't actually in effect.
 		if (
 			this.settings.gpuTilemap &&
-			// duck-type rather than `instanceof WebGLRenderer` to avoid a
-			// runtime import; only the WebGL renderer carries `WebGLVersion`
-			(this.renderer as unknown as { WebGLVersion?: number }).WebGLVersion !== 2
+			// `gpuTilemap` is meaningful only under WebGL2 — Canvas has no
+			// shader path, and WebGL1 lacks the required extensions. The
+			// `instanceof WebGLRenderer` check narrows `this.renderer` so
+			// `WebGLVersion` (defined as a getter on `WebGLRenderer`) is
+			// well-typed — no `as unknown as ...` cast needed.
+			(!(this.renderer instanceof WebGLRenderer) ||
+				this.renderer.WebGLVersion !== 2)
 		) {
 			console.warn(
 				"melonJS: gpuTilemap is enabled but the active renderer is not WebGL 2 — falling back to the legacy tile renderer for every tile layer",

--- a/packages/melonjs/src/particles/emitter.ts
+++ b/packages/melonjs/src/particles/emitter.ts
@@ -361,7 +361,12 @@ export default class ParticleEmitter extends Container {
 			this._defaultParticle.destroy();
 			this._defaultParticle = undefined;
 		}
+		// Clear the image reference so a discarded emitter doesn't pin a
+		// (potentially large) image / canvas alive via `settings.image`.
+		// `this.settings = undefined` was here too but offered no GC win
+		// — once the emitter itself is unreferenced, `settings` follows —
+		// and it required a `as unknown as ParticleEmitterSettings` cast
+		// that lied about the field type. Dropped.
 		this.settings.image = undefined;
-		this.settings = undefined as unknown as ParticleEmitterSettings;
 	}
 }

--- a/packages/melonjs/src/physics/broadphase/octree.ts
+++ b/packages/melonjs/src/physics/broadphase/octree.ts
@@ -1,6 +1,5 @@
 import { Sphere } from "../../geometries/sphere.ts";
 import { Vector2d } from "../../math/vector2d.ts";
-import type Container from "../../renderable/container.js";
 import type World from "../world.js";
 import { AABB3d } from "./aabb3d.ts";
 import type { Broadphase } from "./broadphase.ts";
@@ -322,19 +321,21 @@ export default class Octree implements Broadphase<OctreeItem> {
 	 * leaf. Mirrors `QuadTree.insertContainer`.
 	 * @param container - group of objects to be added
 	 */
-	insertContainer(container: Container) {
+	insertContainer(container: { getChildren(): ContainerOrChild[] }) {
 		const children = container.getChildren();
 		const childrenLength = children.length;
 		for (
 			let i = childrenLength, child: ContainerOrChild;
-			i--, (child = children[i] as ContainerOrChild);
+			i--, (child = children[i]);
 		) {
 			if (child.isKinematic !== true) {
 				if (typeof child.addChild === "function") {
 					if (child.name !== "rootContainer") {
 						this.insert(child);
 					}
-					this.insertContainer(child as unknown as Container);
+					this.insertContainer(
+						child as Required<Pick<ContainerOrChild, "getChildren">>,
+					);
 				} else if (typeof child.getBounds === "function") {
 					this.insert(child);
 				}
@@ -388,7 +389,7 @@ export default class Octree implements Broadphase<OctreeItem> {
 	 * the octree. Mirror of `QuadTree.removeContainer`.
 	 * @param container - group of objects to be removed
 	 */
-	removeContainer(container: Container) {
+	removeContainer(container: { getChildren?(): ContainerOrChild[] }) {
 		const children = container.getChildren?.();
 		if (!children) {
 			return;
@@ -396,14 +397,14 @@ export default class Octree implements Broadphase<OctreeItem> {
 		const childrenLength = children.length;
 		for (
 			let i = childrenLength, child: ContainerOrChild;
-			i--, (child = children[i] as ContainerOrChild);
+			i--, (child = children[i]);
 		) {
 			if (child.isKinematic !== true) {
 				if (typeof child.addChild === "function") {
 					if (child.name !== "rootContainer") {
 						this.remove(child);
 					}
-					this.removeContainer(child as unknown as Container);
+					this.removeContainer(child);
 				} else if (typeof child.getBounds === "function") {
 					this.remove(child);
 				}
@@ -949,9 +950,11 @@ export default class Octree implements Broadphase<OctreeItem> {
 /**
  * Structural shape consumed by `insertContainer` / `removeContainer`
  * — captures only the fields the walk inspects. Same approach as
- * QuadTree.
+ * QuadTree. `getChildren` lets `insertContainer(child)` type-check on
+ * the recursive call without a `Container` cast.
  * @ignore
  */
 interface ContainerOrChild extends OctreeItem {
 	addChild?: (...args: unknown[]) => unknown;
+	getChildren?: () => ContainerOrChild[];
 }

--- a/packages/melonjs/src/physics/broadphase/octree.ts
+++ b/packages/melonjs/src/physics/broadphase/octree.ts
@@ -321,7 +321,7 @@ export default class Octree implements Broadphase<OctreeItem> {
 	 * leaf. Mirrors `QuadTree.insertContainer`.
 	 * @param container - group of objects to be added
 	 */
-	insertContainer(container: { getChildren(): ContainerOrChild[] }) {
+	insertContainer(container: ContainerLike) {
 		const children = container.getChildren();
 		const childrenLength = children.length;
 		for (
@@ -329,13 +329,12 @@ export default class Octree implements Broadphase<OctreeItem> {
 			i--, (child = children[i]);
 		) {
 			if (child.isKinematic !== true) {
-				if (typeof child.addChild === "function") {
+				if (typeof child.addChild === "function" && hasGetChildren(child)) {
 					if (child.name !== "rootContainer") {
 						this.insert(child);
 					}
-					this.insertContainer(
-						child as Required<Pick<ContainerOrChild, "getChildren">>,
-					);
+					// `child` narrowed by `hasGetChildren` — no assertion.
+					this.insertContainer(child);
 				} else if (typeof child.getBounds === "function") {
 					this.insert(child);
 				}
@@ -389,7 +388,7 @@ export default class Octree implements Broadphase<OctreeItem> {
 	 * the octree. Mirror of `QuadTree.removeContainer`.
 	 * @param container - group of objects to be removed
 	 */
-	removeContainer(container: { getChildren?(): ContainerOrChild[] }) {
+	removeContainer(container: ContainerLikeOptional) {
 		const children = container.getChildren?.();
 		if (!children) {
 			return;
@@ -950,11 +949,29 @@ export default class Octree implements Broadphase<OctreeItem> {
 /**
  * Structural shape consumed by `insertContainer` / `removeContainer`
  * — captures only the fields the walk inspects. Same approach as
- * QuadTree. `getChildren` lets `insertContainer(child)` type-check on
- * the recursive call without a `Container` cast.
+ * QuadTree. `getChildren` is optional because leaf renderables don't
+ * have it; the recursive walk narrows via {@link hasGetChildren}.
  * @ignore
  */
 interface ContainerOrChild extends OctreeItem {
 	addChild?: (...args: unknown[]) => unknown;
 	getChildren?: () => ContainerOrChild[];
+}
+
+/** @ignore */
+type ContainerLike = { getChildren(): ContainerOrChild[] };
+/** @ignore */
+type ContainerLikeOptional = { getChildren?(): ContainerOrChild[] };
+
+/**
+ * Type predicate mirror of QuadTree's. Narrows a `ContainerOrChild`
+ * to one whose `getChildren` is definitely a function, letting the
+ * recursive `insertContainer(child)` call pass without an assertion.
+ * @param c - the candidate to test
+ * @returns true if `c` has a callable `getChildren`
+ */
+function hasGetChildren(
+	c: ContainerOrChild,
+): c is ContainerOrChild & ContainerLike {
+	return typeof c.getChildren === "function";
 }

--- a/packages/melonjs/src/physics/broadphase/quadtree.ts
+++ b/packages/melonjs/src/physics/broadphase/quadtree.ts
@@ -1,5 +1,4 @@
 import { Vector2d } from "../../math/vector2d.ts";
-import type Container from "../../renderable/container.js";
 import type { Bounds } from "../bounds.ts";
 import type World from "../world.js";
 import type { Broadphase } from "./broadphase.ts";
@@ -283,9 +282,18 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
 
 	/**
 	 * Insert the given object container into the node.
+	 *
+	 * Typed against the structural duck shape (`getChildren() →
+	 * ContainerOrChild[]`) rather than the concrete `Container` class
+	 * so the recursive call below — where `child` is the structural
+	 * `ContainerOrChild` shape from `getChildren()`, not a `Container`
+	 * instance — type-checks without an `as unknown as Container` cast.
+	 * `Container` itself satisfies the shape (its `getChildren()`
+	 * returns `Renderable[]`, which matches the looser structural
+	 * `ContainerOrChild[]`).
 	 * @param container - group of objects to be added
 	 */
-	insertContainer(container: Container) {
+	insertContainer(container: { getChildren(): ContainerOrChild[] }) {
 		// use getChildren() to lazily initialise an empty array — Container
 		// stores `children` as `undefined` until first access, which would
 		// otherwise crash here for a freshly-constructed world.
@@ -293,7 +301,7 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
 		const childrenLength = children.length;
 		for (
 			let i = childrenLength, child: ContainerOrChild;
-			i--, (child = children[i] as ContainerOrChild);
+			i--, (child = children[i]);
 		) {
 			if (child.isKinematic !== true) {
 				if (typeof child.addChild === "function") {
@@ -302,8 +310,12 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
 					if (child.name !== "rootContainer") {
 						this.insert(child);
 					}
-					// recursively insert all children
-					this.insertContainer(child as unknown as Container);
+					// recursively insert all children — `addChild` and
+					// `getChildren` always come together on real
+					// containers (gated above via the `addChild` check).
+					this.insertContainer(
+						child as Required<Pick<ContainerOrChild, "getChildren">>,
+					);
 				} else {
 					// only insert object with a bounding box
 					// Probably redundant with `isKinematic`
@@ -377,7 +389,7 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
 	 * hit destroyed renderables).
 	 * @param container - group of objects to be removed
 	 */
-	removeContainer(container: Container) {
+	removeContainer(container: { getChildren?(): ContainerOrChild[] }) {
 		const children = container.getChildren?.();
 		if (!children) {
 			return;
@@ -385,7 +397,7 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
 		const childrenLength = children.length;
 		for (
 			let i = childrenLength, child: ContainerOrChild;
-			i--, (child = children[i] as ContainerOrChild);
+			i--, (child = children[i]);
 		) {
 			if (child.isKinematic !== true) {
 				if (typeof child.addChild === "function") {
@@ -395,7 +407,7 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
 					if (child.name !== "rootContainer") {
 						this.remove(child);
 					}
-					this.removeContainer(child as unknown as Container);
+					this.removeContainer(child);
 				} else if (typeof child.getBounds === "function") {
 					this.remove(child);
 				}
@@ -603,8 +615,14 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
  * when walking a Container's `getChildren()`. Captures only the
  * fields the walk inspects — keeps the conversion strict-mode clean
  * without leaking `any`.
+ *
+ * `getChildren` is optional on the type but is what marks a value
+ * as a container in the recursive walk (alongside `addChild`).
+ * Including it here lets the recursive `insertContainer(child)` call
+ * pass without an `as unknown as Container` cast.
  * @ignore
  */
 interface ContainerOrChild extends QuadTreeItem {
 	addChild?: (...args: unknown[]) => unknown;
+	getChildren?: () => ContainerOrChild[];
 }

--- a/packages/melonjs/src/physics/broadphase/quadtree.ts
+++ b/packages/melonjs/src/physics/broadphase/quadtree.ts
@@ -293,7 +293,7 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
 	 * `ContainerOrChild[]`).
 	 * @param container - group of objects to be added
 	 */
-	insertContainer(container: { getChildren(): ContainerOrChild[] }) {
+	insertContainer(container: ContainerLike) {
 		// use getChildren() to lazily initialise an empty array — Container
 		// stores `children` as `undefined` until first access, which would
 		// otherwise crash here for a freshly-constructed world.
@@ -304,18 +304,14 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
 			i--, (child = children[i]);
 		) {
 			if (child.isKinematic !== true) {
-				if (typeof child.addChild === "function") {
+				if (typeof child.addChild === "function" && hasGetChildren(child)) {
 					// `rootContainer` is the world itself — it owns the
 					// quadtree, it isn't an item inside it.
 					if (child.name !== "rootContainer") {
 						this.insert(child);
 					}
-					// recursively insert all children — `addChild` and
-					// `getChildren` always come together on real
-					// containers (gated above via the `addChild` check).
-					this.insertContainer(
-						child as Required<Pick<ContainerOrChild, "getChildren">>,
-					);
+					// `child` narrowed by `hasGetChildren` — no assertion.
+					this.insertContainer(child);
 				} else {
 					// only insert object with a bounding box
 					// Probably redundant with `isKinematic`
@@ -389,7 +385,7 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
 	 * hit destroyed renderables).
 	 * @param container - group of objects to be removed
 	 */
-	removeContainer(container: { getChildren?(): ContainerOrChild[] }) {
+	removeContainer(container: ContainerLikeOptional) {
 		const children = container.getChildren?.();
 		if (!children) {
 			return;
@@ -616,13 +612,38 @@ export default class QuadTree implements Broadphase<QuadTreeItem> {
  * fields the walk inspects — keeps the conversion strict-mode clean
  * without leaking `any`.
  *
- * `getChildren` is optional on the type but is what marks a value
- * as a container in the recursive walk (alongside `addChild`).
- * Including it here lets the recursive `insertContainer(child)` call
- * pass without an `as unknown as Container` cast.
+ * `getChildren` is optional because leaf renderables don't have it;
+ * the recursive `insertContainer` narrows via {@link hasGetChildren}.
  * @ignore
  */
 interface ContainerOrChild extends QuadTreeItem {
 	addChild?: (...args: unknown[]) => unknown;
 	getChildren?: () => ContainerOrChild[];
+}
+
+/**
+ * Structural shape used as the `insertContainer` /
+ * `removeContainer` parameter type. Named (rather than inline) so the
+ * JSDoc-aware lint doesn't require nested `@param container.getChildren`
+ * documentation at every call site. `Container` itself satisfies this
+ * shape; the optional variant covers the case where the World's lazy
+ * `children` accessor returns `undefined`.
+ * @ignore
+ */
+type ContainerLike = { getChildren(): ContainerOrChild[] };
+/** @ignore */
+type ContainerLikeOptional = { getChildren?(): ContainerOrChild[] };
+
+/**
+ * Type predicate: narrows a `ContainerOrChild` to one whose
+ * `getChildren` is definitely a function. Lets the recursive
+ * `insertContainer(child)` call pass without an
+ * `as Required<Pick<..., "getChildren">>` assertion.
+ * @param c - the candidate to test
+ * @returns true if `c` has a callable `getChildren`
+ */
+function hasGetChildren(
+	c: ContainerOrChild,
+): c is ContainerOrChild & ContainerLike {
+	return typeof c.getChildren === "function";
 }

--- a/packages/melonjs/src/physics/builtin/body.js
+++ b/packages/melonjs/src/physics/builtin/body.js
@@ -53,9 +53,13 @@ export default class Body {
 
 		if (typeof this.shapes === "undefined") {
 			/**
-			 * The collision shapes of the body
+			 * The collision shapes of the body. Always an array — every
+			 * mutation path goes through `push` / `includes`. The
+			 * non-array `Point` that used to be in this union was a
+			 * mis-doc and broke downstream `shapes.length` reads in
+			 * TypeScript.
 			 * @ignore
-			 * @type {Polygon[]|Line[]|Ellipse[]|Point|Point[]}
+			 * @type {(Polygon|Line|Ellipse|Point)[]}
 			 */
 			this.shapes = [];
 		}

--- a/packages/melonjs/src/physics/builtin/raycast.ts
+++ b/packages/melonjs/src/physics/builtin/raycast.ts
@@ -5,6 +5,7 @@ import { Vector2d } from "../../math/vector2d.ts";
 import type Renderable from "../../renderable/renderable.js";
 import type { RaycastHit } from "../adapter.ts";
 import type World from "../world.js";
+import type Body from "./body.js";
 
 /**
  * Shared internal raycast walker for the built-in physics path. Used by
@@ -221,10 +222,12 @@ export function raycastQuery(
 			continue;
 		}
 
-		const bodyB = objB.body as unknown as {
-			shapes: ArrayLike<unknown>;
-			getShape(i: number): Polygon | Ellipse;
-		};
+		// This raycast walks the BuiltinAdapter's broadphase, so every
+		// `objB.body` here is a concrete builtin `Body` — narrow from
+		// the portable `PhysicsBody` interface (which doesn't expose
+		// `shapes` / `getShape` since those are adapter-specific) to
+		// the concrete type.
+		const bodyB = objB.body as Body;
 		const shapeCount = bodyB.shapes.length;
 		if (shapeCount === 0) {
 			continue;

--- a/packages/melonjs/src/state/stage.ts
+++ b/packages/melonjs/src/state/stage.ts
@@ -200,14 +200,21 @@ export default class Stage {
 		// inherited the loader's Camera2d → "z" sortOn and a Camera3d
 		// sub-stage would never snap back to "depth".
 		if (isFirstReset && app?.world) {
+			// Every camera class in the engine carries
+			// `static defaultSortOn: "x" | "y" | "z" | "depth"` (see
+			// `Camera2d.defaultSortOn = "z"`, `Camera3d.defaultSortOn =
+			// "depth"`), but the constructor-shape type used by
+			// `settings.cameraClass` doesn't expose statics. Read the
+			// static via a structural narrowing instead of a
+			// constructor-to-static cast.
 			type SortAwareCameraClass = {
 				defaultSortOn?: "x" | "y" | "z" | "depth";
 			};
 			let chosenClass: SortAwareCameraClass | undefined;
 			if (typeof StageCameraClass === "function") {
-				chosenClass = StageCameraClass as unknown as SortAwareCameraClass;
+				chosenClass = StageCameraClass as SortAwareCameraClass;
 			} else if (typeof AppCameraClass === "function") {
-				chosenClass = AppCameraClass as unknown as SortAwareCameraClass;
+				chosenClass = AppCameraClass as SortAwareCameraClass;
 			} else if (this.settings.cameras.length > 0) {
 				// Read the camera actually registered under the "default"
 				// key, NOT `settings.cameras[0]`. A split-screen / minimap

--- a/packages/melonjs/src/state/state.ts
+++ b/packages/melonjs/src/state/state.ts
@@ -603,11 +603,7 @@ const state = {
 			// apply transition effect if configured
 			if (_transitionConfig.duration && _stages[stateId].transition) {
 				const onComplete = () => {
-					defer(
-						_switchState as unknown as (...args: unknown[]) => unknown,
-						state,
-						stateId,
-					);
+					defer(_switchState, state, stateId);
 				};
 
 				switch (_transitionType) {
@@ -680,11 +676,7 @@ const state = {
 				if (forceChange) {
 					_switchState(stateId);
 				} else {
-					defer(
-						_switchState as unknown as (...args: unknown[]) => unknown,
-						this,
-						stateId,
-					);
+					defer(_switchState, this, stateId);
 				}
 			}
 		}

--- a/packages/melonjs/src/utils/function.ts
+++ b/packages/melonjs/src/utils/function.ts
@@ -4,6 +4,12 @@
 
 /**
  * Executes a function as soon as the interpreter is idle (stack empty).
+ *
+ * Generic over the target function's tail-args tuple so call sites pass
+ * the function's actual parameters without lying to TypeScript via
+ * `as unknown as (...args: unknown[]) => unknown` casts. The compiler
+ * infers `TArgs` from the trailing rest args and constrains `func` to
+ * accept them.
  * @param func - The function to be deferred.
  * @param thisArg - The value to be passed as the this parameter to the target function when the deferred function is called
  * @param args - Optional additional arguments to carry for the function.
@@ -14,10 +20,10 @@
  * // with the current context and [1, 2, 3] as parameter
  * me.utils.function.defer(myFunc, this, 1, 2, 3);
  */
-export function defer(
-	func: (...args: unknown[]) => unknown,
+export function defer<TArgs extends unknown[]>(
+	func: (...args: TArgs) => unknown,
 	thisArg: unknown,
-	...args: unknown[]
+	...args: TArgs
 ) {
 	return setTimeout(func.bind(thisArg), 0, ...args);
 }


### PR DESCRIPTION
Closes #1466.

Cleans up most of the `as unknown as ...` cast sites the engine carried. Each cast was a "we lied to TypeScript about the runtime type" patch — most could be replaced with proper generics, structural types, or `instanceof` narrowing.

## Removed

| File | Before | After |
|---|---|---|
| `utils/function.ts` | `defer(func: (...args: unknown[]) => unknown, ...)` | `defer<TArgs>(func: (...args: TArgs) => unknown, ...)` |
| `state/state.ts` (× 2) | `defer(_switchState as unknown as ...)` | `defer(_switchState, ...)` |
| `particles/emitter.ts` | `this.settings = undefined as unknown as ParticleEmitterSettings` | Line deleted (dead — nothing reads `settings` after `destroy()`, image-clear stays) |
| `physics/builtin/raycast.ts` | `objB.body as unknown as { shapes, getShape }` | `objB.body as Body` (concrete builtin Body) |
| `physics/builtin/body.js` | `@type {Polygon[]\|Line[]\|Ellipse[]\|Point\|Point[]}` | `@type {(Polygon\|Line\|Ellipse\|Point)[]}` — fixed wrong JSDoc that broke downstream typing |
| `physics/broadphase/quadtree.ts` (× 2) | `this.insertContainer(child as unknown as Container)` | Signature changed to structural `{ getChildren(): ContainerOrChild[] }` shape; cast dropped |
| `physics/broadphase/octree.ts` (× 2) | same | same |
| `state/stage.ts` (× 2) | `StageCameraClass as unknown as SortAwareCameraClass` | `as SortAwareCameraClass` (structural shape narrowing) |
| `application.ts` | `(this.renderer as unknown as { WebGLVersion?: number }).WebGLVersion !== 2` | `!(this.renderer instanceof WebGLRenderer) \|\| this.renderer.WebGLVersion !== 2` |

## Intentionally kept (documented)

- `audio/backend.ts:188` — `(Howler as unknown as { _muted: boolean })._muted`. Reaches Howler's private field; no public getter exists.
- `state/stage.ts:233` — `.constructor as unknown as SortAwareCameraClass`. `Object.constructor` is typed as `Function` with no statics; the structural shape conversion needs the `unknown` step.

## Test plan

- [x] `pnpm test:types` clean
- [x] Full Vitest suite: `120 / 120 files`, **3969 passed**, **0 failed**, 13 skipped (same as master baseline)
- [x] Engine builds clean (`pnpm build` runs lint + types as part of CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)