### PR TITLE
ci: align melonjs prepublishOnly hook with publish workflow

### DIFF
--- a/packages/melonjs/package.json
+++ b/packages/melonjs/package.json
@@ -84,7 +84,7 @@
 		"doc": "typedoc src/index.ts --tsconfig tsconfig.build.json --readme DOC_README.md --hideGenerator --name 'melonJS' --navigation.includeCategories true --categorizeByGroup false",
 		"doc:watch": "typedoc src/index.ts --tsconfig tsconfig.build.json --readme DOC_README.md --hideGenerator --name 'melonJS' --navigation.includeCategories true --categorizeByGroup false --watch --skipErrorChecking --preserveWatchOutput --logLevel Error",
 		"serve": "serve docs",
-		"prepublishOnly": "pnpm dist",
+		"prepublishOnly": "pnpm dist:publish",
 		"clean": "tsx scripts/clean.ts",
 		"types": "tsc --project tsconfig.build.json",
 		"test:types": "tsc"


### PR DESCRIPTION
Tiny follow-up to #1497. That PR swapped the publish workflow's \`build_cmd\` from \`pnpm dist\` to \`pnpm dist:publish\` (drops the redundant \`pnpm vitest run\` since main.yml gates tests now). But \`npm publish\` ALSO fires the package's own \`prepublishOnly\` lifecycle hook, which still hardcoded \`pnpm dist\`. So the workflow built cleanly with the new recipe and then **\`npm publish\` re-triggered \`pnpm dist\` → \`pnpm vitest run\` → died on missing Playwright browsers**.

Caught it on the first real publish attempt: workflow run [27173932906](https://github.com/melonjs/melonJS/actions/runs/27173932906). \`Build & test\` step (running \`pnpm dist:publish\`) → ✅. \`Publish to npm\` step (running \`npm publish\` → \`prepublishOnly\` → \`pnpm dist\`) → ❌ on \`Executable doesn't exist at .../chrome-headless-shell\`.

Fix: point \`prepublishOnly\` at the same \`dist:publish\` script the workflow uses. Keeps the safety net for local manual \`npm publish\` (still builds + lints before shipping) without dragging vitest back in.

Pure one-line script-rename. Zero behavior change for healthy paths.

## Test plan

- [x] Local \`pnpm dist:publish\` — clean exit
- [ ] Merge → re-dispatch \`publish.yml package=melonjs\` → publish completes through to npm + tag + GH release

🤖 Generated with [Claude Code](https://claude.com/claude-code)