### PR TITLE
ci: centralize all tests in main.yml; drop redundant test re-run from publish.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,8 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm i
       - run: pnpm test
+      - run: pnpm -F @melonjs/matter-adapter test
+      - run: pnpm -F @melonjs/planck-adapter test
 
   # Windows build — only on master push, not on PRs
   windows:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,12 +45,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Install Playwright browsers
-        timeout-minutes: 10
-        env:
-          DEBUG: pw:install
-        run: pnpm exec playwright install --with-deps chromium
-
       - name: Lint & check
         run: |
           pnpm lint
@@ -61,7 +55,7 @@ jobs:
         run: |
           if [ "${{ inputs.package }}" = "melonjs" ]; then
             echo "dir=packages/melonjs" >> "$GITHUB_OUTPUT"
-            echo "build_cmd=pnpm dist" >> "$GITHUB_OUTPUT"
+            echo "build_cmd=pnpm dist:publish" >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.package }}" = "debug-plugin" ]; then
             echo "dir=packages/debug-plugin" >> "$GITHUB_OUTPUT"
             echo "build_cmd=pnpm clean && pnpm build" >> "$GITHUB_OUTPUT"
@@ -73,10 +67,10 @@ jobs:
             echo "build_cmd=pnpm clean && pnpm build" >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.package }}" = "matter-adapter" ]; then
             echo "dir=packages/matter-adapter" >> "$GITHUB_OUTPUT"
-            echo "build_cmd=pnpm clean && pnpm build && pnpm test" >> "$GITHUB_OUTPUT"
+            echo "build_cmd=pnpm clean && pnpm build" >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.package }}" = "planck-adapter" ]; then
             echo "dir=packages/planck-adapter" >> "$GITHUB_OUTPUT"
-            echo "build_cmd=pnpm clean && pnpm build && pnpm test" >> "$GITHUB_OUTPUT"
+            echo "build_cmd=pnpm clean && pnpm build" >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.package }}" = "capacitor-plugin" ]; then
             echo "dir=packages/capacitor-plugin" >> "$GITHUB_OUTPUT"
             echo "build_cmd=pnpm clean && pnpm build" >> "$GITHUB_OUTPUT"

--- a/packages/melonjs/package.json
+++ b/packages/melonjs/package.json
@@ -80,6 +80,7 @@
 		"lint": "eslint src tests",
 		"build": "pnpm lint && tsx scripts/build.js && pnpm types",
 		"dist": "pnpm clean && pnpm lint && pnpm vitest run && pnpm build && pnpm doc && cp ../../README.md .",
+		"dist:publish": "pnpm clean && pnpm lint && pnpm build && pnpm doc && cp ../../README.md .",
 		"doc": "typedoc src/index.ts --tsconfig tsconfig.build.json --readme DOC_README.md --hideGenerator --name 'melonJS' --navigation.includeCategories true --categorizeByGroup false",
 		"doc:watch": "typedoc src/index.ts --tsconfig tsconfig.build.json --readme DOC_README.md --hideGenerator --name 'melonJS' --navigation.includeCategories true --categorizeByGroup false --watch --skipErrorChecking --preserveWatchOutput --logLevel Error",
 		"serve": "serve docs",


### PR DESCRIPTION
Two related cleanups that also unblock the 19.7.0 publish:

## 1. main.yml now gates all package tests, not just melonjs

The adapter test specs (3 × matter, 3 × planck) existed but were **only invoked at publish time** — PR merges never gated on them. The new \`pnpm -F @melonjs/{matter,planck}-adapter test\` lines run inside the same \`mcr.microsoft.com/playwright:v1.59.1-noble\` container the existing melonjs test job uses, so chromium is pre-baked and no install step is needed.

| Package | Tests in CI BEFORE this PR | Tests in CI AFTER |
|---|---|---|
| \`melonjs\` | ✅ main.yml | ✅ main.yml |
| \`@melonjs/matter-adapter\` | ❌ publish.yml only | ✅ main.yml |
| \`@melonjs/planck-adapter\` | ❌ publish.yml only | ✅ main.yml |

Pre-existing CI gap closed.

## 2. publish.yml stops re-running tests main.yml now gates

- Drop the \`Install Playwright browsers\` step entirely (no test step at publish time → no chromium needed)
- Replace melonjs \`pnpm dist\` (\`clean + lint + vitest + build + doc\`) with new \`pnpm dist:publish\` (drops \`vitest\`)
- Drop trailing \`&& pnpm test\` from matter / planck build_cmd

## Also sidesteps a real Playwright bug

We've been blocked all day shipping 19.7.0 because on bare \`ubuntu-latest\` runners, \`playwright install chromium\` was hanging indefinitely on the post-download extract step. Download itself completes in <2s; extract emits no further log line and times out the whole job. **Six consecutive runs** hit the same hang on distinct runners. Identified via the \`DEBUG: pw:install\` + \`timeout-minutes: 10\` instrumentation that #1496 added. The container-based path main.yml already uses sidesteps the install entirely.

## Test plan

- [x] \`pnpm -F @melonjs/matter-adapter test\` locally — 177 / 177 pass
- [x] \`pnpm -F @melonjs/planck-adapter test\` locally — 169 / 169 pass
- [x] \`pnpm dist:publish\` locally — clean exit, docs generated
- [ ] CI green on this PR — confirms main.yml's adapter test invocations work in the container
- [ ] Merge → dispatch \`publish.yml\` with \`package=melonjs\` → ship 19.7.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)