### PR TITLE
chore(rendertarget): align backend detection on `renderer.type.startsWith("WebGL")`

### DIFF
--- a/packages/melonjs/src/video/rendertarget/canvasrendertarget.js
+++ b/packages/melonjs/src/video/rendertarget/canvasrendertarget.js
@@ -255,7 +255,7 @@ class CanvasRenderTarget extends RenderTarget {
 	 * @param {CanvasRenderer|WebGLRenderer} renderer - the renderer to which this canvas texture is attached
 	 */
 	invalidate(renderer) {
-		if (typeof renderer.gl !== "undefined") {
+		if (renderer.type.startsWith("WebGL")) {
 			// flush pending draws referencing the current texture data
 			renderer.flush();
 			renderer.setBatcher("quad");
@@ -289,7 +289,7 @@ class CanvasRenderTarget extends RenderTarget {
 		// render target.
 		if (
 			renderer &&
-			typeof renderer.gl !== "undefined" &&
+			renderer.type.startsWith("WebGL") &&
 			this.canvas &&
 			renderer.cache.has(this.canvas)
 		) {

--- a/packages/melonjs/src/video/rendertarget/rendertarget.ts
+++ b/packages/melonjs/src/video/rendertarget/rendertarget.ts
@@ -24,7 +24,9 @@ export default abstract class RenderTarget {
 	/**
 	 * Bind this render target as the active draw destination.
 	 * All subsequent draw calls will render into this target until {@link unbind} is called.
-	 * No-op by default — subclasses override for GPU render targets (e.g. WebGL FBOs).
+	 * No-op by default — subclasses override for GPU render targets
+	 * (a WebGL FBO today, a `GPURenderPassEncoder` once the WebGPU
+	 * renderer lands).
 	 */
 	bind(): void {}
 


### PR DESCRIPTION
Two sites in \`packages/melonjs/src/video/rendertarget/canvasrendertarget.js\` used \`typeof renderer.gl !== \"undefined\"\` as a \"is this a WebGL renderer?\" guard. Replaced with \`renderer.type.startsWith(\"WebGL\")\` — the renderer already carries a public \`.type\` brand string (\`\"CANVAS\"\` / \`\"WebGL1\"\` / \`\"WebGL2\"\`) that's the engine's canonical way to discriminate backends.

No new import needed — the brand lives on the base class. A future WebGPU port can add a \`|| renderer.type === \"WebGPU\"\` sibling branch without chasing scattered \`typeof\` patterns.

With the \`gl → context\` rename on \`TextureResource.upload\` (#1490), these were the last legacy \`typeof renderer.gl\` duck-type checks in the engine.

## Test plan

- [x] \`pnpm test:types\` clean
- [x] \`pnpm vitest run\` — 3997 / 13 skipped / 0 failed
- [x] \`pnpm build\` — lint + types clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)