### PR TITLE
refactor(video): allocate uniform buffer binding points from the renderer

### DIFF
--- a/packages/melonjs/src/video/webgl/batchers/lit_mesh_batcher.js
+++ b/packages/melonjs/src/video/webgl/batchers/lit_mesh_batcher.js
@@ -1,6 +1,6 @@
 import state from "../../../state/state.ts";
 import UniformBlock from "../buffer/uniformblock.js";
-import { LIGHT3D_BINDING_POINT, MAX_LIGHTS } from "../lighting/constants.ts";
+import { MAX_LIGHTS } from "../lighting/constants.ts";
 import { packMeshLights } from "../lighting/pack3d.ts";
 import { BLOCK_FLOATS, writeLight3dBlock } from "../lighting/std140.ts";
 import litFragment from "./../shaders/mesh-lit.frag";
@@ -52,10 +52,14 @@ export default class LitMeshBatcher extends MeshBatcher {
 		 * @type {UniformBlock}
 		 * @ignore
 		 */
+		// Claim a binding point once and hold it: `init()` re-runs on context
+		// restore, and claiming again each time would walk through the
+		// device's budget over a long session.
+		this._bindingPoint ??= renderer.reserveUniformBindingPoint();
 		this.lightBlock = new UniformBlock(
 			renderer.gl,
 			BLOCK_FLOATS,
-			LIGHT3D_BINDING_POINT,
+			this._bindingPoint,
 		);
 		this._lightBlockProgram = null;
 		// see the note in LitQuadBatcher.init: an active-but-unbound uniform

--- a/packages/melonjs/src/video/webgl/batchers/lit_quad_batcher.js
+++ b/packages/melonjs/src/video/webgl/batchers/lit_quad_batcher.js
@@ -1,6 +1,6 @@
 import { off, on, TEXTURE2D_DESTROYED } from "../../../system/event.ts";
 import UniformBlock from "../buffer/uniformblock.js";
-import { LIGHT2D_BINDING_POINT, MAX_LIGHTS } from "../lighting/constants.ts";
+import { MAX_LIGHTS } from "../lighting/constants.ts";
 import {
 	BLOCK_FLOATS,
 	HEADER_FLOATS,
@@ -135,10 +135,14 @@ export default class LitQuadBatcher extends QuadBatcher {
 		 * @type {UniformBlock}
 		 * @ignore
 		 */
+		// Claim a binding point once and hold it: `init()` re-runs on context
+		// restore, and claiming again each time would walk through the
+		// device's budget over a long session.
+		this._bindingPoint ??= renderer.reserveUniformBindingPoint();
 		this.lightBlock = new UniformBlock(
 			renderer.gl,
 			BLOCK_FLOATS,
-			LIGHT2D_BINDING_POINT,
+			this._bindingPoint,
 		);
 		this._lightBlockProgram = null;
 		// Bind immediately rather than waiting for the first activation. An

--- a/packages/melonjs/src/video/webgl/lighting/constants.ts
+++ b/packages/melonjs/src/video/webgl/lighting/constants.ts
@@ -23,26 +23,3 @@
  * is free — the loop bound is the live count — but filling it is not.
  */
 export const MAX_LIGHTS = 32;
-
-/**
- * Indexed `UNIFORM_BUFFER` binding point for `Light2dBlock` (the lit quad
- * path). Binding points are a context-wide resource, so the two light
- * blocks take distinct ones — a 2D lit sprite and a 3D lit mesh can both be
- * drawn in the same frame.
- *
- * Point 0 is used, deliberately. It is tempting to leave it free so that a
- * forgotten `bindTo` fails loudly instead of silently reading whatever owns
- * point 0 — but it does not fail loudly: an *active* uniform block with no
- * buffer bound is `INVALID_OPERATION` at draw time, which takes the whole
- * program down rather than just the lighting. Keeping a correctly-sized
- * buffer on 0 means a program that somehow escaped binding still draws.
- * The binding is established eagerly in each batcher's `init()` so nothing
- * relies on that safety net in the first place.
- */
-export const LIGHT2D_BINDING_POINT = 0;
-
-/**
- * Indexed `UNIFORM_BUFFER` binding point for `Light3dBlock` (the lit mesh
- * path). See {@link LIGHT2D_BINDING_POINT}.
- */
-export const LIGHT3D_BINDING_POINT = 1;

--- a/packages/melonjs/src/video/webgl/webgl_renderer.js
+++ b/packages/melonjs/src/video/webgl/webgl_renderer.js
@@ -138,6 +138,16 @@ export default class WebGLRenderer extends Renderer {
 		 * @readonly
 		 */
 		this.maxTextures = this.gl.getParameter(this.gl.MAX_TEXTURE_IMAGE_UNITS);
+		/**
+		 * Next free indexed `UNIFORM_BUFFER` binding point, handed out by
+		 * {@link WebGLRenderer#reserveUniformBindingPoint}. Binding points are
+		 * a context-wide namespace shared by every uniform block, so they are
+		 * allocated here rather than picked as literals by whoever needs one —
+		 * the same reason texture units go through `TextureCache.reserveUnit`.
+		 * @type {number}
+		 * @ignore
+		 */
+		this._nextUniformBindingPoint = 0;
 
 		/**
 		 * the default shader precision based on application settings
@@ -738,6 +748,32 @@ export default class WebGLRenderer extends Renderer {
 			// bound fed 4-attribute vertex data to a 5-attribute shader.
 			lit.setLightUniforms(u);
 		}
+	}
+
+	/**
+	 * Claim the next indexed `UNIFORM_BUFFER` binding point.
+	 *
+	 * Binding points are context-wide: two uniform blocks sharing one silently
+	 * overwrite each other, and the loser reads the winner's bytes as its own.
+	 * Allocating them from here rather than hard-coding an integer per feature
+	 * makes that collision impossible, and mirrors how texture units are
+	 * claimed through {@link TextureCache#reserveUnit}.
+	 *
+	 * Callers hold their point for the life of the batcher — a context restore
+	 * re-runs `init()`, which must reuse the point it already has rather than
+	 * claim another, or a long-lived session would leak through the budget.
+	 * @returns {number} the claimed binding point
+	 * @throws {Error} when the device's binding points are exhausted
+	 * @ignore
+	 */
+	reserveUniformBindingPoint() {
+		const max = this.gl.getParameter(this.gl.MAX_UNIFORM_BUFFER_BINDINGS);
+		if (this._nextUniformBindingPoint >= max) {
+			throw new Error(
+				`WebGLRenderer: no free uniform buffer binding point (device limit ${max})`,
+			);
+		}
+		return this._nextUniformBindingPoint++;
 	}
 
 	/**

--- a/packages/melonjs/tests/lighting_block_wiring.spec.js
+++ b/packages/melonjs/tests/lighting_block_wiring.spec.js
@@ -116,6 +116,41 @@ describe("lit batchers → light uniform block (issue #1552)", () => {
 			renderer.setBatcher("quad");
 		});
 
+		it("claims its binding point from the renderer's allocator", (ctx) => {
+			requireWebGL(ctx, renderer);
+			// Binding points are a context-wide namespace: two blocks sharing
+			// one silently overwrite each other and the loser reads the
+			// winner's bytes as lights. They are handed out by the renderer
+			// rather than hard-coded per feature, so a third block cannot
+			// collide by picking a literal someone else already took.
+			const block = renderer.batchers.get("litQuad").lightBlock;
+			expect(typeof block.bindingPoint).toBe("number");
+			expect(Number.isInteger(block.bindingPoint)).toBe(true);
+			expect(block.bindingPoint).toBeGreaterThanOrEqual(0);
+			expect(block.bindingPoint).toBeLessThan(
+				gl.getParameter(gl.MAX_UNIFORM_BUFFER_BINDINGS),
+			);
+			// and it is genuinely reserved — the next claim is a different one
+			const next = renderer.reserveUniformBindingPoint();
+			expect(next).not.toBe(block.bindingPoint);
+			expect(next).not.toBe(
+				renderer.batchers.get("litMesh").lightBlock.bindingPoint,
+			);
+		});
+
+		it("holds its binding point when init re-runs", (ctx) => {
+			requireWebGL(ctx, renderer);
+			// `init()` re-runs on every context restore. Claiming a fresh point
+			// each time would walk through the device's budget over a long
+			// session and eventually throw, for a resource the batcher already
+			// owns.
+			const batcher = renderer.batchers.get("litQuad");
+			const before = batcher.lightBlock.bindingPoint;
+			batcher.init(renderer);
+			batcher.init(renderer);
+			expect(batcher.lightBlock.bindingPoint).toBe(before);
+		});
+
 		it("does not share a binding point with the 3D block", (ctx) => {
 			requireWebGL(ctx, renderer);
 			// both can be live in one frame (lit sprites over a lit mesh); the


### PR DESCRIPTION
Follow-up to #1552, from that PR's review. Internal only — **no behaviour change**.

## What

Uniform buffer binding points were two literals in the lighting module (`LIGHT2D_BINDING_POINT`, `LIGHT3D_BINDING_POINT`). They are a *context-wide* namespace, not a lighting concern: two blocks sharing a point silently overwrite each other, and the loser reads the winner's bytes as its own data. A third block would have had to grep for a free integer, and a collision would not have been caught.

`WebGLRenderer.reserveUniformBindingPoint()` now hands them out — the same shape as `TextureCache.reserveUnit()` for texture units — and throws when the device's `MAX_UNIFORM_BUFFER_BINDINGS` is exhausted rather than binding out of range.

Both lit batchers claim once and hold it. `init()` re-runs on every context restore, so re-claiming each time would walk through the budget over a long session; the test for that is mutation-verified (changing `??=` to `=` fails it).

The points handed out are 0 and 1, exactly what the constants held.

Two things worth knowing:

- The counter has to be initialised *before* the batchers are constructed — they're built in the same constructor, and a later assignment left the first claim `undefined`. Caught by a test, not by review.
- **Point 0 stays occupied deliberately.** Leaving it free looks like a fail-safe (a forgotten binding would read zeroes rather than someone else's data) but isn't: an *active* uniform block with no buffer bound is `INVALID_OPERATION` at draw time, taking the whole program down. Tried it during the #1552 review; it broke two adversarial tests.

## The two follow-ups I did NOT do

Both were investigated and rejected on measurement. Recording the numbers so the question doesn't get reopened from scratch.

**Gate the per-draw light pack.** Can't be done safely. The cheap gate — re-arm from `RENDER_TARGET_CHANGED`, matching the depth-clear cadence — leaves a mid-frame light change stale, which is the bug #1552 fixed. The guard test (`lighting_block_wiring.spec.js` → "picks up a light change between draws with no batcher switch") catches it.

**Collapse the SoA → AoS double pass in the packers.** Measured on the lit mesh path, per draw:

| lights | pack | second pass | total |
| --- | --- | --- | --- |
| 1 | 24 ns | 10 ns | 50 ns |
| 8 | 113 ns | 31 ns | 188 ns |
| 32 | 413 ns | 102 ns | 650 ns |

~100 ns at the cap, against rewriting ~49 stride-indexed assertions in `lights.spec.js` that currently catch real regressions. Its correctness argument — "two places must agree what light *i* means" — is already covered: the layout is pinned against both hand-written and driver-reported offsets.

**And the reason neither matters:** GPU cost of the lit fragment shader, full-screen quad at 1280×720, ANGLE Metal on an Apple M4 Max —

| lights | ms per full-screen lit pass |
| --- | --- |
| 0 | 0.017 |
| 8 | 0.042 |
| 16 | 0.075 |
| 32 | 0.14 |

Every light was given a screen-covering radius, so this is the worst case for brute force — and therefore the **ceiling** on what tiled light culling could ever recover: **0.11 ms/frame, 0.7% of a 60 fps budget**. Not worth a light-list texture and a per-frame binning pass.

Caveats on those numbers: wall-clock around 60 draws with a `readPixels` sync rather than the timer query (which was available), `performance.now()` clamped to 100 µs so ~±1% at 0.14 ms and ~±10% at 0.017 ms, and an M4 Max is near the top end — a low-end mobile GPU could be 10–30× slower, which would change the conclusion. Worth redoing on real hardware if mobile many-light scenes ever become a goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvxaXQRgQn5AoR8DNkv6Wg
