### PR TITLE
fix(noise): NoiseTexture2d animation was imperceptibly slow + blocky water

### DIFF
--- a/packages/examples/src/examples/water/ExampleWater.tsx
+++ b/packages/examples/src/examples/water/ExampleWater.tsx
@@ -210,18 +210,23 @@ class PlayScreen extends Stage {
 
 		// ── ripples: a LIVE-ANIMATED fBm normal map (3D, time on the z axis) ──
 		this.ripples = new NoiseTexture2d({
-			width: 128,
-			height: 128,
+			width: 160,
+			height: 160,
 			type: "simplex",
 			seed: 1,
-			frequency: 0.06,
+			frequency: 0.05,
 			octaves: 4,
 			gain: 0.55,
+			// domain warp gives the ripples an organic, flowing-water character
+			// rather than plain blobby noise
+			domainWarp: true,
+			domainWarpAmp: 8,
+			domainWarpFrequency: 0.04,
 			seamless: true,
 			asNormalMap: true,
-			bumpStrength: 2.5,
+			bumpStrength: 2.0,
 			animated: true,
-			speed: 0.6,
+			speed: 0.5,
 		});
 
 		const water = new Sprite(w / 2, horizonY + bandH / 2, {
@@ -244,7 +249,7 @@ class PlayScreen extends Stage {
 		this.glitter = new Light2d(
 			w / 2,
 			horizonY + bandH * 0.45,
-			70,
+			120,
 			bandH * 0.9,
 			"#ffcf9a",
 			1.4,
@@ -361,6 +366,9 @@ const createGame = () => {
 		// normal-map lighting needs the WebGL lit pipeline; under video.AUTO a
 		// Canvas fallback would draw the flat albedo with no shimmer.
 		renderer: video.WEBGL,
+		// LINEAR texture filtering — the ripple normal map is small (128²) and
+		// stretched over the whole band; without this it upscales blocky.
+		antiAlias: true,
 	});
 
 	state.set(state.PLAY, new PlayScreen());

--- a/packages/melonjs/src/video/texture/noise_texture2d.js
+++ b/packages/melonjs/src/video/texture/noise_texture2d.js
@@ -186,11 +186,20 @@ class NoiseTexture2d extends Texture2d {
 		return this;
 	}
 
-	/** raw noise sample at a texture pixel (2D, or 3D when animated) @ignore */
+	/**
+	 * Raw noise sample at a texture pixel (2D, or 3D when animated). The time
+	 * axis is divided by the noise frequency so that, after `getNoise3d` scales
+	 * all coords by frequency, the field evolves at `speed` noise-units/second —
+	 * decoupled from the spatial frequency (otherwise low-frequency textures
+	 * would animate imperceptibly slowly).
+	 * @ignore
+	 */
 	_rawNoise(x, y) {
-		return this.animated
-			? this.noise.getNoise3d(x, y, this.time)
-			: this.noise.getNoise2d(x, y);
+		if (!this.animated) {
+			return this.noise.getNoise2d(x, y);
+		}
+		const z = this.time / (this.noise.frequency || 1);
+		return this.noise.getNoise3d(x, y, z);
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #1528.

## Two issues reported on the merged water demo

**1. Animation barely moved.** `Noise.getNoise3d` scales the `z` (time) axis by `frequency` just like `x`/`y`, so `NoiseTexture2d`'s animation evolved at `speed × frequency` noise-units/sec — for the demo's `frequency: 0.05`, that's ~0.025 units/sec, imperceptible. The `speed` setting didn't match its documented "noise z-units per second."
*Fix:* `_rawNoise` divides `time` by `noise.frequency` before passing it as `z`, so after the internal `× frequency` the field evolves at exactly `speed` units/sec — decoupled from the spatial frequency.

**2. Water looked like blocky pixel noise.** The ripple normal map (small, stretched over the whole band) was upscaled with **NEAREST** filtering — the example never set `antiAlias`.
*Fix:* `antiAlias: true` (LINEAR filtering). Also added **domain warp** to the ripples for an organic, flowing-water character (vs plain blobby noise), bumped the map to 160², and widened the reflection light so more of the surface shimmers.

Verified live on WebGL: ripples now visibly flow and the surface is smooth (two frames 2s apart show the swirl pattern morphing).

Engine change is example-agnostic (makes `speed` honest for any animated `NoiseTexture2d`); full suite 4537 green, lint/tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)