### PR TITLE
release: melonjs 19.8.0

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [19.8.0] (melonJS 2) - _unreleased_
+## [19.8.0] (melonJS 2) - _2026-06-26_
 
 **Highlights:** glTF / GLB scene loading lands — author a 3D scene in Blender (or any DCC tool), export a `.glb`, and load it like a Tiled map with `level.load(...)`. Animated models play back through the same `setCurrentAnimation` / `play` / `pause` / `stop` API as a 2D `Sprite`. Scene meshes are lit by the authored sun, and 3D meshes can now report a real bounding box. And `Sprite3d` brings the 2.5D workflow — billboarded, frame-animated cut-out sprites that face a `Camera3d` (the Paper Mario look), sharing one `FrameAnimation` engine with the 2D `Sprite`.
 


### PR DESCRIPTION
Stamps the 19.8.0 CHANGELOG (`_unreleased_` → `2026-06-26`) for release.

## 19.8.0 highlights
- **glTF / GLB scene loading** (Tier 1) — `level.load()` a `.glb` like a Tiled map; node graph, primitives, materials, cameras, lights, animations
- **glTF node animation + `GLTFModel`** — rig-driven, hierarchy-preserving TRS animation via the `Sprite`-aligned API
- **`Sprite3d`** — 2.5D billboard sprites under `Camera3d` (cylindrical/spherical/fixed), frame animation, rotated/trimmed atlas parity, alpha cutout, flipX/flipY
- **`FrameAnimation`** — shared 2D/3D frame-animation engine behind `Sprite` + `Sprite3d`
- **`Light3d`** — directional + ambient mesh lighting; glTF `KHR_lights_punctual`
- **Mesh material features** — `textureRepeat`, `textureFilter` (decoupled from `antiAlias`), `baseColorFactor`/vertex colors, `KHR_materials_unlit`, `alphaCutoff`, `emissive`; OBJ/MTL textures auto-load
- **`Mesh.getBounds3d()` / `Camera3d.worldToScreen()` / `AABB3d`** + >65k-vertex meshes
- **`loader.preload()` / `loader.load()` are `await`-able**
- **Perf** — allocation-free glTF pose path; ~30% faster mesh batching (versioned typed-array remap)

No breaking changes — all additive / back-compat.

After merge: tag `19.8.0`, dispatch `publish.yml` (package=melonjs), and cut the GitHub release. (`@melonjs/debug-plugin@16.1.0`, which peer-requires `melonjs >=19.8.0`, is already published.)