### PR TITLE
docs(readme): surface 19.7 3D features in Camera + Physics sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Sound
 
 Physics
 - Polygon (SAT) based collision algorithm for accurate detection and response
-- Fast broad-phase collision detection using spatial partitioning (QuadTree)
-- Raycast and AABB region queries with precise entry geometry
+- Fast broad-phase collision detection using spatial partitioning (QuadTree in 2D, Octree in 3D, swapped automatically)
+- Raycast, AABB and sphere region queries with precise entry geometry, including 3D raycasts (`raycast3d`)
 - Collision lifecycle hooks on every `Renderable`
 - Collision filtering for optimized automatic collision detection
 - Multiple shapes per body for complex hitboxes
@@ -82,7 +82,8 @@ Input
 
 Camera
 - Multi-camera support (split-screen, minimaps, multiple viewports)
-- Camera follow with configurable deadzone and damping
+- Optional perspective camera (`Camera3d`) with frustum culling for 2.5D / 3D-projected scenes — drop-in subclass of the default 2D camera
+- Camera follow with configurable deadzone and frame-rate-independent damping
 - Built-in shake, fade, flash, and mask-based transition effects
 - Per-camera post-processing pipeline with stackable shader effects and color grading (ColorMatrix)
 


### PR DESCRIPTION
The lead paragraph and Graphics section already mentioned 3D mesh / multi-material / perspective projection, but two feature lists hadn't caught up with the 19.7 3D surface:

- **Camera** — added the \`Camera3d\` perspective camera (drop-in 2D subclass with frustum culling), which was entirely absent from the Camera list despite being a headline 19.7 feature. Also noted the follow damping is now frame-rate-independent.
- **Physics** — broad-phase now mentions the \`Octree\` (3D, auto-swapped from QuadTree on \`sortOn\` crossings); region queries now list sphere queries + 3D raycasts (\`raycast3d\`) alongside the existing raycast / AABB.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)