### PR TITLE
fix(NineSliceSprite): preserve expanded size across animation (#1115); open 19.9.0

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [19.9.0] (melonJS 2) - _unreleased_
+
+### Fixed
+- **Animated `NineSliceSprite` collapsed to its frame size** (#1115) — a `NineSliceSprite` driven by an animation (or any per-frame texture change) had its user-specified "expanded" `width`/`height` overwritten by each frame's source dimensions, shrinking the 9-slice panel to a single frame after the first animation step. Static nine-slices were unaffected because the frame is applied only once (during construction, before the expanded size is set). `NineSliceSprite` now applies a new frame by swapping only the source sub-texture, leaving the expanded size and bounds intact. First-ever test coverage for `NineSliceSprite` (the class previously had none).
+
+### Changed
+- **`NineSliceSprite.draw()` collapsed to a single `drawImage` call site** — the 9 hand-written corner/edge/center blits became one call inside a separable 3×3 loop (per-axis source/dest offsets held in reused module-level scratch). Behavior is byte-identical and the draw path stays allocation-free.
+
 ## [19.8.0] (melonJS 2) - _2026-06-26_
 
 **Highlights:** glTF / GLB scene loading lands — author a 3D scene in Blender (or any DCC tool), export a `.glb`, and load it like a Tiled map with `level.load(...)`. Animated models play back through the same `setCurrentAnimation` / `play` / `pause` / `stop` API as a 2D `Sprite`. Scene meshes are lit by the authored sun, and 3D meshes can now report a real bounding box. And `Sprite3d` brings the 2.5D workflow — billboarded, frame-animated cut-out sprites that face a `Camera3d` (the Paper Mario look), sharing one `FrameAnimation` engine with the 2D `Sprite`.

--- a/packages/melonjs/package.json
+++ b/packages/melonjs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "melonjs",
-	"version": "19.8.0",
+	"version": "19.9.0",
 	"description": "melonJS Game Engine",
 	"homepage": "http://www.melonjs.org/",
 	"type": "module",

--- a/packages/melonjs/src/renderable/nineslicesprite.js
+++ b/packages/melonjs/src/renderable/nineslicesprite.js
@@ -6,6 +6,16 @@ import Sprite from "./sprite.js";
  * @import { TextureAtlas } from "./../video/texture/atlas.js";
  */
 
+// Reusable scratch for the 9-slice grid, refilled on every draw. A
+// NineSliceSprite is drawn synchronously on the main thread (drawImage never
+// re-enters another NineSliceSprite.draw), so a shared module-level buffer is
+// safe and keeps draw() free of per-frame allocation. These hold the per-axis
+// source/dest *offsets*; the slice sizes are derived inline in the draw loop.
+const sColX = [0, 0, 0];
+const dColX = [0, 0, 0];
+const sRowY = [0, 0, 0];
+const dRowY = [0, 0, 0];
+
 /**
  * A NineSliceSprite is similar to a Sprite, but it uses 9-slice scaling to stretch its inner area to fit the size of the Renderable,
  * by proportionally scaling a sprite by splitting it in a grid of nine parts (with only parts 1, 3, 7, 9 not being scaled). <br>
@@ -86,6 +96,31 @@ export default class NineSliceSprite extends Sprite {
 	}
 
 	/**
+	 * Apply the current animation/atlas frame. The base {@link Sprite} swaps the
+	 * sub-texture, resolves the anchor (honoring trimming) and resizes itself to
+	 * the frame — but for a NineSliceSprite the size is the user-specified
+	 * "expanded" target that the 9 slices stretch to fill, and must NOT track the
+	 * frame. We delegate to the base for the texture/anchor work, then restore the
+	 * expanded size it clobbered. (Fixes #1115, where animating a NineSliceSprite
+	 * let the per-frame source size shrink the panel to a single frame.)
+	 * @param {object} region - the texture region object
+	 * @ignore
+	 */
+	_applyFrame(region) {
+		// capture the expanded size BEFORE super runs: its `this.width =` writes
+		// route through our setter and overwrite nss_width/nss_height
+		const w = this.nss_width;
+		const h = this.nss_height;
+		super._applyFrame(region);
+		// during construction nss_* is still undefined (the constructor sets the
+		// expanded size right after super()), so only restore once it exists
+		if (w !== undefined) {
+			this.width = w;
+			this.height = h;
+		}
+	}
+
+	/**
 	 * @ignore
 	 */
 	draw(renderer) {
@@ -119,130 +154,47 @@ export default class NineSliceSprite extends Sprite {
 		const corner_width = this.insetx || w / 4;
 		const corner_height = this.insety || h / 4;
 
-		// OPTIMIZE ME !
-
-		// DRAW CORNERS
-
-		// Top Left
-		renderer.drawImage(
-			this.image,
-			sx, // sx
-			sy, // sy
-			corner_width,
-			corner_height, // sw,sh
-			dx,
-			dy, // dx,dy
-			corner_width,
-			corner_height, // dw,dh
-		);
-
-		// Top Right
-		renderer.drawImage(
-			this.image,
-			sx + w - corner_width, // sx
-			sy, // sy
-			corner_width,
-			corner_height, // sw,sh
-			dx + this.nss_width - corner_width, // dx
-			dy, // dy
-			corner_width,
-			corner_height, // dw,dh
-		);
-		// Bottom Left
-		renderer.drawImage(
-			this.image,
-			sx, // sx
-			sy + h - corner_height, // sy
-			corner_width,
-			corner_height, // sw,sh
-			dx, // dx
-			dy + this.nss_height - corner_height, // dy
-			corner_width,
-			corner_height, // dw,dh
-		);
-		// Bottom Right
-		renderer.drawImage(
-			this.image,
-			sx + w - corner_width, // sx
-			sy + h - corner_height, // sy
-			corner_width,
-			corner_height, // sw,sh
-			dx + this.nss_width - corner_width, //dx
-			dy + this.nss_height - corner_height, // dy
-			corner_width,
-			corner_height, // dw,dh
-		);
-
-		// DRAW SIDES and CENTER
 		const image_center_width = w - (corner_width << 1);
 		const image_center_height = h - (corner_height << 1);
 
 		const target_center_width = this.nss_width - (corner_width << 1);
 		const target_center_height = this.nss_height - (corner_height << 1);
 
-		//Top center
-		renderer.drawImage(
-			this.image,
-			sx + corner_width, // sx
-			sy, // sy
-			image_center_width, // sw
-			corner_height, // sh
-			dx + corner_width, // dx
-			dy, // dy
-			target_center_width, // dw
-			corner_height, // dh
-		);
+		// The 9-slice grid is separable per axis: each column/row is an unscaled
+		// corner, a stretched center, then an unscaled corner. Fill the shared
+		// scratch with the per-axis source/dest offsets (no per-draw allocation).
+		sColX[0] = sx;
+		sColX[1] = sx + corner_width;
+		sColX[2] = sx + w - corner_width;
+		dColX[0] = dx;
+		dColX[1] = dx + corner_width;
+		dColX[2] = dx + this.nss_width - corner_width;
+		sRowY[0] = sy;
+		sRowY[1] = sy + corner_height;
+		sRowY[2] = sy + h - corner_height;
+		dRowY[0] = dy;
+		dRowY[1] = dy + corner_height;
+		dRowY[2] = dy + this.nss_height - corner_height;
 
-		//Bottom center
-		renderer.drawImage(
-			this.image,
-			sx + corner_width, // sx
-			sy + h - corner_height, // sy
-			image_center_width, // sw
-			corner_height, // sh
-			dx + corner_width, // dx
-			dy + this.nss_height - corner_height, // dx
-			target_center_width, // dw
-			corner_height, // dh
-		);
-
-		// Middle Left
-		renderer.drawImage(
-			this.image,
-			sx, // sx
-			sy + corner_height, // sy
-			corner_width, // sw
-			image_center_height, // sh
-			dx, // dx
-			dy + corner_height, // dy
-			corner_width, // dw
-			target_center_height, // dh
-		);
-
-		// Middle Right
-		renderer.drawImage(
-			this.image,
-			sx + w - corner_width, // sx
-			sy + corner_height, // sy
-			corner_width, // sw
-			image_center_height, // sh
-			dx + this.nss_width - corner_width, // dx
-			dy + corner_height, // dy
-			corner_width, // dw
-			target_center_height, // dh
-		);
-
-		// Middle Center
-		renderer.drawImage(
-			this.image,
-			sx + corner_width, // sx
-			sy + corner_height, // sy
-			image_center_width, // sw
-			image_center_height, // sh
-			dx + corner_width, // dx
-			dy + corner_height, // dy
-			target_center_width, // dw
-			target_center_height, // dh
-		);
+		// blit the 9 slices: corners keep their size, the center column/row stretch.
+		for (let r = 0; r < 3; r++) {
+			const sh = r === 1 ? image_center_height : corner_height;
+			const dh = r === 1 ? target_center_height : corner_height;
+			for (let c = 0; c < 3; c++) {
+				const sw = c === 1 ? image_center_width : corner_width;
+				const dw = c === 1 ? target_center_width : corner_width;
+				renderer.drawImage(
+					this.image,
+					sColX[c], // sx
+					sRowY[r], // sy
+					sw, // sw
+					sh, // sh
+					dColX[c], // dx
+					dRowY[r], // dy
+					dw, // dw
+					dh, // dh
+				);
+			}
+		}
 	}
 }

--- a/packages/melonjs/tests/nineslicesprite.spec.js
+++ b/packages/melonjs/tests/nineslicesprite.spec.js
@@ -1,0 +1,429 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { boot, NineSliceSprite, video } from "../src/index.js";
+
+/**
+ * NineSliceSprite — 9-slice scaling. The class had ZERO coverage, despite the
+ * draw() being a non-trivial separable 3×3 grid (4 unscaled corners, 2 stretched
+ * edges per axis, 1 stretched center) sourced from a frame/atlas region and
+ * blitted into an arbitrary "expanded" target size.
+ *
+ * These specs pin down the geometry directly: a recording renderer captures every
+ * drawImage(image, sx,sy,sw,sh, dx,dy,dw,dh) so we can assert the slices tile both
+ * the source frame AND the destination exactly, corners stay unscaled, and — the
+ * #1115 regression — that ANIMATING a NineSliceSprite does not let the per-frame
+ * source size clobber the expanded (nss) target size.
+ */
+
+// a filled canvas usable as a sprite source (blank canvases upload fine too, but
+// filling keeps getTexture()/getImage() happy across renderers)
+const makeImage = (w, h) => {
+	const c = document.createElement("canvas");
+	c.width = w;
+	c.height = h;
+	c.getContext("2d").fillRect(0, 0, w, h);
+	return c;
+};
+
+// a renderer that records the rect args of every drawImage, and counts the
+// transform calls the rotated-frame branch makes. draw() touches nothing else.
+const makeRecorder = () => {
+	const calls = [];
+	return {
+		calls,
+		translate: vi.fn(),
+		rotate: vi.fn(),
+		drawImage(image, sx, sy, sw, sh, dx, dy, dw, dh) {
+			calls.push({ sx, sy, sw, sh, dx, dy, dw, dh });
+		},
+	};
+};
+
+// collapse the 9 calls onto one axis into its distinct [start → size] columns
+// (top-left and bottom-left share the same dx, etc. → deduped to 3 entries)
+const axis = (calls, startKey, sizeKey) => {
+	const bySize = new Map();
+	for (const c of calls) {
+		bySize.set(c[startKey], c[sizeKey]);
+	}
+	const starts = [...bySize.keys()].sort((a, b) => {
+		return a - b;
+	});
+	return {
+		starts,
+		sizes: starts.map((s) => {
+			return bySize.get(s);
+		}),
+	};
+};
+
+// assert a 3-column/row axis is contiguous (no gaps, no overlap) and spans `total`
+const expectTiles = (a, total) => {
+	expect(a.starts.length).toBe(3);
+	// each slice's end meets the next slice's start
+	expect(a.starts[0] + a.sizes[0]).toBeCloseTo(a.starts[1], 6);
+	expect(a.starts[1] + a.sizes[1]).toBeCloseTo(a.starts[2], 6);
+	// full span = sum of the three sizes
+	expect(a.sizes[0] + a.sizes[1] + a.sizes[2]).toBeCloseTo(total, 6);
+};
+
+describe("NineSliceSprite", () => {
+	beforeAll(() => {
+		boot();
+		video.init(256, 256, { parent: "screen", renderer: video.CANVAS });
+	});
+
+	// ── construction ─────────────────────────────────────────────────────────
+
+	it("throws when width is missing", () => {
+		expect(() => {
+			return new NineSliceSprite(0, 0, {
+				image: makeImage(32, 32),
+				height: 100,
+			});
+		}).toThrow();
+	});
+
+	it("throws when height is missing", () => {
+		expect(() => {
+			return new NineSliceSprite(0, 0, {
+				image: makeImage(32, 32),
+				width: 100,
+			});
+		}).toThrow();
+	});
+
+	it("stores the expanded size in width/height AND nss_width/nss_height", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 200,
+			height: 120,
+		});
+		expect(nss.width).toBe(200);
+		expect(nss.height).toBe(120);
+		expect(nss.nss_width).toBe(200);
+		expect(nss.nss_height).toBe(120);
+	});
+
+	it("floors fractional width/height", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 200.9,
+			height: 120.4,
+		});
+		expect(nss.width).toBe(200);
+		expect(nss.height).toBe(120);
+	});
+
+	// ── static draw geometry ───────────────────────────────────────────────────
+
+	it("issues exactly 9 drawImage calls", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 200,
+			height: 120,
+		});
+		const r = makeRecorder();
+		nss.draw(r);
+		expect(r.calls.length).toBe(9);
+	});
+
+	it("destination slices tile the full expanded area, no gaps/overlap", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 200,
+			height: 120,
+		});
+		const r = makeRecorder();
+		nss.draw(r);
+		expectTiles(axis(r.calls, "dx", "dw"), 200);
+		expectTiles(axis(r.calls, "dy", "dh"), 120);
+	});
+
+	it("source slices tile the full frame, no gaps/overlap", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 200,
+			height: 120,
+		});
+		const r = makeRecorder();
+		nss.draw(r);
+		expectTiles(axis(r.calls, "sx", "sw"), 64);
+		expectTiles(axis(r.calls, "sy", "sh"), 64);
+	});
+
+	it("the four corners are unscaled — only the center column/row stretch", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 200,
+			height: 120,
+		});
+		const r = makeRecorder();
+		nss.draw(r);
+		// default inset = quarter of a 64px frame → 16px corners
+		const corners = r.calls.filter((c) => {
+			return c.sw === 16 && c.sh === 16;
+		});
+		expect(corners.length).toBe(4);
+		// every corner is blitted 1:1 (source size === dest size)
+		for (const c of corners) {
+			expect(c.dw).toBe(c.sw);
+			expect(c.dh).toBe(c.sh);
+		}
+		// exactly one slice scales on BOTH axes (the center)
+		const center = r.calls.filter((c) => {
+			return c.dw !== c.sw && c.dh !== c.sh;
+		});
+		expect(center.length).toBe(1);
+	});
+
+	it("default inset is a quarter of the frame", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(80, 40),
+			width: 300,
+			height: 200,
+		});
+		const r = makeRecorder();
+		nss.draw(r);
+		// corners: 80/4 = 20 wide, 40/4 = 10 tall
+		expect(axis(r.calls, "sx", "sw").sizes[0]).toBe(20);
+		expect(axis(r.calls, "sy", "sh").sizes[0]).toBe(10);
+	});
+
+	it("honors custom insetx/insety", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 200,
+			height: 120,
+			insetx: 10,
+			insety: 8,
+		});
+		const r = makeRecorder();
+		nss.draw(r);
+		const sxA = axis(r.calls, "sx", "sw");
+		const syA = axis(r.calls, "sy", "sh");
+		expect(sxA.sizes[0]).toBe(10); // left corner
+		expect(sxA.sizes[2]).toBe(10); // right corner
+		expect(syA.sizes[0]).toBe(8);
+		expect(syA.sizes[2]).toBe(8);
+		// dest corners stay at the inset size; only spans differ
+		expect(axis(r.calls, "dx", "dw").sizes[0]).toBe(10);
+		expect(axis(r.calls, "dy", "dh").sizes[2]).toBe(8);
+	});
+
+	it("the public width/height setter resizes the panel for the next draw", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 200,
+			height: 120,
+		});
+		nss.width = 300;
+		nss.height = 90;
+		expect(nss.nss_width).toBe(300);
+		expect(nss.nss_height).toBe(90);
+		const r = makeRecorder();
+		nss.draw(r);
+		expectTiles(axis(r.calls, "dx", "dw"), 300);
+		expectTiles(axis(r.calls, "dy", "dh"), 90);
+	});
+
+	// ── adversarial ────────────────────────────────────────────────────────────
+
+	it("ADVERSARIAL #1115: animating must NOT clobber the expanded size", () => {
+		// 128×32 sheet → four 32×32 frames; panel expanded to 200×120
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(128, 32),
+			framewidth: 32,
+			frameheight: 32,
+			width: 200,
+			height: 120,
+		});
+		nss.addAnimation("walk", [0, 1, 2, 3], 100);
+		nss.setCurrentAnimation("walk");
+
+		// baseline before any frame advance
+		expect(nss.width).toBe(200);
+		expect(nss.height).toBe(120);
+
+		// advance a couple of frames — _applyFrame runs each time
+		nss.update(100); // → frame 1
+		nss.update(100); // → frame 2
+
+		// the expanded target must survive frame application (the bug shrank it
+		// to the 32px frame source size)
+		expect(nss.width).toBe(200);
+		expect(nss.height).toBe(120);
+		expect(nss.nss_width).toBe(200);
+		expect(nss.nss_height).toBe(120);
+
+		const r = makeRecorder();
+		nss.draw(r);
+		// destination still spans the full expanded panel …
+		expectTiles(axis(r.calls, "dx", "dw"), 200);
+		expectTiles(axis(r.calls, "dy", "dh"), 120);
+		// … while the SOURCE now tiles the current 32px frame (proves the frame
+		// was swapped in, not the whole panel resized)
+		expectTiles(axis(r.calls, "sx", "sw"), 32);
+		expectTiles(axis(r.calls, "sy", "sh"), 32);
+		// and the source window sits on frame 2 (offset x = 64)
+		expect(
+			Math.min(
+				...r.calls.map((c) => {
+					return c.sx;
+				}),
+			),
+		).toBe(64);
+	});
+
+	it("ADVERSARIAL: a frame swap keeps the bounds at the expanded size", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(128, 32),
+			framewidth: 32,
+			frameheight: 32,
+			width: 200,
+			height: 120,
+		});
+		nss.addAnimation("walk", [0, 1, 2, 3], 100);
+		nss.setCurrentAnimation("walk");
+		const before = nss.getBounds().clone();
+		nss.update(100);
+		const after = nss.getBounds();
+		expect(after.width).toBe(before.width);
+		expect(after.height).toBe(before.height);
+		expect(after.width).toBe(200);
+		expect(after.height).toBe(120);
+	});
+
+	it("ADVERSARIAL: inset larger than half the target → negative center slice, still 9 finite calls", () => {
+		// corners 16+16 = 32 > target 20 → center span goes negative; the math must
+		// stay finite and the corners must still be correct (no NaN, no crash)
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 20,
+			height: 20,
+		});
+		const r = makeRecorder();
+		expect(() => {
+			return nss.draw(r);
+		}).not.toThrow();
+		expect(r.calls.length).toBe(9);
+		for (const c of r.calls) {
+			for (const v of Object.values(c)) {
+				expect(Number.isFinite(v)).toBe(true);
+			}
+		}
+		// corners 16+16 = 32 > target 20 → the center column/row span goes
+		// negative (documented degenerate result), 3 cells each (the center
+		// column over 3 rows, the center row over 3 columns)
+		const negW = r.calls.filter((c) => {
+			return c.dw < 0;
+		});
+		const negH = r.calls.filter((c) => {
+			return c.dh < 0;
+		});
+		expect(negW.length).toBe(3);
+		expect(negH.length).toBe(3);
+		expect(negW[0].dw).toBeCloseTo(-12, 6); // 20 - 2 × 16
+	});
+
+	it("ADVERSARIAL: target exactly twice the inset → zero-width center slice", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 32, // == 2 × (64/4)
+			height: 32,
+		});
+		const r = makeRecorder();
+		nss.draw(r);
+		expect(r.calls.length).toBe(9);
+		// center column has zero dest width (3 cells), center row zero height
+		const zeroW = r.calls.filter((c) => {
+			return c.dw === 0;
+		});
+		const zeroH = r.calls.filter((c) => {
+			return c.dh === 0;
+		});
+		expect(zeroW.length).toBe(3);
+		expect(zeroH.length).toBe(3);
+	});
+
+	it("ADVERSARIAL: a TexturePacker-rotated frame swaps source dims and still tiles", () => {
+		// a 64×48 frame packed at 90° — draw() must rotate the ctx and treat the
+		// frame as 48×64 for slicing, while the dest still spans the expanded panel
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 48),
+			width: 200,
+			height: 120,
+		});
+		// force the rotated-region path (normally set by the atlas loader)
+		nss.current.angle = -Math.PI / 2;
+		const r = makeRecorder();
+		nss.draw(r);
+		expect(r.translate).toHaveBeenCalledTimes(1);
+		expect(r.rotate).toHaveBeenCalledTimes(1);
+		expect(r.calls.length).toBe(9);
+		// source dims are swapped: width sourced as the frame's 48px height
+		expectTiles(axis(r.calls, "sx", "sw"), 48);
+		expectTiles(axis(r.calls, "sy", "sh"), 64);
+		// destination still tiles the full expanded panel
+		expectTiles(axis(r.calls, "dx", "dw"), 200);
+		expectTiles(axis(r.calls, "dy", "dh"), 120);
+	});
+
+	it("ADVERSARIAL: non-square frame into non-square target tiles each axis independently", () => {
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(40, 80),
+			width: 333,
+			height: 77,
+			insetx: 7,
+			insety: 13,
+		});
+		const r = makeRecorder();
+		nss.draw(r);
+		// source: 7 | 40-14=26 | 7  and  13 | 80-26=54 | 13
+		expect(axis(r.calls, "sx", "sw").sizes).toEqual([7, 26, 7]);
+		expect(axis(r.calls, "sy", "sh").sizes).toEqual([13, 54, 13]);
+		// dest: 7 | 333-14=319 | 7  and  13 | 77-26=51 | 13
+		expect(axis(r.calls, "dx", "dw").sizes).toEqual([7, 319, 7]);
+		expect(axis(r.calls, "dy", "dh").sizes).toEqual([13, 51, 13]);
+	});
+
+	it("ADVERSARIAL: applying an atlas region honors its pivot anchor AND keeps the expanded size (the UI grey_panel path)", () => {
+		// the UI example builds its panel from an atlas region carrying a pivot;
+		// the frame application must apply that anchor (it comes ONLY from the
+		// base _applyFrame) while leaving the expanded size intact. This fails if
+		// the override either skips the anchor work OR lets the frame size win.
+		const nss = new NineSliceSprite(0, 0, {
+			image: makeImage(64, 64),
+			width: 200,
+			height: 120,
+		});
+		// mock the texture source so setRegion can resolve the sub-texture
+		nss.source = {
+			getTexture: () => {
+				return nss.image;
+			},
+			getFormat: () => {
+				return "Spritesheet (fixed cell size)";
+			},
+		};
+		// an untrimmed atlas region with a non-default pivot
+		nss.setRegion({
+			name: "panel",
+			offset: { x: 0, y: 0, setV() {} },
+			width: 100,
+			height: 100,
+			trimmed: false,
+			trim: null,
+			sourceSize: null,
+			angle: 0,
+			anchorPoint: { x: 0.3, y: 0.7 },
+		});
+		// the base resolved the pivot into anchorPoint …
+		expect(nss.anchorPoint.x).toBeCloseTo(0.3, 6);
+		expect(nss.anchorPoint.y).toBeCloseTo(0.7, 6);
+		// … while the expanded target survived the frame application
+		expect(nss.width).toBe(200);
+		expect(nss.height).toBe(120);
+		expect(nss.nss_width).toBe(200);
+		expect(nss.nss_height).toBe(120);
+	});
+});


### PR DESCRIPTION
## What

Fixes #1115 — an **animated** `NineSliceSprite` collapsed to its frame size. The base `Sprite._applyFrame` rewrites `width`/`height` to the current frame's source dimensions every frame, and `NineSliceSprite`'s setter couples `nss_width`/`nss_height` to those, so after the first animation step the 9-slice panel shrank to a single frame. (Static nine-slices were unaffected — the frame is applied once, during construction, before the expanded size is set.)

## How

`NineSliceSprite._applyFrame` now delegates to `Sprite._applyFrame` (preserving the texture swap, anchor, and trim handling — e.g. the UI `grey_panel` pivot) and then **restores the expanded target** the base clobbers. The save/restore wraps the `super` call because `this.width =` inside the base routes through the subclass setter.

## Also in this PR

- **`NineSliceSprite.draw()` collapsed to a single `drawImage` call site** — the 9 hand-written corner/edge/center blits are now one call inside a separable 3×3 loop (per-axis source/dest offsets held in reused module-level scratch). Behavior is byte-identical and the draw path stays allocation-free.
- **First-ever test coverage for `NineSliceSprite`** — `tests/nineslicesprite.spec.js`, 18 specs: construction, exact source+dest tiling, unscaled corners, default/custom inset, public resize, plus adversarial cases (the #1115 animation-resize regression, the atlas-pivot anchor regression, negative/zero-width degenerate centers, TexturePacker-rotated frames, independent non-square axis tiling).
- **Opens the 19.9.0 dev cycle** — version bump (19.8.0 → 19.9.0) + `[19.9.0] _unreleased_` CHANGELOG section.

## Verification

- `nineslicesprite` + `ui` specs: **68/68 pass** (the UI example builds its OPTIONS panel from a static nine-slice, covering the no-regression path).
- biome + eslint clean (incl. `arrow-body-style: always` on tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)