### PR TITLE
ci(publish): diagnose playwright install hang — verbose env + 10min timeout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,9 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright browsers
+        timeout-minutes: 10
+        env:
+          DEBUG: pw:install
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Lint & check


### PR DESCRIPTION
The last five \`publish.yml\` runs all hung indefinitely on the **Install Playwright browsers** step. Logs show the chromium binary downloads cleanly in ~0.5s and then **~51 minutes of dead silence** before manual cancel. So the hang is on a post-download step (extract / validate / spawn), not the CDN. Direct downloads from playwright.dev outside the runner work fine.

Two minimal observability tweaks so the next attempt gives us actionable evidence instead of another black-box hang:

- **\`DEBUG: pw:install\`** — Playwright's install-namespace debug logger emits a line per stage (verify, extract, write marker, etc.). Should pinpoint exactly where the silence starts.
- **\`timeout-minutes: 10\`** — caps the step so a hung install fails fast (frees the runner instead of burning the 6-hour job budget). Healthy installs land in 2-3 min, so 10 min leaves ample headroom.

Pure diagnostic / safety. No behaviour change on a healthy run; visibly faster failure on a sick one.

Once the next dispatch fails with verbose output, we'll know what the real fix is — likely a Playwright version pin, a sandbox flag, or a missing apt package.

## Test plan

- [ ] Merge this
- [ ] Dispatch \`publish.yml\` with \`package=melonjs\` (real, not dry-run) — and either it succeeds and we ship 19.7.0, or it fails in ~10 min with a verbose log we can act on

🤖 Generated with [Claude Code](https://claude.com/claude-code)