### PR TITLE
Release 19.9.1 — video fullscreen frame-sync, 17-fix batch, #1231 resize loop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # must match the workspace's playwright version (root devDependencies)
-      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.0-noble
     steps:
       - uses: actions/checkout@v5
       - name: Setup node

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"files": {
 		"includes": [

--- a/package.json
+++ b/package.json
@@ -26,25 +26,25 @@
 	},
 	"packageManager": "pnpm@10.32.1",
 	"dependencies": {
-		"@biomejs/biome": "2.4.11",
+		"@biomejs/biome": "2.5.5",
 		"@eslint/js": "^10.0.1",
 		"@types/node": "^25.6.0",
 		"@vitest/browser": "^4.1.10",
 		"@vitest/browser-playwright": "^4.1.10",
-		"eslint": "^10.6.0",
-		"eslint-plugin-jsdoc": "^62.9.0",
+		"eslint": "^10.8.0",
+		"eslint-plugin-jsdoc": "^63.2.2",
 		"globals": "^17.7.0",
 		"lefthook": "^2.1.10",
 		"tsconfig": "workspace:^",
-		"tsx": "^4.23.0",
-		"turbo": "^2.10.4",
+		"tsx": "^4.23.1",
+		"turbo": "^2.10.7",
 		"typescript": "^6.0.2",
-		"typescript-eslint": "^8.63.0",
+		"typescript-eslint": "^8.65.0",
 		"vitest": "^4.1.10"
 	},
 	"devDependencies": {
-		"eslint-plugin-react-refresh": "^0.5.2",
-		"playwright": "^1.61.1"
+		"eslint-plugin-react-refresh": "^0.5.3",
+		"playwright": "^1.62.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [
@@ -57,10 +57,10 @@
 			"minimatch@<4.0.0": "3.1.4",
 			"minimatch@>=9.0.0 <9.0.7": "9.0.7",
 			"ajv@<6.14.0": "6.14.0",
-			"vite": "8.0.16",
+			"vite": "8.1.5",
 			"esbuild": "0.28.1",
 			"ws": "^8.21.0",
-			"shell-quote": "^1.8.4",
+			"shell-quote": "^1.9.0",
 			"markdown-it": "^14.2.0",
 			"react-router": "^7.15.1",
 			"vitest": "^4.1.10",

--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -70,7 +70,7 @@
 		"esbuild": "^0.28.0",
 		"melonjs": "workspace:*",
 		"tsconfig": "workspace:*",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "^6.0.2"
 	},
 	"scripts": {

--- a/packages/debug-plugin/package.json
+++ b/packages/debug-plugin/package.json
@@ -50,7 +50,7 @@
 		"esbuild": "^0.27.3",
 		"melonjs": "workspace:*",
 		"tsconfig": "workspace:*",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "^6.0.2"
 	},
 	"scripts": {

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -16,14 +16,14 @@
 		"@melonjs/tiled-inflate-plugin": "workspace:*",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
-		"@vitejs/plugin-react": "^6.0.3",
+		"@vitejs/plugin-react": "^6.0.4",
 		"ace-builds": "^1.44.0",
 		"melonjs": "workspace:^",
-		"react": "^19.2.7",
-		"react-dom": "^19.2.7",
+		"react": "^19.2.8",
+		"react-dom": "^19.2.8",
 		"react-router-dom": "^7.18.1",
 		"tsconfig": "workspace:^",
 		"typescript": "^6.0.2",
-		"vite": "8.0.16"
+		"vite": "8.1.5"
 	}
 }

--- a/packages/matter-adapter/package.json
+++ b/packages/matter-adapter/package.json
@@ -56,7 +56,7 @@
 		"esbuild": "^0.27.3",
 		"melonjs": "workspace:*",
 		"tsconfig": "workspace:*",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "^6.0.2",
 		"vitest": "^4.1.10"
 	},

--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [19.9.1] (melonJS 2) - _2026-07-28_
+
+### Fixed
+- video sprite frames stalled (~4fps) in fullscreen — a pending `requestVideoFrameCallback` now keeps the browser delivering frames at full rate
+- video sprites never paused on `state.pause()` (wrong event name)
+- `onVisibilityChange` fired a spurious leave/enter pair every frame for visible renderables
+- destroyed cameras kept reacting to game reset / canvas resize; stages now destroy the cameras they construct (one leaked per state switch with `cameraClass`)
+- camera bounds clamp ignored a non-zero world origin, making the far edges unreachable
+- dead particles were pool-released while their removal was still deferred — same-frame respawns could silently vanish
+- a completed `loop: false` animation could never be replayed via `play()` / `setCurrentAnimation()`
+- animation frames with a `0` delay froze the game in an infinite loop
+- `Container` / `Entity` `destroy()` passed an `Arguments` object to `onDestroyEvent` instead of the actual arguments
+- `DropTarget.setCheckMethod()` accepted invalid method names (validated the wrong variable)
+- `Container.getNextChild()` returned the first child for a non-member instead of `undefined`
+- `Text` / `BitmapText` `destroy()` wiped a caller-provided string array (now copied on assignment)
+- `NineSliceSprite` showed ~2px seams for region sizes not divisible by 4 (fractional corners were truncated)
+- the canvas slowly grew on window resize inside auto-sized wrappers ([#1231](https://github.com/melonjs/melonJS/issues/1231)) — the canvas now defaults to `display: block` and auto-scale measures the container's content box
+- `ShaderEffect.setTexture()` rejects `HTMLVideoElement` with a `TypeError` instead of silently freezing on the first frame
+- BMFont `padding` was parsed with `padLeft` / `padRight` swapped (AngelCode order is up/right/down/left)
+- removed the texture cache's dead frame-dimension refinement ([#1489](https://github.com/melonjs/melonJS/issues/1489)); the first-registered-atlas behavior is now explicit
+
+### Performance
+- video textures upload to the GPU only when a new frame was actually presented (previously every render tick, per sprite)
+
 ## [19.9.0] (melonJS 2) - _2026-07-14_
 
 **Highlights:** shader effects made easy. Effects that used to demand WebGL expertise, like a pond rippling with the scene reflected in it, heat haze, or frosted glass, now take a few lines of shader code: the engine hands your effect the screen behind it and the right coordinates, animated noise textures come built-in, and shaders preload like any other asset. See the new **Water Overworld** example for all of it in action. Also in this release: named anchor presets (`"bottom"`, `"top-left"`, and friends) on every renderable, shapes with holes in `Path2D`/SVG fills, and a 40+ bug-fix sweep across the loader, audio, texture atlas, and WebGL rendering.

--- a/packages/melonjs/package.json
+++ b/packages/melonjs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "melonjs",
-	"version": "19.9.0",
+	"version": "19.9.1",
 	"description": "melonJS Game Engine",
 	"homepage": "http://www.melonjs.org/",
 	"type": "module",
@@ -66,12 +66,12 @@
 		"esbuild": "^0.27.3",
 		"serve": "^14.2.6",
 		"tsconfig": "workspace:^",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"type-fest": "^5.8.0",
 		"typedoc": "^0.28.20",
 		"typescript": "^6.0.2",
-		"vite": "8.0.16",
-		"vite-plugin-glsl": "^1.6.0"
+		"vite": "8.1.5",
+		"vite-plugin-glsl": "^1.6.1"
 	},
 	"scripts": {
 		"dev": "concurrently --raw \"pnpm build:watch\" \"pnpm tsc:watch\" \"pnpm doc:watch\"",

--- a/packages/melonjs/src/application/application.ts
+++ b/packages/melonjs/src/application/application.ts
@@ -468,7 +468,17 @@ export default class Application {
 		});
 
 		// add our canvas (default to document.body if settings.parent is undefined)
-		this.parentElement.appendChild(this.renderer.getCanvas());
+		const canvas = this.renderer.getCanvas();
+		// the browser default `display: inline` puts the canvas on the text
+		// baseline, so an auto-sized ancestor measures canvas + baseline gap —
+		// and the auto-scale resize path then re-applies that few-px excess on
+		// EVERY resize event (the slow canvas-growth loop of #1231). `block`
+		// removes the gap. Only applied when the canvas carries no explicit
+		// inline display, so user styling stays authoritative.
+		if (canvas.style.display === "") {
+			canvas.style.display = "block";
+		}
+		this.parentElement.appendChild(canvas);
 
 		// Mobile browser hacks
 		if (device.platform.isMobile) {

--- a/packages/melonjs/src/application/resize.ts
+++ b/packages/melonjs/src/application/resize.ts
@@ -55,16 +55,45 @@ export function onresize(game: Application): void {
 			canvasMaxHeight = parseInt(style.maxHeight, 10) || Infinity;
 		}
 
+		let measuredElement;
 		if (typeof game.settings.scaleTarget !== "undefined") {
 			// get the bounds of the given scale target
-			nodeBounds = device.getElementBounds(game.settings.scaleTarget);
+			measuredElement = game.settings.scaleTarget;
+			nodeBounds = device.getElementBounds(measuredElement);
 		} else {
 			// get the maximum canvas size within the parent div containing the canvas container
-			nodeBounds = device.getParentBounds(game.getParentElement());
+			measuredElement = device.getParentElement(game.getParentElement());
+			nodeBounds = device.getElementBounds(measuredElement);
 		}
 
-		const _max_width = Math.min(canvasMaxWidth, nodeBounds.width);
-		const _max_height = Math.min(canvasMaxHeight, nodeBounds.height);
+		let availWidth = nodeBounds.width;
+		let availHeight = nodeBounds.height;
+		// The space available to a child is the measured element's CONTENT
+		// box; `getBoundingClientRect` returns the border box. On an
+		// auto-sized container the difference (padding + border) gets baked
+		// into the canvas size and re-measured on the next pass — growing
+		// the canvas by that amount on every resize event (#1231). The
+		// window-fallback path (string target / document.body) has no
+		// padding concept and is left untouched.
+		if (
+			typeof measuredElement === "object" &&
+			typeof globalThis.getComputedStyle === "function"
+		) {
+			const style = globalThis.getComputedStyle(measuredElement);
+			availWidth -=
+				(parseFloat(style.paddingLeft) || 0) +
+				(parseFloat(style.paddingRight) || 0) +
+				(parseFloat(style.borderLeftWidth) || 0) +
+				(parseFloat(style.borderRightWidth) || 0);
+			availHeight -=
+				(parseFloat(style.paddingTop) || 0) +
+				(parseFloat(style.paddingBottom) || 0) +
+				(parseFloat(style.borderTopWidth) || 0) +
+				(parseFloat(style.borderBottomWidth) || 0);
+		}
+
+		const _max_width = Math.min(canvasMaxWidth, Math.max(0, availWidth));
+		const _max_height = Math.min(canvasMaxHeight, Math.max(0, availHeight));
 
 		// calculate final canvas width & height
 		const screenRatio = _max_width / _max_height;

--- a/packages/melonjs/src/camera/camera2d.ts
+++ b/packages/melonjs/src/camera/camera2d.ts
@@ -14,6 +14,7 @@ import {
 	CANVAS_ONRESIZE,
 	emit,
 	GAME_RESET,
+	off,
 	on,
 	VIEWPORT_ONCHANGE,
 	VIEWPORT_ONRESIZE,
@@ -322,9 +323,12 @@ export default class Camera2d extends Renderable {
 	_followH(target: Vector2d | Vector3d): number {
 		let targetX = this.pos.x;
 		if (target.x - this.pos.x > this.deadzone.right) {
+			// clamp against the bounds' right EDGE — `bounds.width` is
+			// `right - left`, so using it as a max only worked for a
+			// zero-origin world and cut `left` px off the far side
 			targetX = Math.min(
 				target.x - this.deadzone.right,
-				this.bounds.width - this.width,
+				this.bounds.right - this.width,
 			);
 		} else if (target.x - this.pos.x < this.deadzone.pos.x) {
 			targetX = Math.max(target.x - this.deadzone.pos.x, this.bounds.left);
@@ -338,7 +342,7 @@ export default class Camera2d extends Renderable {
 		if (target.y - this.pos.y > this.deadzone.bottom) {
 			targetY = Math.min(
 				target.y - this.deadzone.bottom,
-				this.bounds.height - this.height,
+				this.bounds.bottom - this.height,
 			);
 		} else if (target.y - this.pos.y < this.deadzone.pos.y) {
 			targetY = Math.max(target.y - this.deadzone.pos.y, this.bounds.top);
@@ -591,8 +595,10 @@ export default class Camera2d extends Renderable {
 		const _x = this.pos.x;
 		const _y = this.pos.y;
 
-		this.pos.x = clamp(x, this.bounds.left, this.bounds.width - this.width);
-		this.pos.y = clamp(y, this.bounds.top, this.bounds.height - this.height);
+		// clamp against the bounds' far edges — `bounds.width/height` are
+		// extents (`right - left`), correct as a max only for a zero origin
+		this.pos.x = clamp(x, this.bounds.left, this.bounds.right - this.width);
+		this.pos.y = clamp(y, this.bounds.top, this.bounds.bottom - this.height);
 
 		//publish the VIEWPORT_ONCHANGE event if necessary
 		if (_x !== this.pos.x || _y !== this.pos.y) {
@@ -1106,6 +1112,14 @@ export default class Camera2d extends Renderable {
 	 * @ignore
 	 */
 	override destroy(): void {
+		// unsubscribe the constructor-registered global listeners — without
+		// this a destroyed camera stays reachable forever and keeps reacting
+		// to GAME_RESET (TypeError on freed state) and CANVAS_ONRESIZE
+		// (duplicate VIEWPORT_ONRESIZE emits from zombie cameras)
+		/* eslint-disable @typescript-eslint/unbound-method -- listener identity must match the `on(...)` registration */
+		off(GAME_RESET, this.reset, this);
+		off(CANVAS_ONRESIZE, this.resize, this);
+		/* eslint-enable @typescript-eslint/unbound-method */
 		// clean up the internal colorMatrix effect (may not be in postEffects if identity)
 		if (this._colorMatrixEffect) {
 			if (typeof this._colorMatrixEffect.destroy === "function") {

--- a/packages/melonjs/src/particles/particle.ts
+++ b/packages/melonjs/src/particles/particle.ts
@@ -156,8 +156,16 @@ export default class Particle extends Renderable {
 
 		if (this.alive && this.life <= 0) {
 			const parent = this.ancestor as Container;
-			// use true for keepalive since we recycle the instance directly here after
-			parent.removeChild(this, true);
+			// IMMEDIATE removal (not the deferred `removeChild`) because the
+			// instance is released to the pool on the next line: a deferred
+			// removal leaves a stale `removeChildNow` pending against this
+			// instance, so a same-frame respawn recycling it would be
+			// silently killed by that timer, and a same-frame emitter
+			// teardown would destroy an instance already sitting in the
+			// pool (poisoning every later `particlePool.get()`). The
+			// immediate splice is safe here — `Container.update` walks its
+			// children in reverse. keepalive=true since we recycle directly.
+			parent.removeChildNow(this, true);
 			particlePool.release(this);
 			this.alive = false;
 			return false;

--- a/packages/melonjs/src/particles/settings.ts
+++ b/packages/melonjs/src/particles/settings.ts
@@ -159,7 +159,9 @@ export interface ParticleEmitterSettings {
 	blendMode: string;
 
 	/**
-	 * Update particles only in the viewport; remove when out of viewport.
+	 * Only repaint particles while they are inside the viewport (off-screen
+	 * particles keep simulating and living out their lifetime, but do not
+	 * mark the scene dirty).
 	 * @default true
 	 */
 	onlyInViewport: boolean;

--- a/packages/melonjs/src/renderable/container.js
+++ b/packages/melonjs/src/renderable/container.js
@@ -578,9 +578,11 @@ export default class Container extends Renderable {
 	 * @returns {Renderable} child
 	 */
 	getNextChild(child) {
-		const index = this.getChildren().indexOf(child) + 1;
-		if (index >= 0 && index < this.getChildren().length) {
-			return this.getChildAt(index);
+		const index = this.getChildren().indexOf(child);
+		// `indexOf` returns -1 for a non-member — without this check the +1
+		// would alias "not found" to index 0 and return the first child
+		if (index !== -1 && index + 1 < this.getChildren().length) {
+			return this.getChildAt(index + 1);
 		}
 		return undefined;
 	}
@@ -1098,8 +1100,10 @@ export default class Container extends Renderable {
 	destroy() {
 		// empty the container
 		this.reset();
-		// call the parent destroy method
-		super.destroy(arguments);
+		// call the parent destroy method, spreading the actual arguments —
+		// passing the `arguments` object itself would hand subclasses'
+		// `onDestroyEvent(app)` an Arguments wrapper instead of the value
+		super.destroy(...arguments);
 
 		colorPool.release(this.backgroundColor);
 	}
@@ -1129,14 +1133,18 @@ export default class Container extends Renderable {
 				globalFloatingCounter++;
 			}
 
-			// check if object is in any active cameras
-			obj.inViewport = false;
+			// check if object is in any active cameras — accumulate into a
+			// local and assign ONCE: assigning `false` then `true` through
+			// the setter would fire `onVisibilityChange` (a change-detecting
+			// setter) twice per frame for every continuously-visible object
+			let inViewport = false;
 			// iterate through all cameras
 			cameras.forEach((camera) => {
 				if (camera.isVisible(obj, isFloating)) {
-					obj.inViewport = true;
+					inViewport = true;
 				}
 			});
+			obj.inViewport = inViewport;
 
 			// update our object
 			this.isDirty |= (obj.inViewport || obj.alwaysUpdate) && obj.update(dt);

--- a/packages/melonjs/src/renderable/dragndrop.js
+++ b/packages/melonjs/src/renderable/dragndrop.js
@@ -57,7 +57,7 @@ export class DropTarget extends Renderable {
 	setCheckMethod(checkMethod) {
 		//  We can improve this check,
 		//  because now you can use every method in theory
-		if (typeof this.getBounds()[this.checkMethod] === "function") {
+		if (typeof this.getBounds()[checkMethod] === "function") {
 			this.checkMethod = checkMethod;
 		}
 	}

--- a/packages/melonjs/src/renderable/entity/entity.js
+++ b/packages/melonjs/src/renderable/entity/entity.js
@@ -388,8 +388,10 @@ export default class Entity extends Renderable {
 			this.children.splice(0, 1);
 		}
 
-		// call the parent destroy method
-		super.destroy(arguments);
+		// call the parent destroy method, spreading the actual arguments —
+		// passing the `arguments` object itself would hand subclasses'
+		// `onDestroyEvent(app)` an Arguments wrapper instead of the value
+		super.destroy(...arguments);
 	}
 
 	/**

--- a/packages/melonjs/src/renderable/frameAnimation.js
+++ b/packages/melonjs/src/renderable/frameAnimation.js
@@ -184,7 +184,12 @@ export default class FrameAnimation {
 	 */
 	setCurrentAnimation(name, resetAnim, preserve_dt = false) {
 		if (typeof this.anim[name] !== "undefined") {
-			if (!this.isCurrentAnimation(name)) {
+			// re-selecting the already-current animation is a no-op (so the
+			// common call-every-frame idiom doesn't restart it) — EXCEPT when
+			// a play-once (`loop: false`) run has completed: without the
+			// `_animDone` escape, a finished animation could never be
+			// replayed (`_animDone` stayed set and new options were dropped)
+			if (!this.isCurrentAnimation(name) || this._animDone) {
 				this.current.name = name;
 				this.current.length = this.anim[this.current.name].length;
 				const opts = parseAnimationOptions(resetAnim);
@@ -383,6 +388,14 @@ export default class FrameAnimation {
 				}
 				// Get next frame duration
 				duration = this.getAnimationFrameObjectByIndex(this.current.idx).delay;
+
+				// a zero (or negative) frame delay would never drain `dt` and
+				// spin this loop forever — treat it as "fastest possible":
+				// advance at most one frame per update tick
+				if (duration <= 0) {
+					this.dt = 0;
+					break;
+				}
 			}
 		}
 		return changed;

--- a/packages/melonjs/src/renderable/nineslicesprite.js
+++ b/packages/melonjs/src/renderable/nineslicesprite.js
@@ -154,11 +154,15 @@ export default class NineSliceSprite extends Sprite {
 		const corner_width = this.insetx || w / 4;
 		const corner_height = this.insety || h / 4;
 
-		const image_center_width = w - (corner_width << 1);
-		const image_center_height = h - (corner_height << 1);
+		// `* 2`, not `<< 1`: corners default to w/4 which is fractional for
+		// widths not divisible by 4, and the bit-shift truncates to int32 —
+		// desyncing the center-slice size from the un-truncated corner
+		// offsets below (up to ~2px of seam/bleed on the stretched panel)
+		const image_center_width = w - corner_width * 2;
+		const image_center_height = h - corner_height * 2;
 
-		const target_center_width = this.nss_width - (corner_width << 1);
-		const target_center_height = this.nss_height - (corner_height << 1);
+		const target_center_width = this.nss_width - corner_width * 2;
+		const target_center_height = this.nss_height - corner_height * 2;
 
 		// The 9-slice grid is separable per axis: each column/row is an unscaled
 		// corner, a stretched center, then an unscaled corner. Fill the shared

--- a/packages/melonjs/src/renderable/sprite.js
+++ b/packages/melonjs/src/renderable/sprite.js
@@ -2,7 +2,7 @@ import { game } from "../application/application.ts";
 import { getImage } from "./../loader/loader.js";
 import { Color } from "../math/color.ts";
 import { vector2dPool } from "../math/vector2d.ts";
-import { on } from "../system/event.ts";
+import { on, STATE_PAUSE } from "../system/event.ts";
 import { TextureAtlas } from "./../video/texture/atlas.js";
 import Texture2d from "./../video/texture/texture2d.ts";
 import { resolveAnchorPoint } from "./anchorPoint.ts";
@@ -194,9 +194,33 @@ export default class Sprite extends Renderable {
 				 * pause the video when losing focus
 				 * @ignore
 				 */
-				this.removeStatePauseListener = on("statePause", () => {
+				this.removeStatePauseListener = on(STATE_PAUSE, () => {
 					this.image.pause();
 				});
+
+				// Keep a video-frame callback pending while this sprite is
+				// alive: Chromium parks detached (never-in-DOM) videos on a
+				// ~250ms background timer when the page compositor idles
+				// (e.g. fullscreen direct scanout) — a pending rVFC forces
+				// full-rate frame delivery. The callback also stamps a
+				// monotonic frame counter on the element (the same
+				// duck-typed `version` convention as NoiseTexture2d) so
+				// update()/drawImage only repaint/re-upload when a frame
+				// actually arrived. Browsers without rVFC never get the
+				// stamp and stay on the legacy repaint-while-playing path.
+				this._lastVideoFrameVersion = -1;
+				if (typeof this.image.requestVideoFrameCallback === "function") {
+					this.image.version ??= 0;
+					const tick = () => {
+						// self-healing bump (never a bare `++`): a sharing
+						// sprite's destroy() deletes the stamp, and
+						// `undefined++` would poison the counter with NaN
+						// (NaN !== NaN → permanently dirty + re-uploading)
+						this.image.version = (this.image.version ?? -1) + 1;
+						this._videoFrameHandle = this.image.requestVideoFrameCallback(tick);
+					};
+					this._videoFrameHandle = this.image.requestVideoFrameCallback(tick);
+				}
 
 				// call the onended when the video has ended
 				this.image.onended = () => {
@@ -562,7 +586,7 @@ export default class Sprite extends Renderable {
 	 * this.setCurrentAnimation("walk");
 	 *
 	 * // set "walk" animation if it is not the current animation
-	 * if (this.isCurrentAnimation("walk")) {
+	 * if (!this.isCurrentAnimation("walk")) {
 	 *     this.setCurrentAnimation("walk");
 	 * }
 	 *
@@ -740,7 +764,20 @@ export default class Sprite extends Renderable {
 			} else if (this.image.paused) {
 				this.image.play();
 			}
-			this.isDirty = !this.image.paused;
+			// set-only (never assign false — that would stomp a dirty flag
+			// set earlier in the tick, e.g. by a tween on a paused sprite)
+			if (this.image.version === undefined) {
+				// no rVFC tracking (old browsers): repaint while playing
+				if (!this.image.paused) {
+					this.isDirty = true;
+				}
+			} else if (this.image.version !== this._lastVideoFrameVersion) {
+				// a new frame was presented since we last looked; deliberately
+				// not gated on `paused` so a seek while paused (stop() rewind)
+				// still repaints with the presented frame
+				this._lastVideoFrameVersion = this.image.version;
+				this.isDirty = true;
+			}
 		} else {
 			// advance the shared frame-animation engine; a frame change marks this
 			// sprite dirty via `_applyFrame` (the engine owns no dirty flag)
@@ -864,6 +901,14 @@ export default class Sprite extends Renderable {
 		this.offset = undefined;
 		if (this.isVideo) {
 			this.removeStatePauseListener();
+			if (typeof this._videoFrameHandle !== "undefined") {
+				this.image.cancelVideoFrameCallback(this._videoFrameHandle);
+				// drop the frame-counter stamp so a later non-Sprite consumer
+				// (manual renderer.drawImage) gets the legacy per-frame upload
+				// path back; a still-alive sprite sharing this element simply
+				// re-stamps on its next presented frame
+				delete this.image.version;
+			}
 			this.image.onended = undefined;
 			this.image.pause();
 			this.image.currentTime = 0;

--- a/packages/melonjs/src/renderable/text/bitmaptext.js
+++ b/packages/melonjs/src/renderable/text/bitmaptext.js
@@ -191,7 +191,10 @@ export default class BitmapText extends Renderable {
 			if (!Array.isArray(value)) {
 				this._text = ("" + value).split("\n");
 			} else {
-				this._text = value;
+				// copy — storing the caller's array by reference would let
+				// destroy() (`_text.length = 0`) wipe it, and external
+				// mutation would change the rendered text without isDirty
+				this._text = value.slice();
 			}
 			this.isDirty = true;
 		}

--- a/packages/melonjs/src/renderable/text/bitmaptextdata.ts
+++ b/packages/melonjs/src/renderable/text/bitmaptextdata.ts
@@ -188,10 +188,11 @@ export default class BitmapTextData {
 		}
 		const paddingValues = padding[0].split("=")[1].split(",");
 
+		// AngelCode order is up, RIGHT, down, LEFT (T/R/B/L, like CSS)
 		this.padTop = parseFloat(paddingValues[0]);
-		this.padLeft = parseFloat(paddingValues[1]);
+		this.padRight = parseFloat(paddingValues[1]);
 		this.padBottom = parseFloat(paddingValues[2]);
-		this.padRight = parseFloat(paddingValues[3]);
+		this.padLeft = parseFloat(paddingValues[3]);
 		this.lineHeight = parseFloat(getValueFromPair(lines[1], /lineHeight=\d+/g));
 		const baseLine = parseFloat(getValueFromPair(lines[1], /base=\d+/g));
 
@@ -258,10 +259,11 @@ export default class BitmapTextData {
 
 		// padding is optional in XML exports (e.g. frostyfreeze) → default to 0
 		const pad = (info.get("padding") ?? "0,0,0,0").split(",");
+		// AngelCode order is up, RIGHT, down, LEFT (T/R/B/L, like CSS)
 		this.padTop = parseFloat(pad[0]);
-		this.padLeft = parseFloat(pad[1]);
+		this.padRight = parseFloat(pad[1]);
 		this.padBottom = parseFloat(pad[2]);
-		this.padRight = parseFloat(pad[3]);
+		this.padLeft = parseFloat(pad[3]);
 		this.lineHeight = num(common, "lineHeight");
 		const baseLine = num(common, "base");
 

--- a/packages/melonjs/src/renderable/text/text.js
+++ b/packages/melonjs/src/renderable/text/text.js
@@ -339,7 +339,10 @@ export default class Text extends Renderable {
 			if (!Array.isArray(value)) {
 				this._text = ("" + value).split("\n");
 			} else {
-				this._text = value;
+				// copy — storing the caller's array by reference would let
+				// destroy() (`_text.length = 0`) wipe it, and external
+				// mutation would change the rendered text without isDirty
+				this._text = value.slice();
 			}
 		}
 

--- a/packages/melonjs/src/state/stage.ts
+++ b/packages/melonjs/src/state/stage.ts
@@ -383,6 +383,20 @@ export default class Stage {
 	 * @ignore
 	 */
 	destroy(app: Application): void {
+		// destroy the cameras this stage constructed (the fresh per-stage
+		// `cameraClass` instances) — without this, every state switch leaks
+		// a zombie camera still subscribed to GAME_RESET/CANVAS_ONRESIZE.
+		// NOT stage-owned (so not destroyed here): user instances from
+		// `settings.cameras` (re-added from settings on the next reset) and
+		// the shared module-level Camera2d singleton (reused across stages)
+		this.cameras.forEach((camera) => {
+			if (
+				camera !== default_camera &&
+				!this.settings.cameras.includes(camera)
+			) {
+				camera.destroy();
+			}
+		});
 		// clear all cameras
 		this.cameras.clear();
 		// clear all lights — Light2d.onDeactivateEvent will deregister each

--- a/packages/melonjs/src/video/texture/cache.js
+++ b/packages/melonjs/src/video/texture/cache.js
@@ -254,20 +254,15 @@ class TextureCache {
 	 * return the textureAltas for the given image
 	 */
 	get(image, atlas) {
+		// Always the FIRST atlas registered for this image. A framewidth/
+		// frameheight-based refinement loop lived here for years but was
+		// provably dead (#1489): it compared top-level `.width`/`.height`
+		// on the parsed atlas dict — properties the parsers never set
+		// (frames are keyed by name) — so it never selected anything else.
+		// Whether multi-atlas selection should exist at all is a design
+		// question deferred to the #1410 cache refactor; the single-result
+		// contract is codified in texture.spec.js.
 		let entry = this.cache.get(image)[0];
-
-		if (typeof entry !== "undefined" && typeof atlas !== "undefined") {
-			this.cache.forEach((value, key) => {
-				const _atlas = value.getAtlas();
-				if (
-					key === image &&
-					_atlas.width === atlas.framewidth &&
-					_atlas.height === atlas.frameheight
-				) {
-					entry = value;
-				}
-			});
-		}
 
 		if (typeof entry === "undefined") {
 			if (!atlas) {

--- a/packages/melonjs/src/video/webgl/shadereffect.js
+++ b/packages/melonjs/src/video/webgl/shadereffect.js
@@ -500,6 +500,17 @@ export default class ShaderEffect {
 	 * water.setTime(me.timer.getTime() / 1000);
 	 */
 	setTexture(name, image, repeat = "no-repeat") {
+		// Explicitly reject HTMLVideoElement — it duck-types past the static
+		// upload path, which uploads ONCE (`entry.tex === null` guard in
+		// _prepareTextures) and would silently freeze the sampler on the
+		// video's first frame. Same contract as Sprite.normalMap. Checked
+		// before the Canvas/destroyed no-op guard so the error is raised
+		// consistently under every renderer.
+		if (typeof image?.videoWidth === "number") {
+			throw new TypeError(
+				"ShaderEffect.setTexture does not support HTMLVideoElement (extra textures upload once and would freeze on the first frame)",
+			);
+		}
 		// Canvas stub (no shader) and destroyed effects: keep the inert no-op
 		if (typeof this._shader === "undefined" || this.destroyed === true) {
 			return this;

--- a/packages/melonjs/src/video/webgl/webgl_renderer.js
+++ b/packages/melonjs/src/video/webgl/webgl_renderer.js
@@ -1496,10 +1496,25 @@ export default class WebGLRenderer extends Renderer {
 			shader._prepareTextures?.(this.currentBatcher);
 		}
 
-		// force reuploading if the given image is a HTMLVideoElement or a
-		// force re-upload for video elements
-		const reupload = typeof image.videoWidth !== "undefined";
 		const texture = this.cache.get(image);
+		// Video sources need their GL texture refreshed as the video plays.
+		// When a Sprite tracks the element via requestVideoFrameCallback it
+		// stamps a monotonic `version` counter on it (same duck-typed
+		// convention as NoiseTexture2d) — re-upload only when a new frame was
+		// actually presented, recorded per cached atlas so a shared element
+		// drawn by several sprites uploads once per frame. Without the stamp
+		// (no rVFC support / manual drawImage callers), or on the lit path
+		// (each batcher owns a separate GL texture — one shared record would
+		// go stale across them), keep the legacy per-frame force re-upload.
+		let reupload = false;
+		if (typeof image.videoWidth !== "undefined") {
+			if (image.version === undefined || useLit) {
+				reupload = true;
+			} else if (texture._videoFrameVersion !== image.version) {
+				texture._videoFrameVersion = image.version;
+				reupload = true;
+			}
+		}
 		const uvs = texture.getUVs(sx, sy, sw, sh);
 		if (useLit) {
 			this.currentBatcher.addQuad(

--- a/packages/melonjs/tests/anchorpoint-presets.spec.js
+++ b/packages/melonjs/tests/anchorpoint-presets.spec.js
@@ -160,80 +160,82 @@ const CONSUMERS = [
 	},
 ];
 
-describe.each(CONSUMERS)("settings.anchorPoint on $name", ({
-	make,
-	defaults,
-	throws,
-}) => {
-	it('resolves the "bottom" preset to (0.5, 1)', () => {
-		const r = make("bottom");
-		expect(r.anchorPoint.x).toBe(0.5);
-		expect(r.anchorPoint.y).toBe(1);
-	});
-
-	it('resolves the "top-left" preset to (0, 0)', () => {
-		const r = make("top-left");
-		expect(r.anchorPoint.x).toBe(0);
-		expect(r.anchorPoint.y).toBe(0);
-	});
-
-	it("a preset and its equivalent {x, y} object land identically", () => {
-		const a = make("bottom");
-		const b = make({ x: 0.5, y: 1 });
-		expect(a.anchorPoint.x).toBe(b.anchorPoint.x);
-		expect(a.anchorPoint.y).toBe(b.anchorPoint.y);
-	});
-
-	it("still accepts a Vector2d instance (back-compat)", () => {
-		const r = make(new Vector2d(0.25, 0.75));
-		expect(r.anchorPoint.x).toBe(0.25);
-		expect(r.anchorPoint.y).toBe(0.75);
-	});
-
-	it("out-of-range values pass through unclamped (back-compat)", () => {
-		const r = make({ x: -0.5, y: 2 });
-		expect(r.anchorPoint.x).toBe(-0.5);
-		expect(r.anchorPoint.y).toBe(2);
-	});
-
-	it("the default is preserved when no anchorPoint is given", () => {
-		const r = make(undefined);
-		expect(r.anchorPoint.x).toBe(defaults.x);
-		expect(r.anchorPoint.y).toBe(defaults.y);
-	});
-
-	const garbage = [
-		["an unknown preset", "botom"],
-		["a wrong-cased key object", { X: 1, Y: 1 }],
-		["a string-valued object", { x: "1", y: "1" }],
-		["a NaN component", { x: Number.NaN, y: 1 }],
-	];
-
-	if (throws) {
-		it.each(garbage)("throws on %s (new API surface)", (_label, value) => {
-			expect(() => {
-				make(value);
-			}).toThrow();
+describe.each(CONSUMERS)(
+	"settings.anchorPoint on $name",
+	({ make, defaults, throws }) => {
+		it('resolves the "bottom" preset to (0.5, 1)', () => {
+			const r = make("bottom");
+			expect(r.anchorPoint.x).toBe(0.5);
+			expect(r.anchorPoint.y).toBe(1);
 		});
-	} else {
-		it.each(
-			garbage,
-		)("warns and keeps the legacy (0, 0) outcome on %s — never throws", (_label, value) => {
-			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			try {
-				let r;
+
+		it('resolves the "top-left" preset to (0, 0)', () => {
+			const r = make("top-left");
+			expect(r.anchorPoint.x).toBe(0);
+			expect(r.anchorPoint.y).toBe(0);
+		});
+
+		it("a preset and its equivalent {x, y} object land identically", () => {
+			const a = make("bottom");
+			const b = make({ x: 0.5, y: 1 });
+			expect(a.anchorPoint.x).toBe(b.anchorPoint.x);
+			expect(a.anchorPoint.y).toBe(b.anchorPoint.y);
+		});
+
+		it("still accepts a Vector2d instance (back-compat)", () => {
+			const r = make(new Vector2d(0.25, 0.75));
+			expect(r.anchorPoint.x).toBe(0.25);
+			expect(r.anchorPoint.y).toBe(0.75);
+		});
+
+		it("out-of-range values pass through unclamped (back-compat)", () => {
+			const r = make({ x: -0.5, y: 2 });
+			expect(r.anchorPoint.x).toBe(-0.5);
+			expect(r.anchorPoint.y).toBe(2);
+		});
+
+		it("the default is preserved when no anchorPoint is given", () => {
+			const r = make(undefined);
+			expect(r.anchorPoint.x).toBe(defaults.x);
+			expect(r.anchorPoint.y).toBe(defaults.y);
+		});
+
+		const garbage = [
+			["an unknown preset", "botom"],
+			["a wrong-cased key object", { X: 1, Y: 1 }],
+			["a string-valued object", { x: "1", y: "1" }],
+			["a NaN component", { x: Number.NaN, y: 1 }],
+		];
+
+		if (throws) {
+			it.each(garbage)("throws on %s (new API surface)", (_label, value) => {
 				expect(() => {
-					r = make(value);
-				}).not.toThrow();
-				expect(r.anchorPoint.x).toBe(0);
-				expect(r.anchorPoint.y).toBe(0);
-				expect(warnSpy).toHaveBeenCalled();
-			} finally {
-				warnSpy.mockRestore();
-			}
-		});
-	}
-});
+					make(value);
+				}).toThrow();
+			});
+		} else {
+			it.each(garbage)(
+				"warns and keeps the legacy (0, 0) outcome on %s — never throws",
+				(_label, value) => {
+					const warnSpy = vi
+						.spyOn(console, "warn")
+						.mockImplementation(() => {});
+					try {
+						let r;
+						expect(() => {
+							r = make(value);
+						}).not.toThrow();
+						expect(r.anchorPoint.x).toBe(0);
+						expect(r.anchorPoint.y).toBe(0);
+						expect(warnSpy).toHaveBeenCalled();
+					} finally {
+						warnSpy.mockRestore();
+					}
+				},
+			);
+		}
+	},
+);
 
 describe("ImageLayer bare-number shorthand", () => {
 	it("anchorPoint: 0.3 anchors both axes and never reaches the strict resolver", () => {

--- a/packages/melonjs/tests/bitmaptextdata.spec.js
+++ b/packages/melonjs/tests/bitmaptextdata.spec.js
@@ -182,15 +182,18 @@ for (const format of ["text", "xml"]) {
 			expect(g.id).toBe(8364);
 		});
 
-		it("maps padding to top / left / bottom / right in order", () => {
+		it("maps padding in AngelCode order: up, right, down, left", () => {
+			// the previous version of this test codified a parser bug — it
+			// asserted padLeft received AngelCode's RIGHT value (index 1) and
+			// padRight the LEFT value (index 3); BMFont padding is T/R/B/L
 			const d = font({
 				padding: "1,2,3,4",
 				chars: [{ id: 65, width: 6, height: 10, xadvance: 6 }],
 			});
 			expect(d.padTop).toBe(1);
-			expect(d.padLeft).toBe(2);
+			expect(d.padRight).toBe(2);
 			expect(d.padBottom).toBe(3);
-			expect(d.padRight).toBe(4);
+			expect(d.padLeft).toBe(4);
 		});
 
 		it("stores positive AND negative kerning amounts", () => {

--- a/packages/melonjs/tests/bughunt-renderables.spec.js
+++ b/packages/melonjs/tests/bughunt-renderables.spec.js
@@ -1,0 +1,329 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+	BitmapText,
+	boot,
+	Camera2d,
+	Container,
+	DropTarget,
+	Entity,
+	event,
+	game,
+	loader,
+	NineSliceSprite,
+	ParticleEmitter,
+	Renderable,
+	Sprite,
+	Stage,
+	Text,
+	Vector2d,
+	video,
+} from "../src/index.js";
+
+/**
+ * Regression specs for the 2026-07 renderables/camera/particles bug-hunt
+ * batch. One describe block per confirmed finding.
+ */
+
+function makeSpriteSheet() {
+	const canvas = document.createElement("canvas");
+	canvas.width = 64;
+	canvas.height = 64;
+	return new Sprite(0, 0, {
+		image: canvas,
+		framewidth: 32,
+		frameheight: 32,
+	});
+}
+
+describe("Bug-hunt: renderables / camera / particles", () => {
+	beforeAll(async () => {
+		boot();
+		video.init(800, 600, {
+			parent: "screen",
+			scale: "auto",
+			renderer: video.CANVAS,
+		});
+		// bitmap font fixture for the BitmapText aliasing test
+		await new Promise((resolve) => {
+			loader.preload(
+				[
+					{
+						name: "xolo12",
+						type: "image",
+						src: "/data/fnt/xolo12.png",
+					},
+					{
+						name: "xolo12",
+						type: "binary",
+						src: "/data/fnt/xolo12.fnt",
+					},
+				],
+				resolve,
+			);
+		});
+	});
+
+	describe("onVisibilityChange fires only on actual transitions", () => {
+		it("a continuously-visible object gets no callbacks after entering", () => {
+			const obj = new Renderable(10, 10, 20, 20);
+			const calls = [];
+			obj.onVisibilityChange = (visible) => {
+				calls.push(visible);
+			};
+			game.world.addChild(obj);
+
+			game.world.update(16);
+			expect(calls).toEqual([true]); // enter once
+
+			game.world.update(16);
+			game.world.update(16);
+			expect(calls).toEqual([true]); // no churn while visible
+
+			obj.pos.x = -5000; // move far off-screen
+			game.world.update(16);
+			expect(calls).toEqual([true, false]); // leave once
+
+			game.world.removeChildNow(obj);
+		});
+	});
+
+	describe("Container/Entity destroy forwards real arguments to onDestroyEvent", () => {
+		it("a Container subclass receives the actual value, not an Arguments object", () => {
+			let received = "unset";
+			class TestContainer extends Container {
+				onDestroyEvent(arg) {
+					received = arg;
+				}
+			}
+			const c = new TestContainer(0, 0, 10, 10);
+			c.destroy("the-app");
+			expect(received).toBe("the-app");
+		});
+
+		it("an Entity subclass receives the actual value, not an Arguments object", () => {
+			let received = "unset";
+			class TestEntity extends Entity {
+				onDestroyEvent(arg) {
+					received = arg;
+				}
+			}
+			const e = new TestEntity(0, 0, { width: 10, height: 10 });
+			e.destroy("the-app");
+			expect(received).toBe("the-app");
+		});
+	});
+
+	describe("Container.getNextChild", () => {
+		it("returns undefined for a non-member instead of the first child", () => {
+			const c = new Container(0, 0, 100, 100);
+			const a = new Renderable(0, 0, 1, 1);
+			const b = new Renderable(0, 0, 1, 1);
+			c.addChild(a);
+			c.addChild(b);
+			const orphan = new Renderable(0, 0, 1, 1);
+
+			expect(c.getNextChild(orphan)).toBe(undefined);
+			expect(c.getNextChild(c.getChildren()[0])).toBe(c.getChildren()[1]);
+			expect(c.getNextChild(c.getChildren()[1])).toBe(undefined);
+		});
+	});
+
+	describe("DropTarget.setCheckMethod validates the new method", () => {
+		it("rejects an invalid method name and accepts a valid one", () => {
+			const target = new DropTarget(0, 0, 10, 10);
+			const before = target.checkMethod;
+
+			target.setCheckMethod("nonsense");
+			expect(target.checkMethod).toBe(before);
+
+			target.setCheckMethod(target.CHECKMETHOD_CONTAINS);
+			expect(target.checkMethod).toBe("contains");
+			target.destroy();
+		});
+	});
+
+	describe("Camera2d bounds clamp honors a non-zero origin", () => {
+		it("moveTo can reach the far edge of an offset world", () => {
+			const cam = new Camera2d(0, 0, 320, 240);
+			cam.setBounds(100, 50, 500, 400); // world spans x:[100,600] y:[50,450]
+
+			cam.moveTo(10000, 10000);
+			expect(cam.pos.x).toBe(600 - 320);
+			expect(cam.pos.y).toBe(450 - 240);
+
+			cam.moveTo(-10000, -10000);
+			expect(cam.pos.x).toBe(100);
+			expect(cam.pos.y).toBe(50);
+			cam.destroy();
+		});
+
+		it("the follow path clamps against the far edges too", () => {
+			const cam = new Camera2d(0, 0, 320, 240);
+			cam.setBounds(100, 50, 500, 400);
+			// target far past the deadzone → must clamp to right/bottom edge
+			expect(cam._followH(new Vector2d(10000, 0))).toBe(600 - 320);
+			expect(cam._followV(new Vector2d(0, 10000))).toBe(450 - 240);
+			cam.destroy();
+		});
+	});
+
+	describe("Camera2d.destroy unsubscribes global listeners", () => {
+		it("a destroyed camera no longer reacts to GAME_RESET", () => {
+			const cam = new Camera2d(0, 0, 100, 100);
+			cam.destroy();
+			// before the fix the zombie listener ran reset() on freed state
+			// (this.pos is undefined after destroy) and threw a TypeError
+			expect(() => {
+				event.emit(event.GAME_RESET);
+			}).not.toThrow();
+			expect(() => {
+				event.emit(event.CANVAS_ONRESIZE, 800, 600);
+			}).not.toThrow();
+		});
+
+		it("Stage.destroy destroys the cameras it constructed, sparing user cameras", () => {
+			const userCam = new Camera2d(0, 0, 100, 100);
+			// a secondary user camera (a camera named "default" would occupy
+			// the default slot and the stage would construct nothing)
+			userCam.name = "minimap";
+			const stage = new Stage({
+				cameras: [userCam],
+				cameraClass: Camera2d,
+			});
+			stage.reset(game);
+			const stageCam = stage.cameras.get("default");
+			expect(stageCam).not.toBe(userCam);
+
+			stage.destroy(game);
+			// the stage-constructed default is destroyed (freed state)...
+			expect(stageCam.pos).toBe(undefined);
+			// ...the user-provided camera is untouched (re-added on next reset)
+			expect(userCam.pos).not.toBe(undefined);
+			userCam.destroy();
+		});
+	});
+
+	describe("completed play-once animations can be replayed", () => {
+		it("setCurrentAnimation with the same name restarts a finished loop:false run", () => {
+			const sprite = makeSpriteSheet();
+			sprite.addAnimation("once", [0, 1], 10);
+			sprite.setCurrentAnimation("once", { loop: false });
+
+			sprite.update(25); // 25ms across 2×10ms frames → completes, holds last
+			expect(sprite.getCurrentAnimationFrame()).toBe(1);
+			sprite.update(50); // stays held
+			expect(sprite.getCurrentAnimationFrame()).toBe(1);
+
+			// replay — before the fix this was a permanent no-op
+			sprite.setCurrentAnimation("once", { loop: false });
+			expect(sprite.getCurrentAnimationFrame()).toBe(0);
+			sprite.update(12);
+			expect(sprite.getCurrentAnimationFrame()).toBe(1);
+			sprite.destroy();
+		});
+
+		it("re-selecting a RUNNING animation stays a no-op (call-every-frame idiom)", () => {
+			const sprite = makeSpriteSheet();
+			sprite.addAnimation("walk", [0, 1, 2], 10);
+			sprite.setCurrentAnimation("walk");
+
+			sprite.update(12);
+			expect(sprite.getCurrentAnimationFrame()).toBe(1);
+
+			sprite.setCurrentAnimation("walk"); // must not restart mid-run
+			expect(sprite.getCurrentAnimationFrame()).toBe(1);
+			sprite.destroy();
+		});
+	});
+
+	describe("zero-delay animation frames do not hang the update loop", () => {
+		it("advances one frame per tick instead of spinning forever", () => {
+			const sprite = makeSpriteSheet();
+			sprite.addAnimation("zero", [
+				{ name: 0, delay: 0 },
+				{ name: 1, delay: 0 },
+			]);
+			sprite.setCurrentAnimation("zero");
+
+			sprite.update(16); // before the fix: infinite while loop (tab freeze)
+			expect(sprite.getCurrentAnimationFrame()).toBe(1);
+			sprite.update(16);
+			expect(sprite.getCurrentAnimationFrame()).toBe(0);
+			sprite.destroy();
+		});
+	});
+
+	describe("dead particles are removed synchronously", () => {
+		it("a particle reaching end-of-life leaves its emitter within the same update", () => {
+			const emitter = new ParticleEmitter(100, 100, { totalParticles: 1 });
+			game.world.addChild(emitter);
+			emitter.burstParticles(1);
+			expect(emitter.getChildren().length).toBe(1);
+
+			const particle = emitter.getChildren()[0];
+			particle.life = 0; // force end-of-life
+			particle.update(16);
+
+			// before the fix removal was deferred to a macrotask while the
+			// instance was ALREADY released to the pool — a same-frame
+			// respawn could be silently killed by the stale deferred removal
+			expect(emitter.getChildren().length).toBe(0);
+			expect(particle.ancestor).toBe(undefined);
+
+			game.world.removeChildNow(emitter);
+		});
+	});
+
+	describe("Text does not alias the caller's string array", () => {
+		it("destroy() no longer wipes an array passed to setText", () => {
+			const lines = ["line one", "line two"];
+			const text = new Text(0, 0, {
+				font: "Arial",
+				size: 10,
+				text: "placeholder",
+			});
+			text.setText(lines);
+			text.destroy();
+			expect(lines).toEqual(["line one", "line two"]);
+		});
+
+		it("BitmapText.destroy() no longer wipes an array passed to setText", () => {
+			const lines = ["line one", "line two"];
+			const text = new BitmapText(0, 0, {
+				font: "xolo12",
+				text: "placeholder",
+			});
+			text.setText(lines);
+			text.destroy();
+			expect(lines).toEqual(["line one", "line two"]);
+		});
+	});
+
+	describe("NineSliceSprite fractional corners", () => {
+		it("slices tile the source and target exactly for a non-/4 width", () => {
+			// w = 30 → corner = 7.5; the old `<< 1` truncated 2×7.5 = 15 to
+			// 14, so the three slice widths summed to 31/91 (1px bleed/seam)
+			const canvas = document.createElement("canvas");
+			canvas.width = 30;
+			canvas.height = 30;
+			const nss = new NineSliceSprite(0, 0, {
+				image: canvas,
+				width: 90,
+				height: 90,
+			});
+			const calls = [];
+			nss.draw({
+				drawImage: (...args) => {
+					calls.push(args);
+				},
+			});
+			expect(calls.length).toBe(9);
+			// args: (image, sx, sy, sw, sh, dx, dy, dw, dh) — row 0 = calls 0..2
+			const sourceRowWidth = calls[0][3] + calls[1][3] + calls[2][3];
+			const targetRowWidth = calls[0][7] + calls[1][7] + calls[2][7];
+			expect(sourceRowWidth).toBe(30);
+			expect(targetRowWidth).toBe(90);
+			nss.destroy();
+		});
+	});
+});

--- a/packages/melonjs/tests/resize-feedback.spec.js
+++ b/packages/melonjs/tests/resize-feedback.spec.js
@@ -1,0 +1,67 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { onresize } from "../src/application/resize.ts";
+import { Application, boot, video } from "../src/index.js";
+
+/**
+ * Regression spec for #1231 — the canvas slowly grows on every window
+ * resize event when the canvas container is nested inside a wrapper with
+ * no fixed CSS dimensions.
+ *
+ * The auto-scale path measures the grandparent's border-box rect. When
+ * that ancestor is auto-sized, its rect is derived from the canvas itself
+ * plus layout chrome (its padding/border, and the baseline gap of the
+ * default `display: inline` canvas) — so every resize pass re-adds that
+ * chrome to the canvas size: a monotone growth loop.
+ */
+describe("Auto-scale resize feedback (#1231)", () => {
+	let outer;
+
+	beforeAll(() => {
+		boot();
+	});
+
+	afterEach(() => {
+		if (outer?.parentNode) {
+			outer.parentNode.removeChild(outer);
+		}
+		outer = undefined;
+	});
+
+	function makeApp() {
+		// wrapper with NO fixed dimensions (auto-sizes around its children)
+		// plus padding — the exact layout shape from the issue report
+		outer = document.createElement("div");
+		outer.style.padding = "8px";
+		const inner = document.createElement("div");
+		outer.appendChild(inner);
+		document.body.appendChild(outer);
+
+		return new Application(100, 30, {
+			parent: inner,
+			renderer: video.CANVAS,
+			scale: "auto",
+			consoleHeader: false,
+		});
+	}
+
+	it("canvas CSS size reaches a fixed point instead of growing per resize", () => {
+		const app = makeApp();
+		const canvas = app.renderer.getCanvas();
+
+		onresize(app); // settle once
+		const w1 = parseFloat(canvas.style.width);
+		const h1 = parseFloat(canvas.style.height);
+
+		for (let i = 0; i < 5; i++) {
+			onresize(app);
+		}
+
+		expect(parseFloat(canvas.style.width)).toBeCloseTo(w1, 1);
+		expect(parseFloat(canvas.style.height)).toBeCloseTo(h1, 1);
+	});
+
+	it("the engine-inserted canvas defaults to display:block (no baseline gap)", () => {
+		const app = makeApp();
+		expect(app.renderer.getCanvas().style.display).toBe("block");
+	});
+});

--- a/packages/melonjs/tests/shadereffect-settexture.spec.js
+++ b/packages/melonjs/tests/shadereffect-settexture.spec.js
@@ -311,6 +311,22 @@ describe("ShaderEffect value-setting while disabled (audit fix)", () => {
 		});
 	};
 
+	it("rejects an HTMLVideoElement source with a clear TypeError", () => {
+		// extra textures upload ONCE (`entry.tex === null` guard in
+		// _prepareTextures) — a video would silently freeze on its first
+		// frame, so it must be rejected up front (same contract as
+		// Sprite.normalMap). The guard sits before the Canvas/destroyed
+		// no-op, so no WebGL requirement here: it throws under any renderer.
+		const effect = new ShaderEffect(
+			video.renderer,
+			"uniform sampler2D uVid;\nvec4 apply(vec4 color, vec2 uv) { return color; }",
+		);
+		expect(() => {
+			effect.setTexture("uVid", document.createElement("video"));
+		}).toThrow(TypeError);
+		effect.destroy();
+	});
+
 	it("setUniform while USER-disabled applies once re-enabled", (ctx) => {
 		if (!isWebGL) {
 			ctx.skip();

--- a/packages/melonjs/tests/texture.spec.js
+++ b/packages/melonjs/tests/texture.spec.js
@@ -81,18 +81,24 @@ describe("Texture", () => {
 			expect(retrieved).toBe(entry1);
 		});
 
-		it("should retrieve specific atlas by frame dimensions", () => {
+		it("returns the first registered atlas regardless of frame dimensions (#1489)", () => {
 			const canvas = new CanvasTexture(64, 64);
 			// auto-create default atlas (full image: 64x64)
 			const defaultEntry = cache.get(canvas.canvas);
 			expect(defaultEntry).toBeDefined();
 
-			// request with a specific atlas frame size that matches
-			const entry = cache.get(canvas.canvas, {
-				framewidth: 64,
-				frameheight: 64,
-			});
-			expect(entry).toBeDefined();
+			// Codifies the single-result contract: the frame-dimension
+			// "refinement" documented on get() was dead code for years (the
+			// compared properties were never set — see #1489), so a frame
+			// size — matching or not — must return the SAME first atlas.
+			// Changing this to real multi-atlas selection is a #1410 design
+			// decision, and this test failing is the intended tripwire.
+			expect(
+				cache.get(canvas.canvas, { framewidth: 64, frameheight: 64 }),
+			).toBe(defaultEntry);
+			expect(
+				cache.get(canvas.canvas, { framewidth: 32, frameheight: 16 }),
+			).toBe(defaultEntry);
 		});
 
 		it("should keep different images as separate cache entries", () => {
@@ -356,6 +362,12 @@ describe("Texture", () => {
 				ctx.skip("WebGL-only — Canvas createPattern doesn't allocate GL units");
 				return;
 			}
+			// start from a drained unit pool: the 50 sibling tests above can
+			// leave it near exhaustion, and an exhaustion reset firing INSIDE
+			// createPattern below would clear `usedUnits` mid-test and break
+			// the +1 arithmetic (engine behavior is by-design; the test must
+			// simply not straddle a reset)
+			video.renderer.cache.resetUnitAssignments();
 			const canvas = new CanvasTexture(32, 32);
 
 			// create initial pattern

--- a/packages/melonjs/tests/vertexBuffer.spec.js
+++ b/packages/melonjs/tests/vertexBuffer.spec.js
@@ -303,24 +303,19 @@ describe("VertexArrayBuffer", () => {
 			// 9 floats: x, y, z, u, v, r, g, b, a.
 			const MESH_VERTEX_SIZE = 9;
 
-			it.each(
-				NAN_PATTERN_COLORS,
-			)("$name unpacks to RGBA floats in [0, 1] (no NaN possible)", ({
-				tint,
-				b,
-				g,
-				r,
-				a,
-			}) => {
-				const buf = new VertexArrayBuffer(MESH_VERTEX_SIZE, 4);
-				buf.pushMesh(0, 0, 0, 0, 0, tint);
+			it.each(NAN_PATTERN_COLORS)(
+				"$name unpacks to RGBA floats in [0, 1] (no NaN possible)",
+				({ tint, b, g, r, a }) => {
+					const buf = new VertexArrayBuffer(MESH_VERTEX_SIZE, 4);
+					buf.pushMesh(0, 0, 0, 0, 0, tint);
 
-				// Color floats sit at offsets 5..8 of the first vertex.
-				expect(buf.bufferF32[5]).toBeCloseTo(r / 255, 5);
-				expect(buf.bufferF32[6]).toBeCloseTo(g / 255, 5);
-				expect(buf.bufferF32[7]).toBeCloseTo(b / 255, 5);
-				expect(buf.bufferF32[8]).toBeCloseTo(a / 255, 5);
-			});
+					// Color floats sit at offsets 5..8 of the first vertex.
+					expect(buf.bufferF32[5]).toBeCloseTo(r / 255, 5);
+					expect(buf.bufferF32[6]).toBeCloseTo(g / 255, 5);
+					expect(buf.bufferF32[7]).toBeCloseTo(b / 255, 5);
+					expect(buf.bufferF32[8]).toBeCloseTo(a / 255, 5);
+				},
+			);
 
 			it("never produces a NaN float for any of the historical NaN-pattern packed colors", () => {
 				// The whole point of the FLOAT × 4 path: by writing
@@ -398,30 +393,25 @@ describe("VertexArrayBuffer", () => {
 			// wrote, AND the byte view sees the same little-endian
 			// layout the GPU's `UNSIGNED_BYTE × 4 normalized` aColor
 			// attribute expects.
-			it.each(
-				NAN_PATTERN_COLORS,
-			)("$name round-trips through the Uint32 view AND lays out bytes the GPU expects", ({
-				tint,
-				b,
-				g,
-				r,
-				a,
-			}) => {
-				// vertexSize=6: x, y, z, u, v, color (sprite format).
-				const buf = new VertexArrayBuffer(6, 4);
-				buf.push(0, 0, 0, 0, 0, tint);
+			it.each(NAN_PATTERN_COLORS)(
+				"$name round-trips through the Uint32 view AND lays out bytes the GPU expects",
+				({ tint, b, g, r, a }) => {
+					// vertexSize=6: x, y, z, u, v, color (sprite format).
+					const buf = new VertexArrayBuffer(6, 4);
+					buf.push(0, 0, 0, 0, 0, tint);
 
-				// The exact packed value sits at the Uint32 slot
-				expect(buf.bufferU32[5]).toBe(tint);
+					// The exact packed value sits at the Uint32 slot
+					expect(buf.bufferU32[5]).toBe(tint);
 
-				// Little-endian byte layout: B, G, R, A — matches
-				// what the GPU's UNSIGNED_BYTE × 4 attribute reads.
-				const byteOffset = 5 * 4;
-				expect(buf.bufferU8[byteOffset]).toBe(b);
-				expect(buf.bufferU8[byteOffset + 1]).toBe(g);
-				expect(buf.bufferU8[byteOffset + 2]).toBe(r);
-				expect(buf.bufferU8[byteOffset + 3]).toBe(a);
-			});
+					// Little-endian byte layout: B, G, R, A — matches
+					// what the GPU's UNSIGNED_BYTE × 4 attribute reads.
+					const byteOffset = 5 * 4;
+					expect(buf.bufferU8[byteOffset]).toBe(b);
+					expect(buf.bufferU8[byteOffset + 1]).toBe(g);
+					expect(buf.bufferU8[byteOffset + 2]).toBe(r);
+					expect(buf.bufferU8[byteOffset + 3]).toBe(a);
+				},
+			);
 
 			it("textureId slot in vertexSize=7 writes through the float view", () => {
 				// Color sits at slot 5 (Uint32); textureId at slot 6

--- a/packages/melonjs/tests/video-sprite.spec.js
+++ b/packages/melonjs/tests/video-sprite.spec.js
@@ -1,0 +1,228 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { boot, event, Sprite, video } from "../src/index.js";
+
+/**
+ * Video sprite frame sync via requestVideoFrameCallback (rVFC).
+ *
+ * A detached (never-in-DOM) video element only gets fresh frames from the
+ * browser while the page compositor is active — Chromium parks it on a
+ * ~250ms background timer otherwise (e.g. fullscreen direct scanout). The
+ * Sprite keeps an rVFC pending on the element to force full-rate delivery,
+ * and uses the callback to stamp a monotonic `version` counter so update()
+ * only repaints when a frame was actually presented.
+ *
+ * The rVFC surface and the media playback state are stubbed as INSTANCE
+ * properties on a real `<video>` element (shadowing the prototype) so the
+ * specs can drive frame presentation deterministically — real playback in
+ * a headless runner is not reliable.
+ */
+
+function makeVideoStub() {
+	const el = document.createElement("video");
+	const state = {
+		paused: true,
+		playCalls: 0,
+		pauseCalls: 0,
+		pending: new Map(),
+		nextHandle: 1,
+		cancelled: [],
+	};
+	Object.defineProperty(el, "paused", {
+		get: () => {
+			return state.paused;
+		},
+		configurable: true,
+	});
+	el.play = () => {
+		state.paused = false;
+		state.playCalls++;
+		return Promise.resolve();
+	};
+	el.pause = () => {
+		state.paused = true;
+		state.pauseCalls++;
+	};
+	el.requestVideoFrameCallback = (cb) => {
+		const handle = state.nextHandle++;
+		state.pending.set(handle, cb);
+		return handle;
+	};
+	el.cancelVideoFrameCallback = (handle) => {
+		state.cancelled.push(handle);
+		state.pending.delete(handle);
+	};
+	// deliver "a new frame was presented" to every pending callback; the
+	// engine's callback re-registers itself, so drain a snapshot first
+	state.presentFrame = () => {
+		const callbacks = [...state.pending.values()];
+		state.pending.clear();
+		for (const cb of callbacks) {
+			cb(performance.now(), {});
+		}
+	};
+	return { el, state };
+}
+
+function makeVideoSprite(el) {
+	return new Sprite(0, 0, {
+		image: el,
+		framewidth: 64,
+		frameheight: 64,
+	});
+}
+
+describe("Video Sprite (rVFC frame sync)", () => {
+	beforeAll(() => {
+		boot();
+		video.init(800, 600, {
+			parent: "screen",
+			scale: "auto",
+			renderer: video.CANVAS,
+		});
+	});
+
+	it("registers a video-frame callback and stamps version 0 on construction", () => {
+		const { el, state } = makeVideoStub();
+		const sprite = makeVideoSprite(el);
+		expect(sprite.isVideo).toBe(true);
+		expect(el.version).toBe(0);
+		expect(state.pending.size).toBe(1);
+		sprite.destroy();
+	});
+
+	it("each presented frame bumps the version and re-registers", () => {
+		const { el, state } = makeVideoStub();
+		const sprite = makeVideoSprite(el);
+		state.presentFrame();
+		expect(el.version).toBe(1);
+		expect(state.pending.size).toBe(1);
+		state.presentFrame();
+		expect(el.version).toBe(2);
+		expect(state.pending.size).toBe(1);
+		sprite.destroy();
+	});
+
+	it("update() marks dirty only when a new frame was presented", () => {
+		const { el, state } = makeVideoStub();
+		const sprite = makeVideoSprite(el);
+
+		// first update consumes the initial stamp (paints the poster frame)
+		sprite.isDirty = false;
+		sprite.update(16);
+		expect(sprite.isDirty).toBe(true);
+
+		// no new frame → stays clean
+		sprite.isDirty = false;
+		sprite.update(16);
+		expect(sprite.isDirty).toBe(false);
+
+		// new frame presented → dirty again
+		state.presentFrame();
+		sprite.update(16);
+		expect(sprite.isDirty).toBe(true);
+
+		sprite.destroy();
+	});
+
+	it("a frame presented while paused (seek) still repaints", () => {
+		const { el, state } = makeVideoStub();
+		const sprite = makeVideoSprite(el);
+		sprite.isDirty = false;
+		sprite.update(16); // consume the initial stamp
+		sprite.isDirty = false;
+
+		expect(el.paused).toBe(true);
+		state.presentFrame(); // e.g. a stop() rewind presenting frame 0
+		sprite.update(16);
+		expect(sprite.isDirty).toBe(true);
+
+		sprite.destroy();
+	});
+
+	it("a paused video no longer clears an externally-set dirty flag", () => {
+		const { el } = makeVideoStub();
+		const sprite = makeVideoSprite(el);
+		sprite.isDirty = false;
+		sprite.update(16); // consume the initial stamp
+		expect(el.paused).toBe(true);
+
+		// e.g. a tween moved the sprite earlier in the tick
+		sprite.isDirty = true;
+		sprite.update(16);
+		expect(sprite.isDirty).toBe(true);
+
+		sprite.destroy();
+	});
+
+	it("falls back to repaint-while-playing without rVFC support", () => {
+		const { el, state } = makeVideoStub();
+		// simulate an old browser: no rVFC on this instance
+		el.requestVideoFrameCallback = undefined;
+		const sprite = makeVideoSprite(el);
+		expect(el.version).toBe(undefined);
+
+		// paused → not dirty
+		sprite.isDirty = false;
+		sprite.update(16);
+		expect(sprite.isDirty).toBe(false);
+
+		// playing → dirty every update
+		sprite.animationpause = false;
+		sprite.update(16);
+		expect(state.playCalls).toBe(1);
+		expect(sprite.isDirty).toBe(true);
+		sprite.isDirty = false;
+		sprite.update(16);
+		expect(sprite.isDirty).toBe(true);
+
+		sprite.destroy();
+	});
+
+	it("destroy() cancels the pending callback and removes the version stamp", () => {
+		const { el, state } = makeVideoStub();
+		const sprite = makeVideoSprite(el);
+		expect(state.pending.size).toBe(1);
+		const [pendingHandle] = state.pending.keys();
+
+		sprite.destroy();
+		expect(state.cancelled).toContain(pendingHandle);
+		expect(state.pending.size).toBe(0);
+		expect("version" in el).toBe(false);
+	});
+
+	it("destroying one of two sprites sharing a video keeps the survivor healthy", () => {
+		const { el, state } = makeVideoStub();
+		const spriteA = makeVideoSprite(el);
+		const spriteB = makeVideoSprite(el);
+
+		state.presentFrame();
+		spriteA.destroy(); // cancels A's callback and deletes the stamp
+
+		// B's next presented frame must SELF-HEAL the counter — a bare
+		// `version++` on the deleted stamp would produce NaN, leaving B
+		// permanently dirty (NaN !== NaN) and re-uploading every draw
+		state.presentFrame();
+		expect(Number.isFinite(el.version)).toBe(true);
+
+		spriteB.isDirty = false;
+		spriteB.update(16);
+		expect(spriteB.isDirty).toBe(true); // the new frame repaints once
+
+		spriteB.isDirty = false;
+		spriteB.update(16);
+		expect(spriteB.isDirty).toBe(false); // ...and then settles
+
+		spriteB.destroy();
+	});
+
+	it("pauses the video on STATE_PAUSE (regression: listener used a wrong event name)", () => {
+		const { el, state } = makeVideoStub();
+		const sprite = makeVideoSprite(el);
+		const baseline = state.pauseCalls;
+
+		event.emit(event.STATE_PAUSE);
+		expect(state.pauseCalls).toBe(baseline + 1);
+
+		sprite.destroy();
+	});
+});

--- a/packages/melonjs/tests/video-upload-gating.spec.js
+++ b/packages/melonjs/tests/video-upload-gating.spec.js
@@ -1,0 +1,129 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { boot, video, WebGLRenderer } from "../src/index.js";
+
+/**
+ * WebGL upload gating for video texture sources.
+ *
+ * `WebGLRenderer.drawImage` historically force-re-uploaded any source with a
+ * `videoWidth` on every call. When a Sprite tracks the element via
+ * requestVideoFrameCallback it stamps a monotonic `version` counter on it —
+ * drawImage then re-uploads only when the version changed since the last
+ * upload (recorded per cached atlas), and just re-binds otherwise. Sources
+ * without the stamp (no rVFC support, manual drawImage callers) keep the
+ * legacy per-frame re-upload.
+ *
+ * A real video element with actual frames isn't reliable in a headless
+ * runner, so the specs use an uploadable canvas duck-typed as a video
+ * (`videoWidth`/`videoHeight` grafted on) — the gate only looks at those
+ * properties, and texImage2D accepts a canvas.
+ */
+
+function makeVideoLikeCanvas(w, h) {
+	const canvas = document.createElement("canvas");
+	canvas.width = w;
+	canvas.height = h;
+	canvas.videoWidth = w;
+	canvas.videoHeight = h;
+	return canvas;
+}
+
+describe("Video texture upload gating (WebGL)", () => {
+	let webglReady = false;
+
+	beforeAll(() => {
+		boot();
+		try {
+			video.init(800, 600, {
+				parent: "screen",
+				scale: "auto",
+				renderer: video.WEBGL,
+				failIfMajorPerformanceCaveat: false,
+			});
+			webglReady = video.renderer instanceof WebGLRenderer;
+		} catch {
+			// CI runners without GL acceleration can't construct a WebGL
+			// renderer; the tests below mark themselves skipped at runtime.
+		}
+	});
+
+	afterAll(() => {
+		// hand the world back to the default renderer for any later test files
+		video.init(800, 600, {
+			parent: "screen",
+			scale: "auto",
+			renderer: video.AUTO,
+		});
+	});
+
+	const requireWebGL = (ctx) => {
+		if (!webglReady) {
+			ctx.skip("WebGL renderer not available in this environment");
+		}
+	};
+
+	// count createTexture2D calls (actual texImage2D uploads) on the quad
+	// batcher while fn runs; restores the prototype method afterwards
+	function countUploads(fn) {
+		const quad = video.renderer.batchers.get("quad");
+		const proto = Object.getPrototypeOf(quad);
+		let uploads = 0;
+		quad.createTexture2D = function (...args) {
+			uploads++;
+			return proto.createTexture2D.apply(this, args);
+		};
+		try {
+			fn();
+		} finally {
+			delete quad.createTexture2D;
+		}
+		return uploads;
+	}
+
+	it("unversioned video sources keep the legacy per-frame re-upload", (ctx) => {
+		requireWebGL(ctx);
+		const renderer = video.renderer;
+		const src = makeVideoLikeCanvas(32, 32);
+
+		const uploads = countUploads(() => {
+			renderer.drawImage(src, 0, 0, 32, 32, 0, 0, 32, 32);
+			renderer.drawImage(src, 0, 0, 32, 32, 0, 0, 32, 32);
+		});
+		expect(uploads).toBe(2);
+	});
+
+	it("versioned video sources upload once per presented frame", (ctx) => {
+		requireWebGL(ctx);
+		const renderer = video.renderer;
+		const src = makeVideoLikeCanvas(32, 32);
+		src.version = 0;
+
+		const uploads = countUploads(() => {
+			renderer.drawImage(src, 0, 0, 32, 32, 0, 0, 32, 32);
+			// same frame (e.g. a second sprite sharing the element, or a
+			// 60Hz tick between 30fps video frames) → bind only, no upload
+			renderer.drawImage(src, 0, 0, 32, 32, 0, 0, 32, 32);
+			renderer.drawImage(src, 0, 0, 32, 32, 0, 0, 32, 32);
+			// new frame presented
+			src.version++;
+			renderer.drawImage(src, 0, 0, 32, 32, 0, 0, 32, 32);
+		});
+		expect(uploads).toBe(2);
+	});
+
+	it("a texture-unit cache reset re-uploads even with an unchanged version", (ctx) => {
+		requireWebGL(ctx);
+		const renderer = video.renderer;
+		const src = makeVideoLikeCanvas(32, 32);
+		src.version = 0;
+
+		const uploads = countUploads(() => {
+			renderer.drawImage(src, 0, 0, 32, 32, 0, 0, 32, 32);
+			// eviction safety: the version gate must not survive a unit
+			// reassignment — the batcher's per-unit bookkeeping was cleared,
+			// so the (recreated) GL texture needs actual pixels again
+			renderer.cache.resetUnitAssignments();
+			renderer.drawImage(src, 0, 0, 32, 32, 0, 0, 32, 32);
+		});
+		expect(uploads).toBe(2);
+	});
+});

--- a/packages/planck-adapter/package.json
+++ b/packages/planck-adapter/package.json
@@ -56,7 +56,7 @@
 		"esbuild": "^0.28.0",
 		"melonjs": "workspace:*",
 		"tsconfig": "workspace:*",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "^6.0.2",
 		"vitest": "^4.1.10"
 	},

--- a/packages/spine-plugin/package.json
+++ b/packages/spine-plugin/package.json
@@ -59,7 +59,7 @@
 		"esbuild": "0.28.0",
 		"melonjs": "workspace:*",
 		"tsconfig": "workspace:*",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "^6.0.3"
 	},
 	"scripts": {

--- a/packages/tiled-inflate-plugin/package.json
+++ b/packages/tiled-inflate-plugin/package.json
@@ -45,14 +45,14 @@
 	},
 	"dependencies": {
 		"fzstd": "^0.1.1",
-		"js-base64": "^3.8.1",
+		"js-base64": "^3.9.1",
 		"pako": "^2.1.0"
 	},
 	"devDependencies": {
 		"esbuild": "^0.27.4",
 		"melonjs": "workspace:*",
 		"tsconfig": "workspace:*",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "^6.0.2"
 	},
 	"scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,10 +8,10 @@ overrides:
   minimatch@<4.0.0: 3.1.4
   minimatch@>=9.0.0 <9.0.7: 9.0.7
   ajv@<6.14.0: 6.14.0
-  vite: 8.0.16
+  vite: 8.1.5
   esbuild: 0.28.1
   ws: ^8.21.0
-  shell-quote: ^1.8.4
+  shell-quote: ^1.9.0
   markdown-it: ^14.2.0
   react-router: ^7.15.1
   vitest: ^4.1.10
@@ -23,26 +23,26 @@ importers:
   .:
     dependencies:
       '@biomejs/biome':
-        specifier: 2.4.11
-        version: 2.4.11
+        specifier: 2.5.5
+        version: 2.5.5
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.6.0)
+        version: 10.0.1(eslint@10.8.0)
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.2
       '@vitest/browser':
         specifier: ^4.1.10
-        version: 4.1.10(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/browser-playwright':
         specifier: ^4.1.10
-        version: 4.1.10(playwright@1.61.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(playwright@1.62.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       eslint:
-        specifier: ^10.6.0
-        version: 10.6.0
+        specifier: ^10.8.0
+        version: 10.8.0
       eslint-plugin-jsdoc:
-        specifier: ^62.9.0
-        version: 62.9.0(eslint@10.6.0)
+        specifier: ^63.2.2
+        version: 63.2.2(eslint@10.8.0)
       globals:
         specifier: ^17.7.0
         version: 17.7.0
@@ -53,27 +53,27 @@ importers:
         specifier: workspace:^
         version: link:packages/tsconfig
       tsx:
-        specifier: ^4.23.0
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
       turbo:
-        specifier: ^2.10.4
-        version: 2.10.4
+        specifier: ^2.10.7
+        version: 2.10.7
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
       typescript-eslint:
-        specifier: ^8.63.0
-        version: 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+        specifier: ^8.65.0
+        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
     devDependencies:
       eslint-plugin-react-refresh:
-        specifier: ^0.5.2
-        version: 0.5.2(eslint@10.6.0)
+        specifier: ^0.5.3
+        version: 0.5.3(eslint@10.8.0)
       playwright:
-        specifier: ^1.61.1
-        version: 1.61.1
+        specifier: ^1.62.0
+        version: 1.62.0
 
   packages/capacitor-plugin:
     devDependencies:
@@ -99,8 +99,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsx:
-        specifier: ^4.23.0
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -122,8 +122,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsx:
-        specifier: ^4.23.0
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -152,8 +152,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^6.0.3
-        version: 6.0.3(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
       ace-builds:
         specifier: ^1.44.0
         version: 1.44.0
@@ -161,14 +161,14 @@ importers:
         specifier: workspace:^
         version: link:../melonjs
       react:
-        specifier: ^19.2.7
-        version: 19.2.7
+        specifier: ^19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
       react-router-dom:
         specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tsconfig:
         specifier: workspace:^
         version: link:../tsconfig
@@ -176,8 +176,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.3
       vite:
-        specifier: 8.0.16
-        version: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
+        specifier: 8.1.5
+        version: 8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/matter-adapter:
     dependencies:
@@ -204,14 +204,14 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsx:
-        specifier: ^4.23.0
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/melonjs:
     dependencies:
@@ -244,8 +244,8 @@ importers:
         specifier: workspace:^
         version: link:../tsconfig
       tsx:
-        specifier: ^4.23.0
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
       type-fest:
         specifier: ^5.8.0
         version: 5.8.0
@@ -256,11 +256,11 @@ importers:
         specifier: ^6.0.2
         version: 6.0.3
       vite:
-        specifier: 8.0.16
-        version: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
+        specifier: 8.1.5
+        version: 8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-glsl:
-        specifier: ^1.6.0
-        version: 1.6.0(esbuild@0.28.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+        specifier: ^1.6.1
+        version: 1.6.1(esbuild@0.28.1)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/planck-adapter:
     dependencies:
@@ -281,14 +281,14 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsx:
-        specifier: ^4.23.0
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/spine-plugin:
     dependencies:
@@ -315,8 +315,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsx:
-        specifier: ^4.23.0
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -327,8 +327,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1
       js-base64:
-        specifier: ^3.8.1
-        version: 3.8.1
+        specifier: ^3.9.1
+        version: 3.9.1
       pako:
         specifier: ^2.1.0
         version: 2.1.0
@@ -343,8 +343,8 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsx:
-        specifier: ^4.23.0
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -353,59 +353,59 @@ importers:
 
 packages:
 
-  '@biomejs/biome@2.4.11':
-    resolution: {integrity: sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==}
+  '@biomejs/biome@2.5.5':
+    resolution: {integrity: sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.11':
-    resolution: {integrity: sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg==}
+  '@biomejs/cli-darwin-arm64@2.5.5':
+    resolution: {integrity: sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.11':
-    resolution: {integrity: sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw==}
+  '@biomejs/cli-darwin-x64@2.5.5':
+    resolution: {integrity: sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.11':
-    resolution: {integrity: sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q==}
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
+    resolution: {integrity: sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.11':
-    resolution: {integrity: sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==}
+  '@biomejs/cli-linux-arm64@2.5.5':
+    resolution: {integrity: sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.11':
-    resolution: {integrity: sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==}
+  '@biomejs/cli-linux-x64-musl@2.5.5':
+    resolution: {integrity: sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.11':
-    resolution: {integrity: sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==}
+  '@biomejs/cli-linux-x64@2.5.5':
+    resolution: {integrity: sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.11':
-    resolution: {integrity: sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==}
+  '@biomejs/cli-win32-arm64@2.5.5':
+    resolution: {integrity: sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.11':
-    resolution: {integrity: sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A==}
+  '@biomejs/cli-win32-x64@2.5.5':
+    resolution: {integrity: sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -431,17 +431,17 @@ packages:
     peerDependencies:
       '@capacitor/core': ^6.0.0
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@es-joy/jsdoccomment@0.86.0':
-    resolution: {integrity: sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==}
+  '@es-joy/jsdoccomment@0.90.0':
+    resolution: {integrity: sha512-51x9KxyTAN6guZOCd+lmcDdkhgdMdP/6iMMtg9dyhCWDc3+iSUyoB7f/9WAM/yGHmGFq25Vd6bXRR7CZcB+tog==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@es-joy/resolve.exports@1.2.0':
@@ -604,8 +604,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.9.1':
-    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -618,8 +618,8 @@ packages:
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.2.1':
@@ -678,8 +678,8 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -696,103 +696,103 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-project/types@0.133.0':
-    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@rolldown/binding-android-arm64@1.0.3':
-    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
-    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.3':
-    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
-    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
-    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
-    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
-    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
-    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
-    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
-    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
-    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -826,38 +826,38 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@turbo/darwin-64@2.10.4':
-    resolution: {integrity: sha512-m1MUEI4MJ69r5CwfMYxmHi0H0rrgiYCBOp0tgBZ9x/YVvOb5uu/lRIDyDwdtH054R2yWeQaIigUGu6aCX9f8cA==}
+  '@turbo/darwin-64@2.10.7':
+    resolution: {integrity: sha512-/c9cSBRermWDv85oufLhoH6XRLOVbvzJLRd+WLyfJCP+i0HFLQj4PVNDrHcY17/ve5l8X0Oua4bJBqJUgJPnZA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.4':
-    resolution: {integrity: sha512-VQ1Yxs5zkPT+2z7t1P4mvn6JmcKLkOCAsPuK9XbOvuVj0DlTlETfIXNisX0771v/vTWHOQqiwoGi+TtAUq8efw==}
+  '@turbo/darwin-arm64@2.10.7':
+    resolution: {integrity: sha512-8lpCCGWZBl9PIF8w8f2iEWrLMbHBWIfJeV6l2UEGqysD6HRIM4ySj/8R7HGEzbECJ4r/gnJcHmxEoG8yjFe64A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.4':
-    resolution: {integrity: sha512-IzV1QovmwX7mfGnVinmE++2IB8tbeo38weltiuH5zNqwCTBjLs/DytyRKx+bmnhHdXIq9SheR8p0Nip/LBUPHg==}
+  '@turbo/linux-64@2.10.7':
+    resolution: {integrity: sha512-Midw9Ed00yw9rqkWN82fY3LmLNFQ6yiL1GXB56DJKUEjWaEd27zh7ohCxzzrjfjQVrEeVWd3UPytTAV16XDQlA==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.10.4':
-    resolution: {integrity: sha512-rfujSQkP5aYiRn0PgTM7F00WkJCP/bKDVZbOx3WmrZwa/vHA0bplhCl328kpX7VI9HH2vI90ISGwuSVgJgoqTw==}
+  '@turbo/linux-arm64@2.10.7':
+    resolution: {integrity: sha512-UVEy+MW/xn4BcsiV3v3uv0/oObyaQgVtRT+Jj4WE53rNH05VEYEc1Z13q3zV6276wCZR4Yxc4hiTTcjw7PjSpg==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.10.4':
-    resolution: {integrity: sha512-NnspP7Wd5fa3Wwnqv9bKfhegqZzuHBgbPxdZU/idTLQcazx/vgKu95JlCx2YHY0hdvKCnPcARrDwM+KEUmaO7A==}
+  '@turbo/windows-64@2.10.7':
+    resolution: {integrity: sha512-l2nH9KGLV46SWjcXvyc2+xo5gdf5J0NVADknQk9OCJhzJBpiNl/byd26yIfwZBjLupdqT6UOdPhPxcpUPxRykQ==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.4':
-    resolution: {integrity: sha512-Iv02YgOpaEShc2OkG7mgCJ2pEw1RUKiKbs0h8W5wAf4jZ5vpmraTEjuGTgHRuOORQnC1GN3KHo5WB+hu1abRMA==}
+  '@turbo/windows-arm64@2.10.7':
+    resolution: {integrity: sha512-qjE1apG6RThuX49vUJd5ks2dV2ndXC2qktDChQonFMvUzrMrEnZMQzO+IgxBiYq1j+NbXQcRwj84nGnk1TBw1g==}
     cpu: [arm64]
     os: [win32]
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -897,76 +897,72 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.63.0':
-    resolution: {integrity: sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==}
+  '@typescript-eslint/eslint-plugin@8.65.0':
+    resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.63.0
+      '@typescript-eslint/parser': ^8.65.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.63.0':
-    resolution: {integrity: sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.63.0':
-    resolution: {integrity: sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.63.0':
-    resolution: {integrity: sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.63.0':
-    resolution: {integrity: sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.63.0':
-    resolution: {integrity: sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==}
+  '@typescript-eslint/parser@8.65.0':
+    resolution: {integrity: sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.59.2':
-    resolution: {integrity: sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.63.0':
-    resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.63.0':
-    resolution: {integrity: sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==}
+  '@typescript-eslint/project-service@8.65.0':
+    resolution: {integrity: sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.63.0':
-    resolution: {integrity: sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==}
+  '@typescript-eslint/scope-manager@8.65.0':
+    resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.65.0':
+    resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.65.0':
+    resolution: {integrity: sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.63.0':
-    resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
+  '@typescript-eslint/types@8.65.0':
+    resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitejs/plugin-react@6.0.3':
-    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+  '@typescript-eslint/typescript-estree@8.65.0':
+    resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.65.0':
+    resolution: {integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitejs/plugin-react@6.0.4':
+    resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
-      vite: 8.0.16
+      vite: 8.1.5
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
@@ -991,7 +987,7 @@ packages:
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 8.0.16
+      vite: 8.1.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1024,8 +1020,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -1140,8 +1136,8 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  comment-parser@1.4.6:
-    resolution: {integrity: sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==}
+  comment-parser@1.4.7:
+    resolution: {integrity: sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==}
     engines: {node: '>= 12.0.0'}
 
   compressible@2.0.18:
@@ -1247,14 +1243,14 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-jsdoc@62.9.0:
-    resolution: {integrity: sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint-plugin-jsdoc@63.2.2:
+    resolution: {integrity: sha512-xCoHKeaRwAhZ+i2ZUY11few2Lmy9qpJLDsY139c4KNJLMSZYoFJ5UMYkDjdTkO9PfkFOKmVO+7i4Yjx+x7VQWQ==}
+    engines: {node: ^22.13.0 || >=24}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-react-refresh@0.5.2:
-    resolution: {integrity: sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==}
+  eslint-plugin-react-refresh@0.5.3:
+    resolution: {integrity: sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==}
     peerDependencies:
       eslint: ^9 || ^10
 
@@ -1270,8 +1266,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.6.0:
-    resolution: {integrity: sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==}
+  eslint@10.8.0:
+    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1355,8 +1351,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+  flatted@3.4.3:
+    resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -1417,6 +1413,10 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -1468,11 +1468,11 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  js-base64@3.8.1:
-    resolution: {integrity: sha512-5xVjhUZlHHeuO2W7w2rDFj/Kl1xLX+HjZxdOQwCsUOifl6UaoH1o1wsbsTMz+r0aeC7gCijvru02j6TfKZWzKg==}
+  js-base64@3.9.1:
+    resolution: {integrity: sha512-U73qptcvf/HIOauFOmqT3a0mDUp0MYlfd15oqoe9kqZt5XhiXVb+HG09sLvI9PQ9tZIBFS4nlErai8zbWazP0g==}
 
-  jsdoc-type-pratt-parser@7.2.0:
-    resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
+  jsdoc-type-pratt-parser@7.3.0:
+    resolution: {integrity: sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==}
     engines: {node: '>=20.0.0'}
 
   json-buffer@3.0.1:
@@ -1548,78 +1548,78 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   linkify-it@5.0.2:
@@ -1696,8 +1696,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1712,8 +1712,8 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  object-deep-merge@2.0.0:
-    resolution: {integrity: sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==}
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
@@ -1794,14 +1794,14 @@ packages:
     peerDependencies:
       stage-js: ^1.0.0-alpha.12
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.61.1:
-    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
-    engines: {node: '>=18'}
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
     hasBin: true
 
   pngjs@7.0.0:
@@ -1811,8 +1811,8 @@ packages:
   poly-decomp@0.3.0:
     resolution: {integrity: sha512-hWeBxGzPYiybmI4548Fca7Up/0k1qS5+79cVHI9+H33dKya5YNb9hxl0ZnDaDgvrZSuYFBhkCK/HOnqN7gefkQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1842,10 +1842,10 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-dom@19.2.7:
-    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.2.7
+      react: ^19.2.8
 
   react-router-dom@7.18.1:
     resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
@@ -1864,8 +1864,8 @@ packages:
       react-dom:
         optional: true
 
-  react@19.2.7:
-    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   registry-auth-token@3.3.2:
@@ -1891,8 +1891,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown@1.0.3:
-    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1907,11 +1907,6 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  semver@7.8.0:
-    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1937,8 +1932,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -1962,8 +1957,8 @@ packages:
   spdx-exceptions@2.5.0:
     resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
 
-  spdx-expression-parse@4.0.0:
-    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+  spdx-expression-parse@5.0.0:
+    resolution: {integrity: sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==}
 
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
@@ -2054,13 +2049,13 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.23.0:
-    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo@2.10.4:
-    resolution: {integrity: sha512-GQpduILaKjoaGljw097ScsSyKTtZSY7cZ3bJktzfTkPMyCf3ShKLuXK2IaOEN2Plziml+ArR7WJ1m+V4VbnaKQ==}
+  turbo@2.10.7:
+    resolution: {integrity: sha512-GHx6WExIFSKNJ5qMlzDpXBXlu9ApxaMjqxAVrCNcW94xf/+uqgIz41SAuRUMbXva2ExNAaY/h8V0q90SWSzmRw==}
     hasBin: true
 
   type-check@0.4.0:
@@ -2082,8 +2077,8 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
-  typescript-eslint@8.63.0:
-    resolution: {integrity: sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==}
+  typescript-eslint@8.65.0:
+    resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2114,26 +2109,26 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite-plugin-glsl@1.6.0:
-    resolution: {integrity: sha512-3i3ZvIVb13LhTcAXEHGTOW+cNG2jbJ++XsDFyCWUpnoFN1NPXvdtC4j66pig+i0QjDnmusOK/YCpiDWizxBY0A==}
+  vite-plugin-glsl@1.6.1:
+    resolution: {integrity: sha512-0Ro2lUmDdwWkoAc+dhJ7fXO/2n6JthkzbCqW0/bvlU4R6kXjbpSqNJYfbIilFu9L/HApiXOZ8IExmlz59qzH8Q==}
     engines: {node: '>= 20.17.0', npm: '>= 10.8.3'}
     peerDependencies:
       '@rollup/pluginutils': ^5.x
       esbuild: 0.28.1
-      vite: 8.0.16
+      vite: 8.1.5
     peerDependenciesMeta:
       '@rollup/pluginutils':
         optional: true
       esbuild:
         optional: true
 
-  vite@8.0.16:
-    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.18
+      '@vitejs/devtools': ^0.3.0
       esbuild: 0.28.1
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -2186,7 +2181,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: 8.0.16
+      vite: 8.1.5
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2272,39 +2267,39 @@ packages:
 
 snapshots:
 
-  '@biomejs/biome@2.4.11':
+  '@biomejs/biome@2.5.5':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.11
-      '@biomejs/cli-darwin-x64': 2.4.11
-      '@biomejs/cli-linux-arm64': 2.4.11
-      '@biomejs/cli-linux-arm64-musl': 2.4.11
-      '@biomejs/cli-linux-x64': 2.4.11
-      '@biomejs/cli-linux-x64-musl': 2.4.11
-      '@biomejs/cli-win32-arm64': 2.4.11
-      '@biomejs/cli-win32-x64': 2.4.11
+      '@biomejs/cli-darwin-arm64': 2.5.5
+      '@biomejs/cli-darwin-x64': 2.5.5
+      '@biomejs/cli-linux-arm64': 2.5.5
+      '@biomejs/cli-linux-arm64-musl': 2.5.5
+      '@biomejs/cli-linux-x64': 2.5.5
+      '@biomejs/cli-linux-x64-musl': 2.5.5
+      '@biomejs/cli-win32-arm64': 2.5.5
+      '@biomejs/cli-win32-x64': 2.5.5
 
-  '@biomejs/cli-darwin-arm64@2.4.11':
+  '@biomejs/cli-darwin-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.11':
+  '@biomejs/cli-darwin-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.11':
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.11':
+  '@biomejs/cli-linux-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.11':
+  '@biomejs/cli-linux-x64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.11':
+  '@biomejs/cli-linux-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.11':
+  '@biomejs/cli-win32-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.11':
+  '@biomejs/cli-win32-x64@2.5.5':
     optional: true
 
   '@blazediff/core@1.9.1': {}
@@ -2325,29 +2320,29 @@ snapshots:
     dependencies:
       '@capacitor/core': 6.2.1
 
-  '@emnapi/core@1.10.0':
+  '@emnapi/core@1.11.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@es-joy/jsdoccomment@0.86.0':
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@es-joy/jsdoccomment@0.90.0':
     dependencies:
       '@types/estree': 1.0.9
-      '@typescript-eslint/types': 8.59.2
-      comment-parser: 1.4.6
+      '@typescript-eslint/types': 8.65.0
+      comment-parser: 1.4.7
       esquery: 1.7.0
-      jsdoc-type-pratt-parser: 7.2.0
+      jsdoc-type-pratt-parser: 7.3.0
 
   '@es-joy/resolve.exports@1.2.0': {}
 
@@ -2429,9 +2424,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.6.0)':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0)':
     dependencies:
-      eslint: 10.6.0
+      eslint: 10.8.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2444,7 +2439,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
 
@@ -2452,9 +2447,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.6.0)':
+  '@eslint/js@10.0.1(eslint@10.8.0)':
     optionalDependencies:
-      eslint: 10.6.0
+      eslint: 10.8.0
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -2499,11 +2494,11 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2518,57 +2513,57 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@oxc-project/types@0.133.0': {}
+  '@oxc-project/types@0.139.0': {}
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@rolldown/binding-android-arm64@1.0.3':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.3':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
+  '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
+  '@rolldown/binding-wasm32-wasi@1.1.5':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -2599,25 +2594,25 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@turbo/darwin-64@2.10.4':
+  '@turbo/darwin-64@2.10.7':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.4':
+  '@turbo/darwin-arm64@2.10.7':
     optional: true
 
-  '@turbo/linux-64@2.10.4':
+  '@turbo/linux-64@2.10.7':
     optional: true
 
-  '@turbo/linux-arm64@2.10.4':
+  '@turbo/linux-arm64@2.10.7':
     optional: true
 
-  '@turbo/windows-64@2.10.4':
+  '@turbo/windows-64@2.10.7':
     optional: true
 
-  '@turbo/windows-arm64@2.10.4':
+  '@turbo/windows-arm64@2.10.7':
     optional: true
 
-  '@tybys/wasm-util@0.10.2':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2657,74 +2652,72 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/type-utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.63.0
-      eslint: 10.6.0
-      ignore: 7.0.5
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      eslint: 10.8.0
+      ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.63.0
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
-      eslint: 10.6.0
+      eslint: 10.8.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.65.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.63.0':
+  '@typescript-eslint/scope-manager@8.65.0':
     dependencies:
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/visitor-keys': 8.63.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
 
-  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.6.0
+      eslint: 10.8.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.59.2': {}
+  '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/types@8.63.0': {}
-
-  '@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/visitor-keys': 8.63.0
+      '@typescript-eslint/project-service': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
@@ -2734,50 +2727,50 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
-      '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      eslint: 10.6.0
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      eslint: 10.8.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.63.0':
+  '@typescript-eslint/visitor-keys@8.65.0':
     dependencies:
-      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.3(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
 
-  '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.10(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
-      playwright: 1.61.1
+      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+      playwright: 1.62.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -2794,13 +2787,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -2830,11 +2823,11 @@ snapshots:
 
   ace-builds@1.44.0: {}
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
-  acorn@8.16.0: {}
+  acorn@8.17.0: {}
 
   ajv@6.15.0:
     dependencies:
@@ -2941,7 +2934,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  comment-parser@1.4.6: {}
+  comment-parser@1.4.7: {}
 
   compressible@2.0.18:
     dependencies:
@@ -2965,7 +2958,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -3059,29 +3052,29 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-jsdoc@62.9.0(eslint@10.6.0):
+  eslint-plugin-jsdoc@63.2.2(eslint@10.8.0):
     dependencies:
-      '@es-joy/jsdoccomment': 0.86.0
+      '@es-joy/jsdoccomment': 0.90.0
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
-      comment-parser: 1.4.6
+      comment-parser: 1.4.7
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint: 10.6.0
+      eslint: 10.8.0
       espree: 11.2.0
       esquery: 1.7.0
       html-entities: 2.6.0
-      object-deep-merge: 2.0.0
+      object-deep-merge: 2.0.1
       parse-imports-exports: 0.2.4
-      semver: 7.8.0
-      spdx-expression-parse: 4.0.0
+      semver: 7.8.5
+      spdx-expression-parse: 5.0.0
       to-valid-identifier: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.2(eslint@10.6.0):
+  eslint-plugin-react-refresh@0.5.3(eslint@10.8.0):
     dependencies:
-      eslint: 10.6.0
+      eslint: 10.8.0
 
   eslint-scope@9.1.2:
     dependencies:
@@ -3094,12 +3087,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.6.0:
+  eslint@10.8.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@humanfs/node': 0.16.8
@@ -3131,8 +3124,8 @@ snapshots:
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
 
   esquery@1.7.0:
@@ -3204,10 +3197,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.2
+      flatted: 3.4.3
       keyv: 4.5.4
 
-  flatted@3.4.2: {}
+  flatted@3.4.3: {}
 
   fsevents@2.3.2:
     optional: true
@@ -3252,6 +3245,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  ignore@7.0.6: {}
+
   imurmurhash@0.1.4: {}
 
   ini@1.3.8: {}
@@ -3282,9 +3277,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  js-base64@3.8.1: {}
+  js-base64@3.9.1: {}
 
-  jsdoc-type-pratt-parser@7.2.0: {}
+  jsdoc-type-pratt-parser@7.3.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -3346,54 +3341,54 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lightningcss-android-arm64@1.32.0:
+  lightningcss-android-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-arm64@1.32.0:
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
+  lightningcss-darwin-x64@1.33.0:
     optional: true
 
-  lightningcss-freebsd-x64@1.32.0:
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
+  lightningcss-linux-arm-gnueabihf@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.32.0:
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
+  lightningcss-linux-arm64-musl@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.32.0:
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
+  lightningcss-linux-x64-musl@1.33.0:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.32.0:
+  lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.32.0:
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
-  lightningcss@1.32.0:
+  lightningcss@1.33.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   linkify-it@5.0.2:
     dependencies:
@@ -3459,7 +3454,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -3469,7 +3464,7 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  object-deep-merge@2.0.0: {}
+  object-deep-merge@2.0.1: {}
 
   obug@2.1.3: {}
 
@@ -3530,11 +3525,11 @@ snapshots:
     dependencies:
       stage-js: 1.0.2
 
-  playwright-core@1.61.1: {}
+  playwright-core@1.62.0: {}
 
-  playwright@1.61.1:
+  playwright@1.62.0:
     dependencies:
-      playwright-core: 1.61.1
+      playwright-core: 1.62.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -3542,9 +3537,9 @@ snapshots:
 
   poly-decomp@0.3.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3567,26 +3562,26 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dom@19.2.7(react@19.2.7):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
       scheduler: 0.27.0
 
-  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router-dom@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-router: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       cookie: 1.1.1
-      react: 19.2.7
+      react: 19.2.8
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.2.7(react@19.2.7)
+      react-dom: 19.2.8(react@19.2.8)
 
-  react@19.2.7: {}
+  react@19.2.8: {}
 
   registry-auth-token@3.3.2:
     dependencies:
@@ -3605,26 +3600,26 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown@1.0.3:
+  rolldown@1.1.5:
     dependencies:
-      '@oxc-project/types': 0.133.0
+      '@oxc-project/types': 0.139.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.3
-      '@rolldown/binding-darwin-arm64': 1.0.3
-      '@rolldown/binding-darwin-x64': 1.0.3
-      '@rolldown/binding-freebsd-x64': 1.0.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
-      '@rolldown/binding-linux-arm64-gnu': 1.0.3
-      '@rolldown/binding-linux-arm64-musl': 1.0.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
-      '@rolldown/binding-linux-s390x-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-musl': 1.0.3
-      '@rolldown/binding-openharmony-arm64': 1.0.3
-      '@rolldown/binding-wasm32-wasi': 1.0.3
-      '@rolldown/binding-win32-arm64-msvc': 1.0.3
-      '@rolldown/binding-win32-x64-msvc': 1.0.3
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   run-parallel@1.2.0:
     dependencies:
@@ -3637,8 +3632,6 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   scheduler@0.27.0: {}
-
-  semver@7.8.0: {}
 
   semver@7.8.5: {}
 
@@ -3676,7 +3669,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   siginfo@2.0.0: {}
 
@@ -3694,7 +3687,7 @@ snapshots:
 
   spdx-exceptions@2.5.0: {}
 
-  spdx-expression-parse@4.0.0:
+  spdx-expression-parse@5.0.0:
     dependencies:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.23
@@ -3771,20 +3764,20 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.23.0:
+  tsx@4.23.1:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.10.4:
+  turbo@2.10.7:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.4
-      '@turbo/darwin-arm64': 2.10.4
-      '@turbo/linux-64': 2.10.4
-      '@turbo/linux-arm64': 2.10.4
-      '@turbo/windows-64': 2.10.4
-      '@turbo/windows-arm64': 2.10.4
+      '@turbo/darwin-64': 2.10.7
+      '@turbo/darwin-arm64': 2.10.7
+      '@turbo/linux-64': 2.10.7
+      '@turbo/linux-arm64': 2.10.7
+      '@turbo/windows-64': 2.10.7
+      '@turbo/windows-arm64': 2.10.7
 
   type-check@0.4.0:
     dependencies:
@@ -3805,13 +3798,13 @@ snapshots:
       typescript: 6.0.3
       yaml: 2.9.0
 
-  typescript-eslint@8.63.0(eslint@10.6.0)(typescript@6.0.3):
+  typescript-eslint@8.65.0(eslint@10.8.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      eslint: 10.8.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3835,30 +3828,30 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-glsl@1.6.0(esbuild@0.28.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)):
+  vite-plugin-glsl@1.6.1(esbuild@0.28.1)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
-      vite: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
     optionalDependencies:
       esbuild: 0.28.1
 
-  vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0):
+  vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.23
+      rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.6.2
       esbuild: 0.28.1
       fsevents: 2.3.3
-      tsx: 4.23.0
+      tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -3875,11 +3868,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.2
-      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## 19.9.1 (patch release)

### Bug Fixes
- **Video sprites stalled (~4fps) in fullscreen** — a pending `requestVideoFrameCallback` keeps the browser delivering frames at full rate for the engine's detached video elements; uploads are now version-gated (GPU upload only when a frame was actually presented). Also fixes the never-firing `statePause` pause listener.
- **Renderables/camera/particles bug-hunt batch** (13 findings, all verified + regression-tested): `onVisibilityChange` fired leave/enter every frame; destroyed cameras leaked global listeners (one camera per state switch under `cameraClass`); camera clamp ignored non-zero world origins; particle pool release race; play-once animations could never be replayed; zero-delay frames froze the game; `destroy(arguments)` forwarding; `DropTarget.setCheckMethod` validation; `getNextChild` non-member aliasing; `Text`/`BitmapText` caller-array wipe; `NineSliceSprite` fractional-corner seams.
- **#1231** — canvas slowly grew on window resize inside auto-sized wrappers: engine canvas now defaults to `display: block` and auto-scale measures the container's content box. Reproduced failing-first in `tests/resize-feedback.spec.js`.
- **Hardening**: `setTexture(video)` rejects with a clear `TypeError` (would silently freeze on frame 0); BMFont padding order (`padLeft`/`padRight` were swapped, and the old spec codified the bug); dead texture-cache frame-dimension refinement removed (#1489) with the single-atlas contract now test-codified.

### Tooling
Routine batch: playwright 1.62 (+ matching CI container), vite 8.1.5, biome 2.5.5, eslint 10.8 stack, `shell-quote >=1.9` security override (CVE-2026-13311, dev-only). The new chromium headless shell provides WebGL locally — 14 previously-skipped WebGL tests now run.

**Tests**: 172 files, 5209 passed, 1 skipped (full `turbo build` + suite). 3 new spec files, ~40 new regression tests.

Closes #1231
Closes #1489

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvxaXQRgQn5AoR8DNkv6Wg