### PR TITLE
chore(tests): silent-skip sweep pt2 — 8 more spec files

### DIFF
--- a/packages/melonjs/tests/batcher_attribute_leak.spec.js
+++ b/packages/melonjs/tests/batcher_attribute_leak.spec.js
@@ -61,8 +61,18 @@ describe("Batcher attribute leak between switches (WebGL)", () => {
 		return set;
 	}
 
-	it("switching from quad → primitive disables quad-only attribute locations", () => {
+	// Runtime skip helper — visible "skipped" reporter status instead
+	// of silent early-return. Mirrors `webgl_pipeline_adversarial.spec.js`.
+	const skipIfNoWebGL = (ctx) => {
 		if (!isWebGL) {
+			ctx.skip("WebGL renderer not available in this environment");
+			return true;
+		}
+		return false;
+	};
+
+	it("switching from quad → primitive disables quad-only attribute locations", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 
@@ -90,13 +100,13 @@ describe("Batcher attribute leak between switches (WebGL)", () => {
 		expect(leaked).toEqual([]);
 	});
 
-	it("drawing after quad → primitive switch produces no GL error", () => {
+	it("drawing after quad → primitive switch produces no GL error", (ctx) => {
 		// End-to-end reproducer of the original report: a frame that draws a
 		// sprite (quad path) followed by a primitive (line/rect) used to
 		// throw INVALID_OPERATION on the primitive draw because quad's
 		// aNormalTextureId stayed enabled at a larger stride than the
 		// primitive buffer's stride.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 
@@ -121,10 +131,10 @@ describe("Batcher attribute leak between switches (WebGL)", () => {
 		expect(gl.getError()).toBe(gl.NO_ERROR);
 	});
 
-	it("Batcher.unbind disables exactly the locations bind/useShader enabled", () => {
+	it("Batcher.unbind disables exactly the locations bind/useShader enabled", (ctx) => {
 		// Symmetry test: bind enables N locations, unbind disables those same
 		// N locations and no others.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 
@@ -152,13 +162,13 @@ describe("Batcher attribute leak between switches (WebGL)", () => {
 		renderer.setBatcher("quad");
 	});
 
-	it("switching from litQuad → primitive disables litQuad-only attribute locations", () => {
+	it("switching from litQuad → primitive disables litQuad-only attribute locations", (ctx) => {
 		// The dispatch path that originally triggered the platformer crash:
 		// a normal-mapped sprite drawn through `litQuad` (5 attributes)
 		// followed by a primitive draw (`primitive`, 3 attribs). The lit
 		// batcher's `aNormalTextureId` and `aTextureId` must be disabled
 		// before the primitive's vertex buffer is uploaded.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 
@@ -209,8 +219,16 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		});
 	});
 
-	it("unlit sprite (no normalMap, no lights) dispatches to `quad`", () => {
+	const skipIfNoWebGL = (ctx) => {
 		if (!isWebGL) {
+			ctx.skip("WebGL renderer not available in this environment");
+			return true;
+		}
+		return false;
+	};
+
+	it("unlit sprite (no normalMap, no lights) dispatches to `quad`", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.activeLightCount = 0;
@@ -220,8 +238,8 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		expect(renderer.currentBatcher).toBe(renderer.batchers.get("quad"));
 	});
 
-	it("normal-mapped sprite WITH active lights dispatches to `litQuad`", () => {
-		if (!isWebGL) {
+	it("normal-mapped sprite WITH active lights dispatches to `litQuad`", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.activeLightCount = 1;
@@ -232,11 +250,11 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		expect(renderer.currentBatcher).toBe(renderer.batchers.get("litQuad"));
 	});
 
-	it("normal-mapped sprite WITHOUT active lights still uses `quad` (nothing to light)", () => {
+	it("normal-mapped sprite WITHOUT active lights still uses `quad` (nothing to light)", (ctx) => {
 		// A sprite with normalMap but no Light2d in the scene has no lit
 		// math to run — the unlit batcher renders it identically to a plain
 		// sprite, at full texture-unit capacity.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.activeLightCount = 0;
@@ -247,8 +265,8 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		expect(renderer.currentBatcher).toBe(renderer.batchers.get("quad"));
 	});
 
-	it("active lights but no normalMap on the sprite still uses `quad` (no normal to sample)", () => {
-		if (!isWebGL) {
+	it("active lights but no normalMap on the sprite still uses `quad` (no normal to sample)", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.activeLightCount = 3;
@@ -258,11 +276,11 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		expect(renderer.currentBatcher).toBe(renderer.batchers.get("quad"));
 	});
 
-	it("`quad` keeps full texture-unit capacity (no halving)", () => {
+	it("`quad` keeps full texture-unit capacity (no halving)", (ctx) => {
 		// The whole reason for splitting batchers: unlit `quad` is no longer
 		// punished for the lit pipeline's paired-sampler layout. Capacity
 		// equals `min(maxTextures, 16)`, not `floor(maxTextures / 2)`.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const quad = renderer.batchers.get("quad");
@@ -270,8 +288,8 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		expect(quad.maxBatchTextures).toBe(expected);
 	});
 
-	it("`litQuad` halves texture-unit capacity for paired (color, normal) layout", () => {
-		if (!isWebGL) {
+	it("`litQuad` halves texture-unit capacity for paired (color, normal) layout", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const lit = renderer.batchers.get("litQuad");
@@ -282,8 +300,8 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		expect(lit.maxBatchTextures).toBe(expected);
 	});
 
-	it("`setLightUniforms` updates renderer.activeLightCount and forwards to litQuad", () => {
-		if (!isWebGL) {
+	it("`setLightUniforms` updates renderer.activeLightCount and forwards to litQuad", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const lit = renderer.batchers.get("litQuad");
@@ -308,10 +326,10 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		expect(lit._lightCount).toBe(2);
 	});
 
-	it("setLightUniforms tolerates undefined / empty inputs (no throw, count = 0)", () => {
+	it("setLightUniforms tolerates undefined / empty inputs (no throw, count = 0)", (ctx) => {
 		// Camera2d.draw forwards `stage?._activeLights` — when there's no
 		// active stage, both lights and ambient are undefined.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		expect(() => {
@@ -330,7 +348,7 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		expect(renderer.activeLightCount).toBe(0);
 	});
 
-	it("setLightUniforms must not leak gl.useProgram out of the active batcher", () => {
+	it("setLightUniforms must not leak gl.useProgram out of the active batcher", (ctx) => {
 		// Real-world reproducer for the bug that broke the platformer:
 		// every camera draw calls `renderer.setLightUniforms(...)` even
 		// when the scene has no lights. That call writes to litQuad's
@@ -338,7 +356,7 @@ describe("WebGLRenderer.drawImage lit/unlit dispatch", () => {
 		// program. If the renderer doesn't restore the active batcher's
 		// program before the next draw, quad's 4-attribute vertex data gets
 		// fed to litQuad's 5-attribute shader and renders as garbage.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const gl = renderer.gl;
@@ -396,7 +414,15 @@ describe("LitQuadBatcher internal bookkeeping invariants", () => {
 		});
 	});
 
-	it("cached normal-map rebind updates boundTextures and currentTextureUnit", () => {
+	const skipIfNoWebGL = (ctx) => {
+		if (!isWebGL) {
+			ctx.skip("WebGL renderer not available in this environment");
+			return true;
+		}
+		return false;
+	};
+
+	it("cached normal-map rebind updates boundTextures and currentTextureUnit", (ctx) => {
 		// Original Copilot-reported footgun: the cached branch in
 		// `bindNormalMap` was using raw `gl.activeTexture` + `gl.bindTexture`,
 		// which set GL state correctly but didn't update MaterialBatcher's
@@ -404,7 +430,7 @@ describe("LitQuadBatcher internal bookkeeping invariants", () => {
 		// `bindTexture2D(cached, unit, false)` so a subsequent color-texture
 		// upload at the same unit can correctly skip the rebind (or,
 		// conversely, knows the slot is already taken).
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const lit = renderer.batchers.get("litQuad");
@@ -429,12 +455,12 @@ describe("LitQuadBatcher internal bookkeeping invariants", () => {
 		expect(lit.currentTextureUnit).toBe(unit);
 	});
 
-	it("cached rebind to the SAME unit doesn't trigger redundant work", () => {
+	it("cached rebind to the SAME unit doesn't trigger redundant work", (ctx) => {
 		// Sanity check: if the bookkeeping already says this unit holds the
 		// texture, the cached path should be a true no-op (no flush, no
 		// activeTexture, no bindTexture). `bindTexture2D` skips the work
 		// when `texture === boundTextures[unit] && unit === currentTextureUnit`.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const lit = renderer.batchers.get("litQuad");

--- a/packages/melonjs/tests/clipRect.spec.js
+++ b/packages/melonjs/tests/clipRect.spec.js
@@ -73,8 +73,20 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 		return calls;
 	}
 
-	it("clipRect under identity transform: scissor matches the input rect", () => {
+	// Runtime skip helper. Produces a real "skipped" reporter status
+	// instead of silently no-op'ing with an early `return`, which
+	// hides regressions behind a green check. Mirrors the helper
+	// pattern in `webgl_pipeline_adversarial.spec.js`.
+	const skipIfNoWebGL = (ctx) => {
 		if (!isWebGL) {
+			ctx.skip("WebGL renderer not available in this environment");
+			return true;
+		}
+		return false;
+	};
+
+	it("clipRect under identity transform: scissor matches the input rect", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.save();
@@ -94,8 +106,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 		expect(calls[0].h).toBe(60);
 	});
 
-	it("clipRect under a translated transform: scissor honors the translation", () => {
-		if (!isWebGL) {
+	it("clipRect under a translated transform: scissor honors the translation", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.save();
@@ -119,8 +131,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 
 	// ---- Fixed bugs (flipped from `it.fails` after #1349 fix) ----
 
-	it("Bug #1349 (fixed): clipRect under a scaled transform produces a scaled scissor box", () => {
-		if (!isWebGL) {
+	it("Bug #1349 (fixed): clipRect under a scaled transform produces a scaled scissor box", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.save();
@@ -140,8 +152,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 		expect(calls[0].h).toBe(60);
 	});
 
-	it("Bug #1349 (fixed): clipRect under a rotated transform produces the rotated AABB", () => {
-		if (!isWebGL) {
+	it("Bug #1349 (fixed): clipRect under a rotated transform produces the rotated AABB", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.save();
@@ -162,8 +174,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 
 	// ---- Bug #1 (call site) — Container nested in a translated wrapper ----
 
-	it("Bug #1349 (fixed): Container nested in a translated wrapper produces a correctly-placed scissor", () => {
-		if (!isWebGL) {
+	it("Bug #1349 (fixed): Container nested in a translated wrapper produces a correctly-placed scissor", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		// reproducer matches the visual demo in the Clipping example:
@@ -215,8 +227,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 
 	// ---- Regression guard: full-canvas input is an explicit "no clip" signal ----
 
-	it("clipRect with input matching the canvas size disables the scissor without running transform math", () => {
-		if (!isWebGL) {
+	it("clipRect with input matching the canvas size disables the scissor without running transform math", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		// Reproduces the `ColorLayer.draw` contract: ColorLayer is a
@@ -292,8 +304,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 		return calls;
 	}
 
-	it("vertices queued inside a nested clip flush under that clip's scissor", () => {
-		if (!isWebGL) {
+	it("vertices queued inside a nested clip flush under that clip's scissor", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.save();
@@ -342,8 +354,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 
 	// ---- Regression guard: nested save/restore correctly snapshots the scissor box ----
 
-	it("nested save/restore restores the outer scissor box after an inner clipRect", () => {
-		if (!isWebGL) {
+	it("nested save/restore restores the outer scissor box after an inner clipRect", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.save();
@@ -372,8 +384,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 	// ---- Regression guard: AABB ≥ canvas under a non-identity transform
 	// disables the scissor (transform-aware fast path).
 
-	it("clipRect whose screen-space AABB covers the canvas disables the scissor", () => {
-		if (!isWebGL) {
+	it("clipRect whose screen-space AABB covers the canvas disables the scissor", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.save();
@@ -399,8 +411,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 	// (TRIANGLES → LINES) forces a `PrimitiveBatcher` flush; that flush
 	// must happen under the active scissor.
 
-	it("primitive mode switch (fillRect → strokeLine) inside a clip stays clipped", () => {
-		if (!isWebGL) {
+	it("primitive mode switch (fillRect → strokeLine) inside a clip stays clipped", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.save();
@@ -430,17 +442,17 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 	// ---- Regression guard: batcher swap inside a clip flushes the
 	// outgoing batcher under the active scissor (primitive ↔ quad).
 
-	it("alternating fillRect ↔ drawImage inside a clip stays clipped across batcher swaps", () => {
-		if (!isWebGL) {
+	it("alternating fillRect ↔ drawImage inside a clip stays clipped across batcher swaps", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		// build a 4×4 image source (HTMLCanvasElement) for drawImage.
 		const src = document.createElement("canvas");
 		src.width = 4;
 		src.height = 4;
-		const ctx = src.getContext("2d");
-		ctx.fillStyle = "#ffffff";
-		ctx.fillRect(0, 0, 4, 4);
+		const srcCtx = src.getContext("2d");
+		srcCtx.fillStyle = "#ffffff";
+		srcCtx.fillRect(0, 0, 4, 4);
 
 		renderer.save();
 		renderer.resetTransform();
@@ -473,8 +485,8 @@ describe("WebGLRenderer.clipRect (#1349)", () => {
 	// must drain BEFORE a subsequent `clipRect` activates a new scissor
 	// — symmetric to the `restore()` flush-ordering fix.
 
-	it("pre-clip vertices flush under no scissor, post-clip vertices flush under the new scissor", () => {
-		if (!isWebGL) {
+	it("pre-clip vertices flush under no scissor, post-clip vertices flush under the new scissor", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.save();

--- a/packages/melonjs/tests/depth.spec.js
+++ b/packages/melonjs/tests/depth.spec.js
@@ -208,10 +208,18 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 		});
 	});
 
+	const skipIfNoWebGL = (ctx) => {
+		if (!isWebGL) {
+			ctx.skip("WebGL renderer not available in this environment");
+			return true;
+		}
+		return false;
+	};
+
 	// QuadBatcher layout: aVertex(3) + aRegion(2) + aColor(4 UBYTE = 1 float-slot)
 	// + aTextureId(1) = 7 float-slots * 4 bytes = 28 bytes
-	it("QuadBatcher declares aVertex size 3, stride 28", () => {
-		if (!isWebGL) {
+	it("QuadBatcher declares aVertex size 3, stride 28", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("quad");
@@ -224,8 +232,8 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 	});
 
 	// LitQuadBatcher adds aNormalTextureId at the tail → 8 float-slots = 32 bytes
-	it("LitQuadBatcher declares aVertex size 3, stride 32", () => {
-		if (!isWebGL) {
+	it("LitQuadBatcher declares aVertex size 3, stride 32", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("litQuad");
@@ -239,8 +247,8 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 
 	// PrimitiveBatcher: aVertex(3) + aNormal(2) + aColor(4 UBYTE = 1 float-slot)
 	// = 6 float-slots * 4 bytes = 24 bytes
-	it("PrimitiveBatcher declares aVertex size 3, stride 24", () => {
-		if (!isWebGL) {
+	it("PrimitiveBatcher declares aVertex size 3, stride 24", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("primitive");
@@ -252,8 +260,8 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 		expect(batcher.stride).toBe(24);
 	});
 
-	it("renderer.setDepth value is emitted as the z component of every vertex (quad)", () => {
-		if (!isWebGL) {
+	it("renderer.setDepth value is emitted as the z component of every vertex (quad)", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 
@@ -283,8 +291,8 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 		batcher.vertexData.clear();
 	});
 
-	it("default depth = 0 produces z = 0 in the vertex stream", () => {
-		if (!isWebGL) {
+	it("default depth = 0 produces z = 0 in the vertex stream", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("quad");
@@ -305,8 +313,8 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 		batcher.vertexData.clear();
 	});
 
-	it("emits the same depth across all vertices of a primitive draw", () => {
-		if (!isWebGL) {
+	it("emits the same depth across all vertices of a primitive draw", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("primitive");
@@ -326,7 +334,7 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 		batcher.vertexData.clear();
 	});
 
-	it("tint slot survives at the correct offset after vertex layout widening (regression)", () => {
+	it("tint slot survives at the correct offset after vertex layout widening (regression)", (ctx) => {
 		// The original PR A had a bug where `VertexArrayBuffer.push()` still
 		// indexed by the old (pre-vec3) positional layout. The caller passed
 		// (x, y, z, u, v, tint, textureId) but push() wrote arg 4 ("v") to
@@ -337,7 +345,7 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 		// Guard: verify that after a drawImage with a known tint, the tint
 		// slot at the new offset 5 contains the actual tint uint32 — NOT a
 		// reinterpreted float.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("quad");
@@ -376,11 +384,11 @@ describe("WebGL batchers carry depth as vec3 aVertex (PR A)", () => {
 		batcher.vertexData.clear();
 	});
 
-	it("draws without GL error after vertex layout widening (regression)", () => {
+	it("draws without GL error after vertex layout widening (regression)", (ctx) => {
 		// End-to-end: a frame of sprite + primitive draws at non-zero depth
 		// must not produce INVALID_OPERATION (stride mismatch) or
 		// INVALID_VALUE (out-of-range attribute) on either path.
-		if (!isWebGL) {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 

--- a/packages/melonjs/tests/depth_adversarial.spec.js
+++ b/packages/melonjs/tests/depth_adversarial.spec.js
@@ -65,10 +65,11 @@ describe("depth pipeline adversarial integration", () => {
 		});
 	});
 
+	// Internal helpers called from inside it() callbacks. By the time
+	// we reach these, the calling test has already skipped via
+	// `skipIfNoWebGL(ctx)` if WebGL isn't available — so we can use
+	// `gl` directly without guarding here.
 	function expectNoGLErrors() {
-		if (!isWebGL) {
-			return;
-		}
 		const err = gl.getError();
 		if (err !== gl.NO_ERROR) {
 			expect.fail(`GL error after draw: 0x${err.toString(16)}`);
@@ -76,18 +77,23 @@ describe("depth pipeline adversarial integration", () => {
 	}
 
 	function drainGLErrors() {
-		if (!isWebGL) {
-			return;
-		}
 		while (gl.getError() !== gl.NO_ERROR) {
 			/* drain stale errors from previous tests */
 		}
 	}
 
+	const skipIfNoWebGL = (ctx) => {
+		if (!isWebGL) {
+			ctx.skip("WebGL renderer not available in this environment");
+			return true;
+		}
+		return false;
+	};
+
 	// ---- cross-batcher depth persistence ----
 
-	it("currentDepth survives a quad → primitive → quad batcher switch", () => {
-		if (!isWebGL) {
+	it("currentDepth survives a quad → primitive → quad batcher switch", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		renderer.setDepth(33);
@@ -106,8 +112,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- mid-batch per-vertex emission ----
 
-	it("mid-batch depth change produces per-vertex distinct z without retroactive rewrite", () => {
-		if (!isWebGL) {
+	it("mid-batch depth change produces per-vertex distinct z without retroactive rewrite", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("quad");
@@ -143,8 +149,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- composite renderable inheritance ----
 
-	it("NineSliceSprite (9-quad renderable) — every emitted quad inherits the same depth", () => {
-		if (!isWebGL) {
+	it("NineSliceSprite (9-quad renderable) — every emitted quad inherits the same depth", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("quad");
@@ -181,8 +187,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- parent/child depth nesting via save/restore stack ----
 
-	it("nested preDraw/postDraw — child's vertices carry child's depth, then stack pops back", () => {
-		if (!isWebGL) {
+	it("nested preDraw/postDraw — child's vertices carry child's depth, then stack pops back", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("quad");
@@ -227,8 +233,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- blitTexture invariant (post-fx blits always z=0) ----
 
-	it("blitTexture ignores currentDepth and emits z=0 (screen-space invariant)", () => {
-		if (!isWebGL) {
+	it("blitTexture ignores currentDepth and emits z=0 (screen-space invariant)", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		// install a deeply non-zero depth — the blit path should not pick it up
@@ -295,8 +301,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- Mesh batcher independence ----
 
-	it("Mesh batcher's pushMesh ignores currentDepth (Mesh owns its own projection)", () => {
-		if (!isWebGL) {
+	it("Mesh batcher's pushMesh ignores currentDepth (Mesh owns its own projection)", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		// poison currentDepth — pushMesh must not pick this up; mesh vertices
@@ -346,8 +352,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- backward compat: custom shader declaring vec2 aVertex ----
 
-	it("custom GLShader declaring `attribute vec2 aVertex` renders without GL error", () => {
-		if (!isWebGL) {
+	it("custom GLShader declaring `attribute vec2 aVertex` renders without GL error", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		drainGLErrors();
@@ -418,8 +424,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- extreme values ----
 
-	it("setDepth tolerates extreme values without GL errors", () => {
-		if (!isWebGL) {
+	it("setDepth tolerates extreme values without GL errors", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		drainGLErrors();
@@ -445,8 +451,8 @@ describe("depth pipeline adversarial integration", () => {
 		renderer.setDepth(0);
 	});
 
-	it("setDepth(NaN) / setDepth(Infinity) do not throw or produce GL errors", () => {
-		if (!isWebGL) {
+	it("setDepth(NaN) / setDepth(Infinity) do not throw or produce GL errors", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		drainGLErrors();
@@ -474,8 +480,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- flush boundary ----
 
-	it("flushing mid-frame and continuing to draw preserves depth correctly", () => {
-		if (!isWebGL) {
+	it("flushing mid-frame and continuing to draw preserves depth correctly", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		const batcher = renderer.setBatcher("quad");
@@ -503,8 +509,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- fuzz ----
 
-	it("fuzz: 500 random (setDepth, draw, batcher-switch) ops produce no GL error", () => {
-		if (!isWebGL) {
+	it("fuzz: 500 random (setDepth, draw, batcher-switch) ops produce no GL error", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		drainGLErrors();
@@ -558,8 +564,8 @@ describe("depth pipeline adversarial integration", () => {
 
 	// ---- one final sanity end-to-end ----
 
-	it("end-to-end frame: sprite + primitive + nineslice at varying depths, no error", () => {
-		if (!isWebGL) {
+	it("end-to-end frame: sprite + primitive + nineslice at varying depths, no error", (ctx) => {
+		if (skipIfNoWebGL(ctx)) {
 			return;
 		}
 		drainGLErrors();

--- a/packages/melonjs/tests/texture.spec.js
+++ b/packages/melonjs/tests/texture.spec.js
@@ -340,9 +340,10 @@ describe("Texture", () => {
 	});
 
 	describe("createPattern", () => {
-		it("should create a pattern texture", () => {
+		it("should create a pattern texture", (ctx) => {
 			if (typeof video.renderer.gl === "undefined") {
-				return; // skip in Canvas mode
+				ctx.skip("WebGL renderer not available in this environment");
+				return;
 			}
 			const canvas = new CanvasTexture(32, 32);
 			const pattern = video.renderer.createPattern(canvas.canvas, "repeat");
@@ -350,9 +351,10 @@ describe("Texture", () => {
 			expect(pattern.repeat).toEqual("repeat");
 		});
 
-		it("allocates a separate texture unit per (image, repeat) pair (#1448)", () => {
+		it("allocates a separate texture unit per (image, repeat) pair (#1448)", (ctx) => {
 			if (typeof video.renderer.gl === "undefined") {
-				return; // WebGL-only — Canvas createPattern doesn't allocate GL units
+				ctx.skip("WebGL-only — Canvas createPattern doesn't allocate GL units");
+				return;
 			}
 			const canvas = new CanvasTexture(32, 32);
 


### PR DESCRIPTION
Follow-up to the silent-skip sweep on \`webgl_pipeline_adversarial.spec.js\` that landed in #1490 — the same anti-pattern turned out to be in **8 more spec files** (54 sites total, ~30× the original sweep). Same hygiene class: \`if (!isWebGL) { return; }\` reports as \`passed\` in the vitest reporter, hiding broken assertions behind a green check (#1481).

## Per-file breakdown

| File | Sites | Helper |
|---|---|---|
| \`batcher_attribute_leak.spec.js\` | 15 | 3 \`skipIfNoWebGL\` helpers (one per describe block) |
| \`depth_adversarial.spec.js\` | 14 | 1 |
| \`clipRect.spec.js\` | 12 | 1 |
| \`depth.spec.js\` | 8 | 1 (in the only describe block that gates on WebGL) |
| \`texture.spec.js\` | 2 | inline \`ctx.skip(...)\` (different probe shape: \`typeof video.renderer.gl === \"undefined\"\`, no \`isWebGL\` boolean in scope) |
| \`webgl_save_restore.spec.js\` | — | already had a \`requireWebGL(ctx)\` helper using \`ctx.skip()\` — left as-is |
| \`webgl_save_restore_bench.spec.js\` | — | benchmark — genuinely wants the \`console.log(\"[BENCH] skipped\")\` shape, left as-is |
| \`drawmesh_bench.spec.js\` | — | benchmark — same as above |

## Tag-along clean-ups

- **Dropped two now-redundant inner \`if (!isWebGL)\` guards** in \`depth_adversarial.spec.js\` — they were inside \`expectNoGLErrors\` / \`drainGLErrors\` helper functions called from inside test bodies; by the time the helper runs, the test has already skipped via \`skipIfNoWebGL(ctx)\`, so the inner check was unreachable defensive code.
- **Renamed a local \`const ctx\`** in \`clipRect.spec.js\` (it was a Canvas 2D context for a fixture) → \`const srcCtx\` — collided with the new \`(ctx)\` test parameter.

## What this is NOT

Not a behavioural change — when WebGL IS available (which it is in our local + CI env via SwiftShader), every transformed test runs identically. The reporter shape only flips when WebGL is missing: those tests now show as \`skipped\` rather than silently \`passed\`. The two \`texture.spec.js > createPattern\` tests under \`video.AUTO\` (Canvas fallback) are the only currently-visible delta — they were silently passing and now correctly report \`skipped\` (3995 / 15 skipped / 0 failed, vs 3997 / 13 / 0 baseline).

## Test plan

- [x] \`pnpm test:types\` clean
- [x] \`pnpm vitest run\` — 3995 / 15 skipped / 0 failed
- [x] \`pnpm build\` — lint + types clean
- [x] \`node --check\` clean on each transformed file (caught one \`const ctx\` collision pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)