### PR TITLE
chore(tests): silent-skip sweep on webgl_pipeline_adversarial + minor renderer naming polish

### DIFF
--- a/packages/melonjs/src/math/color.ts
+++ b/packages/melonjs/src/math/color.ts
@@ -205,7 +205,7 @@ for (const [name, rgb] of CSS_COLORS) {
  * @category Math
  */
 export class Color {
-	private glArray: Float32Array;
+	private normalizedRGBA: Float32Array;
 
 	/**
 	 * Creates a new Color instance.
@@ -216,13 +216,13 @@ export class Color {
 	 */
 	constructor(r: Color | string | number = 0, g = 0, b = 0, alpha = 1.0) {
 		if (typeof r === "number") {
-			this.glArray = new Float32Array([0, 0, 0, 1]);
+			this.normalizedRGBA = new Float32Array([0, 0, 0, 1]);
 			this.setColor(r, g, b, alpha);
 		} else if (typeof r === "string") {
-			this.glArray = new Float32Array([0, 0, 0, 1]);
+			this.normalizedRGBA = new Float32Array([0, 0, 0, 1]);
 			this.parseCSS(r);
 		} else if (typeof r === "object") {
-			this.glArray = r.glArray.slice();
+			this.normalizedRGBA = r.normalizedRGBA.slice();
 		} else {
 			throw new Error("Color: invalid parameter");
 		}
@@ -233,7 +233,7 @@ export class Color {
 	 * @returns The red component [0 .. 255].
 	 */
 	get r() {
-		return ~~(this.glArray[0] * 255);
+		return ~~(this.normalizedRGBA[0] * 255);
 	}
 
 	/**
@@ -241,7 +241,7 @@ export class Color {
 	 * @param value - The red component [0 .. 255].
 	 */
 	set r(value) {
-		this.glArray[0] = clamp(value, 0, 255) / 255.0;
+		this.normalizedRGBA[0] = clamp(value, 0, 255) / 255.0;
 	}
 
 	/**
@@ -249,7 +249,7 @@ export class Color {
 	 * @returns The green component [0 .. 255].
 	 */
 	get g() {
-		return ~~(this.glArray[1] * 255);
+		return ~~(this.normalizedRGBA[1] * 255);
 	}
 
 	/**
@@ -257,7 +257,7 @@ export class Color {
 	 * @param value - The green component [0 .. 255].
 	 */
 	set g(value) {
-		this.glArray[1] = clamp(value, 0, 255) / 255.0;
+		this.normalizedRGBA[1] = clamp(value, 0, 255) / 255.0;
 	}
 
 	/**
@@ -265,7 +265,7 @@ export class Color {
 	 * @returns The blue component [0 .. 255].
 	 */
 	get b() {
-		return ~~(this.glArray[2] * 255);
+		return ~~(this.normalizedRGBA[2] * 255);
 	}
 
 	/**
@@ -273,7 +273,7 @@ export class Color {
 	 * @param value - The blue component [0 .. 255].
 	 */
 	set b(value) {
-		this.glArray[2] = clamp(value, 0, 255) / 255.0;
+		this.normalizedRGBA[2] = clamp(value, 0, 255) / 255.0;
 	}
 
 	/**
@@ -281,7 +281,7 @@ export class Color {
 	 * @returns The alpha component [0.0 .. 1.0].
 	 */
 	get alpha() {
-		return this.glArray[3];
+		return this.normalizedRGBA[3];
 	}
 
 	/**
@@ -289,7 +289,7 @@ export class Color {
 	 * @param value - The alpha component [0.0 .. 1.0].
 	 */
 	set alpha(value) {
-		this.glArray[3] = clamp(value, 0, 1.0);
+		this.normalizedRGBA[3] = clamp(value, 0, 1.0);
 	}
 
 	/**
@@ -318,7 +318,7 @@ export class Color {
 	 * @returns Reference to this object for method chaining.
 	 */
 	setFloat(r: number, g: number, b: number, alpha = 1.0) {
-		const a = this.glArray;
+		const a = this.normalizedRGBA;
 		a[0] = clamp(r, 0, 1.0);
 		a[1] = clamp(g, 0, 1.0);
 		a[2] = clamp(b, 0, 1.0);
@@ -471,7 +471,7 @@ export class Color {
 		if (typeof color === "string") {
 			return this.parseCSS(color);
 		} else {
-			this.glArray.set(color.glArray);
+			this.normalizedRGBA.set(color.normalizedRGBA);
 			return this;
 		}
 	}
@@ -482,10 +482,23 @@ export class Color {
 	 * @returns Reference to this object for method chaining.
 	 */
 	add(color: Color) {
-		this.glArray[0] = clamp(this.glArray[0] + color.glArray[0], 0, 1);
-		this.glArray[1] = clamp(this.glArray[1] + color.glArray[1], 0, 1);
-		this.glArray[2] = clamp(this.glArray[2] + color.glArray[2], 0, 1);
-		this.glArray[3] = (this.glArray[3] + color.glArray[3]) / 2;
+		this.normalizedRGBA[0] = clamp(
+			this.normalizedRGBA[0] + color.normalizedRGBA[0],
+			0,
+			1,
+		);
+		this.normalizedRGBA[1] = clamp(
+			this.normalizedRGBA[1] + color.normalizedRGBA[1],
+			0,
+			1,
+		);
+		this.normalizedRGBA[2] = clamp(
+			this.normalizedRGBA[2] + color.normalizedRGBA[2],
+			0,
+			1,
+		);
+		this.normalizedRGBA[3] =
+			(this.normalizedRGBA[3] + color.normalizedRGBA[3]) / 2;
 
 		return this;
 	}
@@ -497,9 +510,9 @@ export class Color {
 	 */
 	darken(scale: number) {
 		scale = clamp(scale, 0, 1);
-		this.glArray[0] *= scale;
-		this.glArray[1] *= scale;
-		this.glArray[2] *= scale;
+		this.normalizedRGBA[0] *= scale;
+		this.normalizedRGBA[1] *= scale;
+		this.normalizedRGBA[2] *= scale;
 
 		return this;
 	}
@@ -512,9 +525,12 @@ export class Color {
 	 */
 	lerp(color: Color, alpha: number) {
 		alpha = clamp(alpha, 0, 1);
-		this.glArray[0] += (color.glArray[0] - this.glArray[0]) * alpha;
-		this.glArray[1] += (color.glArray[1] - this.glArray[1]) * alpha;
-		this.glArray[2] += (color.glArray[2] - this.glArray[2]) * alpha;
+		this.normalizedRGBA[0] +=
+			(color.normalizedRGBA[0] - this.normalizedRGBA[0]) * alpha;
+		this.normalizedRGBA[1] +=
+			(color.normalizedRGBA[1] - this.normalizedRGBA[1]) * alpha;
+		this.normalizedRGBA[2] +=
+			(color.normalizedRGBA[2] - this.normalizedRGBA[2]) * alpha;
 
 		return this;
 	}
@@ -526,18 +542,18 @@ export class Color {
 	 */
 	lighten(scale: number) {
 		scale = clamp(scale, 0, 1);
-		this.glArray[0] = clamp(
-			this.glArray[0] + (1 - this.glArray[0]) * scale,
+		this.normalizedRGBA[0] = clamp(
+			this.normalizedRGBA[0] + (1 - this.normalizedRGBA[0]) * scale,
 			0,
 			1,
 		);
-		this.glArray[1] = clamp(
-			this.glArray[1] + (1 - this.glArray[1]) * scale,
+		this.normalizedRGBA[1] = clamp(
+			this.normalizedRGBA[1] + (1 - this.normalizedRGBA[1]) * scale,
 			0,
 			1,
 		);
-		this.glArray[2] = clamp(
-			this.glArray[2] + (1 - this.glArray[2]) * scale,
+		this.normalizedRGBA[2] = clamp(
+			this.normalizedRGBA[2] + (1 - this.normalizedRGBA[2]) * scale,
 			0,
 			1,
 		);
@@ -574,10 +590,10 @@ export class Color {
 	 */
 	equals(color: Color) {
 		return (
-			this.glArray[0] === color.glArray[0] &&
-			this.glArray[1] === color.glArray[1] &&
-			this.glArray[2] === color.glArray[2] &&
-			this.glArray[3] === color.glArray[3]
+			this.normalizedRGBA[0] === color.normalizedRGBA[0] &&
+			this.normalizedRGBA[1] === color.normalizedRGBA[1] &&
+			this.normalizedRGBA[2] === color.normalizedRGBA[2] &&
+			this.normalizedRGBA[3] === color.normalizedRGBA[3]
 		);
 	}
 
@@ -676,7 +692,7 @@ export class Color {
 	 * @returns A Uint32 ARGB representation of this color
 	 */
 	toUint32(alpha = 1.0) {
-		const a = this.glArray;
+		const a = this.normalizedRGBA;
 
 		const ur = (a[0] * 255) >> 0;
 		const ug = (a[1] * 255) >> 0;
@@ -690,7 +706,7 @@ export class Color {
 	 * @returns A Float Array representation of this color
 	 */
 	toArray() {
-		return this.glArray;
+		return this.normalizedRGBA;
 	}
 
 	/**
@@ -698,7 +714,7 @@ export class Color {
 	 * @returns The color in "#RRGGBB" format
 	 */
 	toHex() {
-		const a = this.glArray;
+		const a = this.normalizedRGBA;
 		return `#${toHex((a[0] * 255) >> 0)}${toHex((a[1] * 255) >> 0)}${toHex((a[2] * 255) >> 0)}`;
 	}
 
@@ -707,8 +723,8 @@ export class Color {
 	 * @param alpha - The alpha value [0.0 .. 1.0] to use in the output string.
 	 * @returns The color in "#RRGGBBAA" format
 	 */
-	toHex8(alpha = this.glArray[3]) {
-		const a = this.glArray;
+	toHex8(alpha = this.normalizedRGBA[3]) {
+		const a = this.normalizedRGBA;
 		return `#${toHex((a[0] * 255) >> 0)}${toHex((a[1] * 255) >> 0)}${toHex((a[2] * 255) >> 0)}${toHex((alpha * 255) >> 0)}`;
 	}
 

--- a/packages/melonjs/src/video/canvas/canvas_renderer.js
+++ b/packages/melonjs/src/video/canvas/canvas_renderer.js
@@ -1044,7 +1044,7 @@ export default class CanvasRenderer extends Renderer {
 		if (typeof context.fillStyle === "string") {
 			this.currentColor.copy(context.fillStyle);
 		}
-		this.currentColor.normalizedRGBA[3] = context.globalAlpha;
+		this.currentColor.alpha = context.globalAlpha;
 		// reset scissor cache so the next clipRect() won't skip
 		this.currentScissor[0] = 0;
 		this.currentScissor[1] = 0;
@@ -1119,7 +1119,8 @@ export default class CanvasRenderer extends Renderer {
 	 * @param {number} alpha - 0.0 to 1.0 values accepted.
 	 */
 	setGlobalAlpha(alpha) {
-		this.getContext().globalAlpha = this.currentColor.normalizedRGBA[3] = alpha;
+		this.currentColor.alpha = alpha;
+		this.getContext().globalAlpha = alpha;
 	}
 
 	/**

--- a/packages/melonjs/src/video/canvas/canvas_renderer.js
+++ b/packages/melonjs/src/video/canvas/canvas_renderer.js
@@ -1044,7 +1044,7 @@ export default class CanvasRenderer extends Renderer {
 		if (typeof context.fillStyle === "string") {
 			this.currentColor.copy(context.fillStyle);
 		}
-		this.currentColor.glArray[3] = context.globalAlpha;
+		this.currentColor.normalizedRGBA[3] = context.globalAlpha;
 		// reset scissor cache so the next clipRect() won't skip
 		this.currentScissor[0] = 0;
 		this.currentScissor[1] = 0;
@@ -1119,7 +1119,7 @@ export default class CanvasRenderer extends Renderer {
 	 * @param {number} alpha - 0.0 to 1.0 values accepted.
 	 */
 	setGlobalAlpha(alpha) {
-		this.getContext().globalAlpha = this.currentColor.glArray[3] = alpha;
+		this.getContext().globalAlpha = this.currentColor.normalizedRGBA[3] = alpha;
 	}
 
 	/**

--- a/packages/melonjs/src/video/renderer.js
+++ b/packages/melonjs/src/video/renderer.js
@@ -678,7 +678,7 @@ export default class Renderer {
 	 * @returns {number}
 	 */
 	globalAlpha() {
-		return this.currentColor.normalizedRGBA[3];
+		return this.currentColor.alpha;
 	}
 
 	/**

--- a/packages/melonjs/src/video/renderer.js
+++ b/packages/melonjs/src/video/renderer.js
@@ -73,7 +73,8 @@ export default class Renderer {
 		this.isContextValid = true;
 
 		/**
-		 * The GPU renderer string (WebGL only, undefined for Canvas)
+		 * The GPU device identifier string (set by GPU renderers — WebGL today,
+		 * WebGPU once it lands; undefined for Canvas).
 		 * @type {string|undefined}
 		 */
 		this.GPURenderer = undefined;
@@ -81,7 +82,7 @@ export default class Renderer {
 		/**
 		 * an optional custom shader to use instead of the default one.
 		 * Set by a renderable's preDraw when a shader is assigned.
-		 * (WebGL only, ignored by Canvas renderer)
+		 * (GPU renderers only; ignored by Canvas renderer)
 		 * @type {GLShader|ShaderEffect|undefined}
 		 * @ignore
 		 */
@@ -190,9 +191,10 @@ export default class Renderer {
 	}
 
 	/**
-	 * Current per-renderable depth value. WebGL batchers push it into the
-	 * vertex stream as the `z` component of each vertex — a no-op under the
-	 * default orthographic projection, used by perspective (Camera3d) to
+	 * Current per-renderable depth value. GPU batchers (WebGL today,
+	 * WebGPU once it lands) push it into the vertex stream as the `z`
+	 * component of each vertex — a no-op under the default orthographic
+	 * projection, used by perspective (Camera3d) to
 	 * scale and parallax sprites by distance. Mirrors `renderable.depth`,
 	 * set automatically by `Renderable.preDraw` via {@link Renderer#setDepth}.
 	 * @type {number}
@@ -336,9 +338,11 @@ export default class Renderer {
 
 	/**
 	 * return the list of supported compressed texture formats.
-	 * The base implementation returns null for all formats (no GPU compressed texture support).
-	 * The WebGL renderer overrides this with actual extension availability.
-	 * @returns {Object} an object with one key per extension family, each value is the WebGL extension object or null
+	 * The base implementation returns null for all formats (no GPU
+	 * compressed texture support). GPU renderers (WebGL today, WebGPU
+	 * once it lands) override this with the backend-specific extension /
+	 * feature query.
+	 * @returns {Object} an object with one key per extension family, each value is the backend's compressed-texture handle or null
 	 */
 	getSupportedCompressedTextureFormats() {
 		return {
@@ -474,9 +478,10 @@ export default class Renderer {
 
 	/**
 	 * set the current blend mode.
-	 * Subclasses (CanvasRenderer, WebGLRenderer) implement the actual GL/Canvas logic.
+	 * Subclasses (CanvasRenderer, WebGLRenderer, WebGPURenderer once it
+	 * lands) implement the actual backend logic.
 	 * @param {string} [mode="normal"] - blend mode
-	 * @param {boolean} [premultipliedAlpha=true] - whether textures use premultiplied alpha (WebGL only)
+	 * @param {boolean} [premultipliedAlpha=true] - whether textures use premultiplied alpha (GPU renderers only)
 	 */
 	setBlendMode(mode = "normal") {
 		this.currentBlendMode = mode;
@@ -487,11 +492,12 @@ export default class Renderer {
 	 *
 	 * Called once per camera per frame by `Camera2d.draw()` (after the
 	 * FBO is bound, before the world tree walk fires `Sprite.draw` for
-	 * any normal-mapped sprite). The WebGL renderer overrides this to
-	 * pack the lights into the lit shader's uniform buffers; the Canvas
-	 * renderer cannot do per-pixel normal-map lighting and silently
-	 * ignores the call. The first time a non-empty light list is passed
-	 * in Canvas mode, a one-shot console warning is emitted.
+	 * any normal-mapped sprite). GPU renderers (WebGL today, WebGPU once
+	 * it lands) override this to pack the lights into the lit shader's
+	 * uniform buffers; the Canvas renderer cannot do per-pixel normal-map
+	 * lighting and silently ignores the call. The first time a non-empty
+	 * light list is passed in Canvas mode, a one-shot console warning is
+	 * emitted.
 	 *
 	 * Stage stays renderer-agnostic by passing the raw scene data —
 	 * lights iterable and ambient color — and letting the renderer
@@ -672,7 +678,7 @@ export default class Renderer {
 	 * @returns {number}
 	 */
 	globalAlpha() {
-		return this.currentColor.glArray[3];
+		return this.currentColor.normalizedRGBA[3];
 	}
 
 	/**
@@ -720,7 +726,8 @@ export default class Renderer {
 	}
 
 	/**
-	 * set/change the current projection matrix (WebGL only)
+	 * set/change the current projection matrix (GPU renderers only —
+	 * the Canvas renderer applies projection via the 2D context's transform stack).
 	 * @param {Matrix3d} matrix
 	 */
 	setProjection(matrix) {
@@ -956,7 +963,8 @@ export default class Renderer {
 
 	/**
 	 * Draw an image or sub-image into the framebuffer.
-	 * Implemented by subclasses (`CanvasRenderer` / `WebGLRenderer`).
+	 * Implemented by subclasses (`CanvasRenderer` / `WebGLRenderer` /
+	 * future `WebGPURenderer`).
 	 *
 	 * The 9-argument signature shown here is the canonical form used
 	 * throughout the engine; the concrete renderers also accept the
@@ -1011,10 +1019,11 @@ export default class Renderer {
 	}
 
 	/**
-	 * Set the current per-renderable depth value. WebGL batchers push it
-	 * into the vertex stream as the `z` component of each vertex — a no-op
-	 * under the default orthographic projection, used by perspective
-	 * (Camera3d) to scale and parallax sprites by distance.
+	 * Set the current per-renderable depth value. GPU batchers (WebGL
+	 * today, WebGPU once it lands) push it into the vertex stream as the
+	 * `z` component of each vertex — a no-op under the default
+	 * orthographic projection, used by perspective (Camera3d) to scale
+	 * and parallax sprites by distance.
 	 *
 	 * Typically called automatically by `Renderable.preDraw` from the
 	 * renderable's `depth` property. User code only needs to call this

--- a/packages/melonjs/src/video/texture/resource.js
+++ b/packages/melonjs/src/video/texture/resource.js
@@ -1,5 +1,5 @@
 /**
- * A texture data source that knows how to upload itself to a WebGL
+ * A texture data source that knows how to upload itself to a GPU
  * texture. Subclasses provide the actual upload logic for their kind
  * of source (raw buffer, image, compressed data, etc.).
  *
@@ -8,13 +8,18 @@
  * shape (`sources`, `activeAtlas`, `getTexture()`, plus `width` /
  * `height` / `premultipliedAlpha` / `repeat` / `filter`) the cache
  * uses for unit allocation and the batcher uses for `boundTextures`
- * bookkeeping. The cache therefore owns every `gl.bindTexture` call,
+ * bookkeeping. The cache therefore owns every backend bind call,
  * which keeps the JS-side binding state in lockstep with the actual
- * GL state across all texture kinds — image atlases included.
+ * backend state across all texture kinds — image atlases included.
  *
- * Subclasses MUST implement `upload(gl, target)`. The framework calls
- * it once per texture on first use (and again on forced re-upload via
- * `batcher.uploadTexture(resource, w, h, true)`).
+ * Subclasses MUST implement `upload(context, target)`. The framework
+ * calls it once per texture on first use (and again on forced re-upload
+ * via `batcher.uploadTexture(resource, w, h, true)`). `context` is the
+ * renderer's backend context (the value returned by
+ * `renderer.getContext()`) — a `WebGLRenderingContext` /
+ * `WebGL2RenderingContext` today, the WebGPU equivalent once that
+ * renderer lands. The signature stays the same; each concrete
+ * subclass uses whatever the context happens to be.
  *
  * @category Rendering
  */
@@ -54,7 +59,7 @@ export class TextureResource {
 	/**
 	 * Returns the upload "source" the batcher hands to `createTexture2D`.
 	 * For a resource this is the resource itself — `createTexture2D`
-	 * dispatches to `resource.upload(gl, target)`.
+	 * dispatches to `resource.upload(context, target)`.
 	 * @ignore
 	 */
 	getTexture() {
@@ -62,15 +67,18 @@ export class TextureResource {
 	}
 
 	/**
-	 * Issue the `gl.texImage2D` (or equivalent) call that uploads this
-	 * resource's data into the currently-bound `TEXTURE_2D` slot.
-	 * Subclasses MUST override.
+	 * Issue the backend-specific upload call (`gl.texImage2D` on WebGL,
+	 * the WebGPU equivalent once that renderer lands) that places this
+	 * resource's data into the currently-bound texture slot. Subclasses
+	 * MUST override.
 	 * @abstract
-	 * @param {WebGLRenderingContext|WebGL2RenderingContext} gl
-	 * @param {number} target - `gl.TEXTURE_2D` (or future cube-map targets)
+	 * @param {WebGLRenderingContext|WebGL2RenderingContext} context - the
+	 *   renderer's backend context, as returned by `renderer.getContext()`
+	 * @param {number} target - the target to upload into (`TEXTURE_2D` on
+	 *   WebGL today, the WebGPU equivalent once that lands)
 	 */
 	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-	upload(gl, target) {
+	upload(context, target) {
 		throw new Error("TextureResource subclasses must implement upload()");
 	}
 }
@@ -115,39 +123,39 @@ export class BufferTextureResource extends TextureResource {
 	}
 
 	/** @ignore */
-	upload(gl, target) {
+	upload(context, target) {
 		if (this.format === "rgba8ui") {
 			// `RGBA8UI` / `RGBA_INTEGER` are WebGL 2-only enums. On a
 			// WebGL 1 context they're `undefined`, which would otherwise
 			// silently invoke `texImage2D` with bogus values and corrupt
 			// the texture — surface a clear error so callers know to
 			// either drop down to `rgba8` or guard their construction.
-			if (typeof gl.RGBA8UI === "undefined") {
+			if (typeof context.RGBA8UI === "undefined") {
 				throw new Error(
 					'BufferTextureResource: format "rgba8ui" requires a WebGL 2 context',
 				);
 			}
-			gl.texImage2D(
+			context.texImage2D(
 				target,
 				0,
-				gl.RGBA8UI,
+				context.RGBA8UI,
 				this.width,
 				this.height,
 				0,
-				gl.RGBA_INTEGER,
-				gl.UNSIGNED_BYTE,
+				context.RGBA_INTEGER,
+				context.UNSIGNED_BYTE,
 				this.data,
 			);
 		} else {
-			gl.texImage2D(
+			context.texImage2D(
 				target,
 				0,
-				gl.RGBA,
+				context.RGBA,
 				this.width,
 				this.height,
 				0,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
+				context.RGBA,
+				context.UNSIGNED_BYTE,
 				this.data,
 			);
 		}

--- a/packages/melonjs/src/video/webgl/batchers/material_batcher.js
+++ b/packages/melonjs/src/video/webgl/batchers/material_batcher.js
@@ -163,7 +163,12 @@ export class MaterialBatcher extends Batcher {
 		if (pixels !== null && typeof pixels.upload === "function") {
 			// `TextureResource` path: the resource owns its upload (raw
 			// buffer, future synthesized sources, etc.). Keeps every
-			// `gl.texImage2D` variant in one place per source type.
+			// backend-specific upload call in one place per source type.
+			// The resource's `upload(context, target)` contract is
+			// renderer-agnostic — we pass `gl` here because this is the
+			// WebGL batcher; a future WebGPU batcher would pass its own
+			// `renderer.getContext()` result and the resource subclass
+			// implementing that backend would handle it.
 			pixels.upload(gl, gl.TEXTURE_2D);
 		} else if (pixels !== null && pixels.compressed === true) {
 			const mipmaps = pixels.mipmaps;

--- a/packages/melonjs/tests/depth.spec.js
+++ b/packages/melonjs/tests/depth.spec.js
@@ -348,7 +348,7 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 		// (drawImage's currentTint converts to uint32 via toUint32(alpha))
 		renderer.save();
 		renderer.setTint(
-			{ r: 255, g: 0, b: 0, alpha: 1.0, glArray: [1, 0, 0, 1] },
+			{ r: 255, g: 0, b: 0, alpha: 1.0, normalizedRGBA: [1, 0, 0, 1] },
 			1.0,
 		);
 		renderer.setDepth(11);

--- a/packages/melonjs/tests/depth.spec.js
+++ b/packages/melonjs/tests/depth.spec.js
@@ -347,10 +347,10 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 		// distinctive tint: solid red with full alpha = 0xff0000ff in ABGR
 		// (drawImage's currentTint converts to uint32 via toUint32(alpha))
 		renderer.save();
-		renderer.setTint(
-			{ r: 255, g: 0, b: 0, alpha: 1.0, normalizedRGBA: [1, 0, 0, 1] },
-			1.0,
-		);
+		// `setTint` accepts a CSS color string and parses it via
+		// `Color.copy`; using the public surface keeps the test from
+		// depending on Color's private backing array shape.
+		renderer.setTint("#ff0000", 1.0);
 		renderer.setDepth(11);
 		renderer.drawImage(tex, 0, 0, 16, 16, 0, 0, 16, 16);
 		renderer.restore();

--- a/packages/melonjs/tests/webgl_pipeline_adversarial.spec.js
+++ b/packages/melonjs/tests/webgl_pipeline_adversarial.spec.js
@@ -74,10 +74,10 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- Cross-batcher transitions in a single "frame" ----
 
-	it("frame: sprite → primitive → sprite produces no GL error", () => {
+	it("frame: sprite → primitive → sprite produces no GL error", (ctx) => {
 		// Common pattern: world-space sprites, debug primitive overlay,
 		// more sprites (UI). Every transition must reset stride/attrib/program.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const tex = video.createCanvas(16, 16);
@@ -88,11 +88,11 @@ describe("WebGL pipeline adversarial integration", () => {
 		expectNoGLErrors();
 	});
 
-	it("frame: lit sprite → unlit sprite → lit sprite (mixed lighting in one frame)", () => {
+	it("frame: lit sprite → unlit sprite → lit sprite (mixed lighting in one frame)", (ctx) => {
 		// SpriteIlluminator-style scene: ambient backdrop (unlit), prop with
 		// normal map (lit), more backdrop. The dispatch must flip between
 		// `quad` and `litQuad` cleanly each time.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const tex = video.createCanvas(16, 16);
@@ -127,12 +127,12 @@ describe("WebGL pipeline adversarial integration", () => {
 		expectNoGLErrors();
 	});
 
-	it("frame: setLightUniforms with no lights followed by sprite draw uses quad's program", () => {
+	it("frame: setLightUniforms with no lights followed by sprite draw uses quad's program", (ctx) => {
 		// The exact platformer reproducer: every camera frame calls
 		// setLightUniforms even when there are no lights; that call writes
 		// to litQuad's shader and would leave gl.useProgram pointing at it.
 		// The next drawImage must NOT render quad data through litQuad's shader.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.setBatcher("quad");
@@ -150,11 +150,11 @@ describe("WebGL pipeline adversarial integration", () => {
 		expectNoGLErrors();
 	});
 
-	it("frame: mesh → sprite → primitive (three different vertex layouts)", () => {
+	it("frame: mesh → sprite → primitive (three different vertex layouts)", (ctx) => {
 		// Mesh batcher has its own vertex format (x, y, z, u, v, tint).
 		// Switching from mesh to quad to primitive requires three different
 		// stride/offset configurations.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const tex = video.createCanvas(16, 16);
@@ -171,11 +171,11 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- Texture-slot pressure ----
 
-	it("frame: many distinct textures forces multi-texture overflow + reset", () => {
+	it("frame: many distinct textures forces multi-texture overflow + reset", (ctx) => {
 		// Push more distinct textures than the batcher's sampler range to
 		// trigger the overflow path (`flush + cache.resetUnitAssignments`).
 		// The end state must still draw correctly with no GL errors.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const quad = renderer.batchers.get("quad");
@@ -192,11 +192,11 @@ describe("WebGL pipeline adversarial integration", () => {
 		expectNoGLErrors();
 	});
 
-	it("frame: same texture used by quad AND litQuad in the same frame", () => {
+	it("frame: same texture used by quad AND litQuad in the same frame", (ctx) => {
 		// The texture cache is shared between batchers. A texture used unlit
 		// (slot N in quad) then lit (slot M in litQuad) must work without
 		// double-binding to a now-stale unit.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const tex = video.createCanvas(16, 16);
@@ -226,10 +226,10 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- save / restore stack interactions ----
 
-	it("save/restore around a batcher switch: state stays consistent", () => {
+	it("save/restore around a batcher switch: state stays consistent", (ctx) => {
 		// renderer.save() snapshots color/transform/blend; the batcher
 		// switching should not corrupt that snapshot.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const tex = video.createCanvas(8, 8);
@@ -265,11 +265,11 @@ describe("WebGL pipeline adversarial integration", () => {
 		};
 	}
 
-	it("light count: 3 → 0 zeroes the lit batcher's uLightCount on next call", () => {
+	it("light count: 3 → 0 zeroes the lit batcher's uLightCount on next call", (ctx) => {
 		// Stage transitions can drop active-light count to 0. The lit
 		// batcher must update — leftover non-zero count would make a
 		// subsequent normal-mapped sprite read garbage from light array slots.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const lit = renderer.batchers.get("litQuad");
@@ -286,10 +286,10 @@ describe("WebGL pipeline adversarial integration", () => {
 		expect(lit._lightCount).toBe(0);
 	});
 
-	it("light count: 9 (over MAX_LIGHTS) clamps to MAX_LIGHTS without overflow", () => {
+	it("light count: 9 (over MAX_LIGHTS) clamps to MAX_LIGHTS without overflow", (ctx) => {
 		// Boundary check: count > MAX_LIGHTS must clamp, not overrun the
 		// 8-slot uLightPos array.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const lit = renderer.batchers.get("litQuad");
@@ -305,10 +305,10 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- Repeated batcher switching (worst-case frame churn) ----
 
-	it("100 alternating batcher switches in one frame: no error, no leak", () => {
+	it("100 alternating batcher switches in one frame: no error, no leak", (ctx) => {
 		// Pathological-but-valid: a frame that bounces between sprite and
 		// primitive draws 100 times. Each switch must flush + unbind cleanly.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const tex = video.createCanvas(8, 8);
@@ -322,8 +322,8 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- Empty flushes ----
 
-	it("flushing an empty batcher is a no-op (no error, no draw)", () => {
-		if (!isWebGL) {
+	it("flushing an empty batcher is a no-op (no error, no draw)", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.setBatcher("quad");
@@ -336,11 +336,11 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- Vertex attribute consistency ----
 
-	it("after every batcher switch, gl.useProgram matches the active batcher's program", () => {
+	it("after every batcher switch, gl.useProgram matches the active batcher's program", (ctx) => {
 		// Universal invariant: whatever public API was just called, the
 		// active program must be the active batcher's. Otherwise the next
 		// flush draws through the wrong shader.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const names = ["quad", "litQuad", "primitive", "mesh"];
@@ -356,12 +356,12 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- ShaderEffect / custom shader interactions ----
 
-	it("custom shader on quad → revert: useMultiTexture flips off and back on", () => {
+	it("custom shader on quad → revert: useMultiTexture flips off and back on", (ctx) => {
 		// QuadBatcher.useShader(non-default) sets useMultiTexture=false
 		// (single-texture fallback path). useShader(default) must
 		// restore it. Use a real custom shader so the test actually
 		// exercises both transitions.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const quad = renderer.setBatcher("quad");
@@ -730,10 +730,10 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- Mode flag interactions (blend, scissor) ----
 
-	it("blend mode change between batcher switches: no error", () => {
+	it("blend mode change between batcher switches: no error", (ctx) => {
 		// setBlendMode flushes the current batcher and updates GL state.
 		// Doing this between unrelated draws shouldn't corrupt either batch.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const tex = video.createCanvas(8, 8);
@@ -750,7 +750,7 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- Fuzz: random sequences of public APIs ----
 
-	it("fuzz: 1000 random ops produce no GL error and leave no batcher in a stuck state", () => {
+	it("fuzz: 1000 random ops produce no GL error and leave no batcher in a stuck state", (ctx) => {
 		// Random sequences of public renderer ops. After every op,
 		// `gl.getError()` must be `NO_ERROR` and `gl.CURRENT_PROGRAM` must
 		// match the active batcher's program. Failure dumps the seed and
@@ -758,7 +758,7 @@ describe("WebGL pipeline adversarial integration", () => {
 		//
 		// Deterministic: a seeded LCG drives the choices, so any failure
 		// here is a single-line repro from the printed seed.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 
@@ -933,12 +933,12 @@ describe("WebGL pipeline adversarial integration", () => {
 
 	// ---- Per-batcher unbind symmetry ----
 
-	it("every registered batcher's unbind disables exactly its own attribute locations", () => {
+	it("every registered batcher's unbind disables exactly its own attribute locations", (ctx) => {
 		// Generic invariant on the Batcher contract: unbind must only
 		// touch locations it owns, never leave one of its own enabled,
 		// never disable a location it doesn't own (e.g. one belonging to a
 		// different batcher's currently-active program).
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		for (const [name, batcher] of renderer.batchers) {
@@ -1967,8 +1967,8 @@ describe("WebGL pipeline adversarial integration", () => {
 	// what the upload sees. A regression that goes back to `toFloat32()`
 	// surfaces here as the `instanceof Uint8Array` assertion failing.
 	describe("vertex buffer is uploaded as Uint8Array (NaN-canonicalization regression)", () => {
-		it("quad batcher flush uploads via Uint8Array, not Float32Array", () => {
-			if (!isWebGL) {
+		it("quad batcher flush uploads via Uint8Array, not Float32Array", (ctx) => {
+			if (skipIfNoWebGL(ctx)) {
 				return;
 			}
 			// Record every gl.bufferData call's srcData arg. We only
@@ -2007,14 +2007,14 @@ describe("WebGL pipeline adversarial integration", () => {
 			expectNoGLErrors();
 		});
 
-		it("the uploaded Uint8 view sees the SAME ArrayBuffer as the underlying Float32 view (sanity: it's a view, not a copy)", () => {
+		it("the uploaded Uint8 view sees the SAME ArrayBuffer as the underlying Float32 view (sanity: it's a view, not a copy)", (ctx) => {
 			// The whole point is that no NaN-pattern values exist on the
 			// upload path. The Uint8 view is a view of the SAME bytes
 			// that bufferF32 would see; if the implementation ever
 			// regressed to allocating a Uint8 copy (subtle perf hit AND
 			// breaks the zero-allocation hot-path contract), the
 			// `.buffer` identity check would catch it.
-			if (!isWebGL) {
+			if (skipIfNoWebGL(ctx)) {
 				return;
 			}
 			const captures = [];
@@ -2047,14 +2047,14 @@ describe("WebGL pipeline adversarial integration", () => {
 			}
 		});
 
-		it("mesh batcher's indexed flush also uploads via Uint8Array (catches a regression in the indexed path only)", async () => {
+		it("mesh batcher's indexed flush also uploads via Uint8Array (catches a regression in the indexed path only)", async (ctx) => {
 			// The Mesh-rendering path goes through a *different* upload
 			// branch than the regular quad path (own glVertexBuffer +
 			// drawElements with an index buffer). A targeted regression
 			// could fix one branch and miss the other — so we exercise
 			// the mesh path directly and confirm the Uint8 upload there
 			// too.
-			if (!isWebGL) {
+			if (skipIfNoWebGL(ctx)) {
 				return;
 			}
 			// Tiny mesh: 4 vertices, 2 triangles, indexed.
@@ -2092,12 +2092,12 @@ describe("WebGL pipeline adversarial integration", () => {
 			expectNoGLErrors();
 		});
 
-		it("the byteLength upload matches `vertexCount × vertexSize × 4`", () => {
+		it("the byteLength upload matches `vertexCount × vertexSize × 4`", (ctx) => {
 			// A subtle regression class: switching the view to Uint8
 			// but forgetting to multiply `vertexCount * vertexSize` by
 			// 4 (bytes per Float32) → only the first quarter of the
 			// vertices land on the GPU. Pin the byte arithmetic.
-			if (!isWebGL) {
+			if (skipIfNoWebGL(ctx)) {
 				return;
 			}
 			let captured = null;


### PR DESCRIPTION
## What

Two small clean-ups bundled. Both are zero-behavior-change.

### 1. Silent-skip sweep on \`webgl_pipeline_adversarial.spec.js\` (20 sites)

20 tests in this file used the \`if (!isWebGL) { return; }\` pattern, which reports as \`passed\` in the vitest reporter rather than \`skipped\`. The same file already had a \`skipIfNoWebGL(ctx)\` helper used by 38 other tests that does the right thing via \`ctx.skip()\`. This commit aligns the remaining 20 on that helper so every WebGL-required test in the file produces a visible \"skipped\" status on no-WebGL runners.

Same hygiene class as the \`webgl_render_state.spec.js\` clean-up under #1481 — broken assertions hid for ~3 months behind a green check before that one was found, so the cost of leaving silent skips around is real.

### 2. Minor renderer-agnostic-naming polish

Two small follow-ons in the same spirit as \`GPU_TEXTURE_CACHE_RESET\` / \`RENDER_TARGET_CHANGED\` (event names chosen backend-agnostic on purpose so the WebGPU port doesn't have to rename them later):

- **\`Renderer\` base JSDoc audit.** Six places where the wording said \"WebGL only\" / \"the WebGL renderer overrides this\" when the actual contract applies to any GPU backend. Examples: \`GPURenderer\` (the GPU device identifier string), \`customShader\`, \`setBlendMode\`'s \`premultipliedAlpha\` flag, the Camera3d depth push, \`setProjection\`, the \`drawImage\` subclass list. Pure wording.
- **\`Color.glArray\` → \`Color.normalizedRGBA\`.** The private Float32Array of \`[r, g, b, a]\` 0..1 floats kept its WebGL-era field name even though the data is just normalized RGBA. 39 occurrences in \`color.ts\` (declaration + internal reads/writes), 3 external callers (\`renderer.js\`, \`canvas_renderer.js\`), one test stub (\`depth.spec.js\`). Field is marked \`private\` in TS so the rename is internal-API-only.

## What it is NOT

Honest framing: this is **not** a major WebGPU-port-prep refactor. The architectural abstractions needed for a backend port (\`getContext()\` on the base renderer, renderer-agnostic event names, the \`Renderer\` abstract method surface, \`TextureResource\` pattern, the \`Batcher\` base class) are already in place from prior batches. The wording + naming bits above are the small leftover hygiene; structural moves like an internal \`renderer.gl\` deprecation belong with whoever's actually wiring up the WebGPU port.

## Test plan

- [x] \`pnpm test:types\` clean
- [x] \`pnpm vitest run\` — 3997 passing / 13 skipped / 0 failed
- [x] \`pnpm build\` — lint + types clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)