### PR TITLE
docs(readme): procedural Noise/NoiseTexture2d feature + Water Surface example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Graphics
 - Built-in effects such as tinting, masking, and CSS-style blend modes (normal, additive, multiply, screen, darken, lighten)
 - Standard spritesheet, single and multiple Packed Textures support
 - Compressed texture support (DDS, KTX, KTX2, PVR, PKM) with automatic format detection and fallback
+- Procedural noise textures: `Noise` (simplex/perlin/value/cellular, fBm / ridged / ping-pong fractal, domain warp; renderer-free and CPU-samplable for heightmaps, terrain, and spawn jitter) and `NoiseTexture2d` — bake a noise field into a sprite image, a `Gradient` color ramp, or a live-animated tangent-space normal map for lit water and surfaces; unified under a new `Texture2d` base alongside `TextureAtlas`
 - 3D mesh rendering with OBJ/MTL model loading, multi-material support, hardware depth testing, and perspective projection via `Camera3d` — ~30% faster mesh rendering with near-zero per-frame allocation (a re-drawn static mesh produces no GC garbage)
 - Lighting, in 2D and 3D:
     - **2D** — `Light2d` as a first-class `Renderable` (multiple dynamic lights, radial-gradient falloff, illumination-only mode, procedural rendering via `drawLight`), plus optional per-pixel normal-map shading on sprites for 3D-looking dynamic lights
@@ -180,6 +181,7 @@ Examples
 * [Hello World](https://melonjs.github.io/melonJS/examples/#/hello-world) ([source](https://github.com/melonjs/melonJS/tree/master/packages/examples/src/examples/helloWorld))
 * [Whac-A-Mole](https://melonjs.github.io/melonJS/examples/#/whac-a-mole) ([source](https://github.com/melonjs/melonJS/tree/master/packages/examples/src/examples/whac-a-mole))
 * [Compressed Textures](https://melonjs.github.io/melonJS/examples/#/compressed-textures) ([source](https://github.com/melonjs/melonJS/tree/master/packages/examples/src/examples/compressedTextures))
+* [Water Surface](https://melonjs.github.io/melonJS/examples/#/water) ([source](https://github.com/melonjs/melonJS/tree/master/packages/examples/src/examples/water)) — fully procedural ocean: CPU-noise mountains, a color-ramped `NoiseTexture2d` albedo, and a live-animated ripple normal map lit by `Light2d`, with a day↔night slider
 * [3D Mesh](https://melonjs.github.io/melonJS/examples/#/mesh-3d) ([source](https://github.com/melonjs/melonJS/tree/master/packages/examples/src/examples/mesh3d))
 * [3D Mesh Material](https://melonjs.github.io/melonJS/examples/#/mesh-3d-material) ([source](https://github.com/melonjs/melonJS/tree/master/packages/examples/src/examples/mesh3dMaterial))
 * [AfterBurner Clone](https://melonjs.github.io/melonJS/examples/#/after-burner) ([source](https://github.com/melonjs/melonJS/tree/master/packages/examples/src/examples/afterBurner)) — `Camera3d` + 3D Mesh arcade shooter


### PR DESCRIPTION
Follow-up to #1528 / #1529 — the README's feature list and examples list didn't mention the new procedural-noise capability.

- **Features:** added a bullet for `Noise` + `NoiseTexture2d` (noise types, fractal modes, domain warp; bake to image / color ramp / live-animated normal map) under the new `Texture2d` base.
- **Examples:** added the **Water Surface** demo to the list.

Docs-only. (`packages/melonjs/README.md` is regenerated from this root README at publish via `cp`, so only the root needs editing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)