### PR TITLE
chore(release): stamp CHANGELOG dates for 19.7.0 + adapters 1.1.0

### DIFF
--- a/packages/matter-adapter/CHANGELOG.md
+++ b/packages/matter-adapter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0 - _unreleased_
+## 1.1.0 - _2026-06-06_
 
 ### Changed
 - **Minimum melonJS bumped to 19.7.0.** The `PhysicsAdapter` interface gained the required `raycasts3d: boolean` capability and the optional `raycast3d?` / `querySphere?` methods in 19.7 alongside `Camera3d` + the `Octree` broadphase. `@melonjs/matter-adapter` declares `raycasts3d: false` and omits both 3D methods — Matter is 2D-only, so any `world.raycast3d` / `world.adapter.querySphere?(...)` call under this adapter falls through to `null` / `undefined` at the call site.

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [19.7.0] (melonJS 2) - _unreleased_
+## [19.7.0] (melonJS 2) - _2026-06-06_
 
 **Highlights:** `Camera3d` perspective camera lands. Every batched shader now carries per-sprite depth as `vec3 aVertex`, unlocking 3D-projected sprites and meshes. Backward compatible with existing 2D code.
 

--- a/packages/planck-adapter/CHANGELOG.md
+++ b/packages/planck-adapter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0 - _unreleased_
+## 1.1.0 - _2026-06-06_
 
 ### Changed
 - **Minimum melonJS bumped to 19.7.0.** The `PhysicsAdapter` interface gained the required `raycasts3d: boolean` capability and the optional `raycast3d?` / `querySphere?` methods in 19.7 alongside `Camera3d` + the `Octree` broadphase. `@melonjs/planck-adapter` declares `raycasts3d: false` and omits both 3D methods — planck (Box2D) is 2D-only, so any `world.raycast3d` / `world.adapter.querySphere?(...)` call under this adapter falls through to `null` / `undefined` at the call site.


### PR DESCRIPTION
Stamps the three pending CHANGELOG headers with today's release date so the tag + publish can proceed.

| Package | Version | Date |
|---|---|---|
| \`melonjs\` | 19.7.0 | 2026-06-06 |
| \`@melonjs/matter-adapter\` | 1.1.0 | 2026-06-06 |
| \`@melonjs/planck-adapter\` | 1.1.0 | 2026-06-06 |

\`package.json\` versions and \`>=19.7.0\` peer deps on the two adapters are already on the release values from prior PRs — only the CHANGELOG dates needed the stamp.

Pure release-ritual change. No code, no behaviour.

## Test plan

- [x] \`pnpm test:types\` clean
- [x] \`pnpm build\` clean

Once this lands, the remaining release steps are:

1. Tag \`19.7.0\` (no \`v\` prefix), push tag
2. Manually dispatch \`publish.yml\` with \`package=melonjs\` (and again for the two adapters)
3. Create GitHub release \`v19.7.0\` in the v19.3.0 format

🤖 Generated with [Claude Code](https://claude.com/claude-code)