### PR TITLE
Fix the CI WebGL flake, the silent-skip pattern, and a camera-effect double-destroy bug

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [20.0.1] (melonJS 2) - _unreleased_
+
+### Fixed
+- `FadeEffect.destroy()` and `MaskEffect.destroy()` threw "Instance is already in pool" when called twice. Neither guarded its pooled `tween`, `color` or mask shape before releasing them, so a second call re-released the same instances. This is reachable without doing anything unusual: `removePostEffect()` destroys the effect it removes, so a caller that also destroys it explicitly gets a throw from the pool rather than from anything in their own code. Both are now guarded and cleared, matching the `Body.destroy()` fix in 20.0.0
+
+
 ## [20.0.0] (melonJS 2) - _2026-08-21_
 
 **Highlights:** version 20.0 introduces a new **WebGPU backend** and retires the aging WebGL 1 path, making **WebGL 2** the baseline and putting melonJS on a modern, top-of-the-line rendering stack. `video.AUTO` now tries WebGPU first, falls back to WebGL 2 if that is unavailable, and ultimately to Canvas. The new backend covers the entire engine feature set, 2D and 3D, verified example-for-example against WebGL, and the WebGL 2 baseline lets that backend modernize throughout: immutable texture storage, vertex array objects, uniform-buffer lighting (up to **32 lights**), and a multi-texture limit that follows the device instead of a hardcoded 16. 3D gains real depth: **mesh instancing** (a 100 000-tree forest in one draw call), **ground shadows**, **point and spot lights**, **`Box3d` collision** that resolves along Z, and retained meshes that upload once and never re-transform on the CPU. Custom shaders and post effects are **dual-language**: one asset carries GLSL and WGSL and runs on either backend. Measured against 19.9.1 on the same machine, the two paths 20.0 reworked come out **up to 75× faster once a scene uses more distinct textures than the batch limit** (4.71 → 0.06 ms/frame, and 1 626 texture uploads per frame → none) and **up to 95× faster at submitting vertex-heavy meshes** (3.80 → 0.04 ms/frame).

--- a/packages/melonjs/src/camera/effects/fade_effect.ts
+++ b/packages/melonjs/src/camera/effects/fade_effect.ts
@@ -111,8 +111,20 @@ export default class FadeEffect extends CameraEffect {
 	}
 
 	override destroy(): void {
-		this.tween.stop();
-		tweenPool.release(this.tween);
-		colorPool.release(this.color);
+		// Guarded and cleared so a second destroy() is a no-op rather than a
+		// throw. `removePostEffect()` destroys the effect it removes, so a
+		// caller that also destroys it explicitly hits this path, and an
+		// unguarded re-release throws "Instance is already in pool" from the
+		// pool rather than from anything the caller can see. Same defect and
+		// same fix as `Body.destroy()` in 20.0.0.
+		if (this.tween !== undefined) {
+			this.tween.stop();
+			tweenPool.release(this.tween);
+			this.tween = undefined as unknown as typeof this.tween;
+		}
+		if (this.color !== undefined) {
+			colorPool.release(this.color);
+			this.color = undefined as unknown as typeof this.color;
+		}
 	}
 }

--- a/packages/melonjs/src/camera/effects/mask_effect.ts
+++ b/packages/melonjs/src/camera/effects/mask_effect.ts
@@ -181,13 +181,24 @@ export default class MaskEffect extends CameraEffect {
 	}
 
 	override destroy(): void {
-		this.tween.stop();
-		tweenPool.release(this.tween);
-		colorPool.release(this.color);
-		if (this._maskShape.type === "Ellipse") {
-			ellipsePool.release(this._maskShape as Ellipse);
-		} else {
-			polygonPool.release(this._maskShape as Polygon);
+		// see FadeEffect.destroy(): guarded so a second call is a no-op instead
+		// of throwing "Instance is already in pool" out of the pool
+		if (this.tween !== undefined) {
+			this.tween.stop();
+			tweenPool.release(this.tween);
+			this.tween = undefined as unknown as typeof this.tween;
+		}
+		if (this.color !== undefined) {
+			colorPool.release(this.color);
+			this.color = undefined as unknown as typeof this.color;
+		}
+		if (this._maskShape !== undefined) {
+			if (this._maskShape.type === "Ellipse") {
+				ellipsePool.release(this._maskShape as Ellipse);
+			} else {
+				polygonPool.release(this._maskShape as Polygon);
+			}
+			this._maskShape = undefined as unknown as typeof this._maskShape;
 		}
 	}
 }

--- a/packages/melonjs/tests/audio.spec.js
+++ b/packages/melonjs/tests/audio.spec.js
@@ -218,11 +218,14 @@ describe("audio", () => {
 			}).not.toThrow();
 		});
 
-		it("tone schedules nodes on the shared context (when available)", () => {
+		it("tone schedules nodes on the shared context (when available)", (t) => {
 			const ctx = audio.getAudioContext();
 			if (!ctx) {
+				// headless env has no WebAudio: skip VISIBLY, a bare return
+				// reports as a pass and hides the assertions below
+				t.skip("WebAudio not available in this environment");
 				return;
-			} // headless env — skip the WebAudio assertions
+			}
 			const before = ctx.currentTime;
 			audio.tone({ freq: 880, duration: 0.05 });
 			// Time should keep advancing — sanity check we didn't blow
@@ -291,9 +294,12 @@ describe("audio", () => {
 			}).not.toThrow();
 		});
 
-		it("noise schedules nodes on the shared context (when available)", () => {
+		it("noise schedules nodes on the shared context (when available)", (t) => {
 			const ctx = audio.getAudioContext();
 			if (!ctx) {
+				// headless env has no WebAudio: skip VISIBLY, a bare return
+				// reports as a pass and hides the assertions below
+				t.skip("WebAudio not available in this environment");
 				return;
 			}
 			const before = ctx.currentTime;
@@ -302,9 +308,12 @@ describe("audio", () => {
 			expect(ctx.currentTime).toBeGreaterThanOrEqual(before);
 		});
 
-		it("noise respects muteAll / unmuteAll (routes through master gain)", () => {
+		it("noise respects muteAll / unmuteAll (routes through master gain)", (t) => {
 			const ctx = audio.getAudioContext();
 			if (!ctx) {
+				// headless env has no WebAudio: skip VISIBLY, a bare return
+				// reports as a pass and hides the assertions below
+				t.skip("WebAudio not available in this environment");
 				return;
 			}
 			audio.muteAll();

--- a/packages/melonjs/tests/camera.spec.js
+++ b/packages/melonjs/tests/camera.spec.js
@@ -1220,8 +1220,17 @@ describe("Camera2d", () => {
 				color: "#000",
 				duration: 500,
 			});
-			// should not throw
-			effect.destroy();
+			// The name promises resources are RELEASED, so assert something about
+			// release rather than leaving a bare call whose only failure mode is
+			// a throw. Destroy twice: a pooled resource handed back correctly can
+			// be handed back again without the pool rejecting it, which is what
+			// double-release regressions actually look like.
+			expect(() => {
+				effect.destroy();
+			}).not.toThrow();
+			expect(() => {
+				effect.destroy();
+			}).not.toThrow();
 		});
 	});
 
@@ -1333,8 +1342,17 @@ describe("Camera2d", () => {
 				color: "#000",
 				duration: 500,
 			});
-			// should not throw
-			effect.destroy();
+			// The name promises resources are RELEASED, so assert something about
+			// release rather than leaving a bare call whose only failure mode is
+			// a throw. Destroy twice: a pooled resource handed back correctly can
+			// be handed back again without the pool rejecting it, which is what
+			// double-release regressions actually look like.
+			expect(() => {
+				effect.destroy();
+			}).not.toThrow();
+			expect(() => {
+				effect.destroy();
+			}).not.toThrow();
 		});
 
 		it("isPersistent should default to false", () => {

--- a/packages/melonjs/tests/clipRect.spec.js
+++ b/packages/melonjs/tests/clipRect.spec.js
@@ -638,8 +638,9 @@ describe("CanvasRenderer.clipRect (#1349)", () => {
 		};
 	}
 
-	it("clipRect under identity transform: clip path matches the input rect", () => {
+	it("clipRect under identity transform: clip path matches the input rect", (ctx) => {
 		if (!isCanvas) {
+			ctx.skip("Canvas renderer not active in this environment");
 			return;
 		}
 		// reset the scissor cache so the call doesn't get short-circuited
@@ -656,8 +657,9 @@ describe("CanvasRenderer.clipRect (#1349)", () => {
 		expect(screen.y).toBe(100);
 	});
 
-	it("clipRect under a translated transform: clip lands at translated screen rect", () => {
+	it("clipRect under a translated transform: clip lands at translated screen rect", (ctx) => {
 		if (!isCanvas) {
+			ctx.skip("Canvas renderer not active in this environment");
 			return;
 		}
 		renderer.save();
@@ -682,8 +684,9 @@ describe("CanvasRenderer.clipRect (#1349)", () => {
 		expect(screen.y).toBe(230);
 	});
 
-	it("Bug #1349 (fixed): Container nested in a translated wrapper produces a correctly-placed clip path", () => {
+	it("Bug #1349 (fixed): Container nested in a translated wrapper produces a correctly-placed clip path", (ctx) => {
 		if (!isCanvas) {
+			ctx.skip("Canvas renderer not active in this environment");
 			return;
 		}
 		// reproducer mirrors the WebGL Bug #1 test above, and the visual

--- a/packages/melonjs/tests/drawmesh_bench.spec.js
+++ b/packages/melonjs/tests/drawmesh_bench.spec.js
@@ -214,7 +214,14 @@ describe("drawMesh benchmark (baseline for #1468)", () => {
 		);
 	};
 
-	it("baseline cost across mesh counts", () => {
+	it("baseline cost across mesh counts", (ctx) => {
+		// `measure()` below logs and returns when there is no WebGL, which
+		// reports as a PASS — a benchmark that never ran then looks exactly
+		// like one that did. Decide it once, visibly, up front.
+		if (!(renderer instanceof WebGLRenderer)) {
+			ctx.skip("Canvas renderer — drawMesh benchmark not applicable");
+			return;
+		}
 		// Frame counts chosen so total drawMesh calls stays in the same
 		// ballpark (~1500-3000), making per-mesh cost the dominant signal
 		// rather than per-frame fixed overhead.

--- a/packages/melonjs/tests/renderTarget.spec.js
+++ b/packages/melonjs/tests/renderTarget.spec.js
@@ -1,9 +1,13 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { boot } from "../src/index.js";
 import CanvasRenderTarget from "../src/video/rendertarget/canvasrendertarget.js";
 import RenderTarget from "../src/video/rendertarget/rendertarget.ts";
 import WebGLRenderTarget from "../src/video/rendertarget/webglrendertarget.js";
-import { getWebGLRenderer } from "./helpers/webgl-context.js";
+import {
+	getWebGLRenderer,
+	releaseWebGLRenderer,
+	requireWebGL,
+} from "./helpers/webgl-context.js";
 
 describe("RenderTarget", () => {
 	describe("CanvasRenderTarget", () => {
@@ -62,12 +66,16 @@ describe("RenderTarget", () => {
 	describe("WebGLRenderTarget", () => {
 		let gl;
 
-		beforeEach(async () => {
+		beforeAll(async () => {
 			boot();
-			// `video.WEBGL` now throws when WebGL is unavailable (was a
-			// silent Canvas fallback pre-#1479). Catch the throw so tests
-			// that gracefully handle `gl === undefined` still skip
-			// cleanly instead of crashing every test in this block.
+			// `video.WEBGL` throws when WebGL is unavailable (was a silent
+			// Canvas fallback pre-#1479). Catch the throw so `gl` stays
+			// undefined and every test below skips VISIBLY via requireWebGL,
+			// rather than crashing the block.
+			//
+			// beforeAll, not beforeEach: the helper hands out one context per
+			// file, so re-acquiring per test bought nothing and put context
+			// acquisition on the critical path of all nine.
 			try {
 				const shared = await getWebGLRenderer(100, 100);
 				gl = shared?.gl;
@@ -76,30 +84,30 @@ describe("RenderTarget", () => {
 			}
 		});
 
-		it("should extend RenderTarget", () => {
-			if (!gl) {
-				return;
-			}
+		afterAll(() => {
+			// this file borrowed the shared renderer and never handed it back,
+			// so the next spec in the page inherited its state
+			releaseWebGLRenderer();
+		});
+
+		it("should extend RenderTarget", (ctx) => {
+			requireWebGL(ctx, gl);
 			const rt = new WebGLRenderTarget(gl, 100, 100);
 			expect(rt).toBeInstanceOf(RenderTarget);
 			expect(rt).toBeInstanceOf(WebGLRenderTarget);
 			rt.destroy();
 		});
 
-		it("should have correct width and height", () => {
-			if (!gl) {
-				return;
-			}
+		it("should have correct width and height", (ctx) => {
+			requireWebGL(ctx, gl);
 			const rt = new WebGLRenderTarget(gl, 200, 150);
 			expect(rt.width).toEqual(200);
 			expect(rt.height).toEqual(150);
 			rt.destroy();
 		});
 
-		it("should create valid framebuffer and texture", () => {
-			if (!gl) {
-				return;
-			}
+		it("should create valid framebuffer and texture", (ctx) => {
+			requireWebGL(ctx, gl);
 			const rt = new WebGLRenderTarget(gl, 100, 100);
 			expect(rt.framebuffer).toBeDefined();
 			expect(rt.texture).toBeDefined();
@@ -107,10 +115,8 @@ describe("RenderTarget", () => {
 			rt.destroy();
 		});
 
-		it("should bind and unbind", () => {
-			if (!gl) {
-				return;
-			}
+		it("should bind and unbind", (ctx) => {
+			requireWebGL(ctx, gl);
 			const rt = new WebGLRenderTarget(gl, 100, 100);
 			rt.bind();
 			expect(gl.getParameter(gl.FRAMEBUFFER_BINDING)).toBe(rt.framebuffer);
@@ -119,10 +125,8 @@ describe("RenderTarget", () => {
 			rt.destroy();
 		});
 
-		it("should resize", () => {
-			if (!gl) {
-				return;
-			}
+		it("should resize", (ctx) => {
+			requireWebGL(ctx, gl);
 			const rt = new WebGLRenderTarget(gl, 100, 100);
 			rt.resize(200, 200);
 			expect(rt.width).toEqual(200);
@@ -130,10 +134,8 @@ describe("RenderTarget", () => {
 			rt.destroy();
 		});
 
-		it("should skip resize when dimensions unchanged", () => {
-			if (!gl) {
-				return;
-			}
+		it("should skip resize when dimensions unchanged", (ctx) => {
+			requireWebGL(ctx, gl);
 			const rt = new WebGLRenderTarget(gl, 100, 100);
 			const texture = rt.texture;
 			rt.resize(100, 100);
@@ -142,10 +144,8 @@ describe("RenderTarget", () => {
 			rt.destroy();
 		});
 
-		it("should clear without error", () => {
-			if (!gl) {
-				return;
-			}
+		it("should clear without error", (ctx) => {
+			requireWebGL(ctx, gl);
 			const rt = new WebGLRenderTarget(gl, 100, 100);
 			expect(() => {
 				rt.clear();
@@ -153,10 +153,8 @@ describe("RenderTarget", () => {
 			rt.destroy();
 		});
 
-		it("should return valid ImageData from getImageData", () => {
-			if (!gl) {
-				return;
-			}
+		it("should return valid ImageData from getImageData", (ctx) => {
+			requireWebGL(ctx, gl);
 			const rt = new WebGLRenderTarget(gl, 50, 50);
 			const data = rt.getImageData(0, 0, 50, 50);
 			expect(data).toBeInstanceOf(ImageData);
@@ -165,10 +163,8 @@ describe("RenderTarget", () => {
 			rt.destroy();
 		});
 
-		it("should destroy and null out resources", () => {
-			if (!gl) {
-				return;
-			}
+		it("should destroy and null out resources", (ctx) => {
+			requireWebGL(ctx, gl);
 			const rt = new WebGLRenderTarget(gl, 100, 100);
 			rt.destroy();
 			expect(rt.framebuffer).toBeNull();

--- a/packages/melonjs/tests/renderTargetPool.spec.js
+++ b/packages/melonjs/tests/renderTargetPool.spec.js
@@ -5,6 +5,7 @@ import WebGLRenderTarget from "../src/video/rendertarget/webglrendertarget.js";
 import {
 	getWebGLRenderer,
 	releaseWebGLRenderer,
+	requireWebGL,
 } from "./helpers/webgl-context.js";
 
 describe("RenderTargetPool", () => {
@@ -207,10 +208,8 @@ describe("RenderTargetPool", () => {
 			releaseWebGLRenderer();
 		});
 
-		it("should work with WebGLRenderTarget factory", () => {
-			if (sharedRenderer === undefined) {
-				return;
-			}
+		it("should work with WebGLRenderTarget factory", (ctx) => {
+			requireWebGL(ctx, sharedRenderer);
 			const gl = sharedRenderer.gl;
 			const glPool = new RenderTargetPool((w, h) => {
 				return new WebGLRenderTarget(gl, w, h);
@@ -227,10 +226,8 @@ describe("RenderTargetPool", () => {
 			glPool.destroy();
 		});
 
-		it("should reuse target on subsequent get at same index", () => {
-			if (sharedRenderer === undefined) {
-				return;
-			}
+		it("should reuse target on subsequent get at same index", (ctx) => {
+			requireWebGL(ctx, sharedRenderer);
 			const gl = sharedRenderer.gl;
 			const glPool = new RenderTargetPool((w, h) => {
 				return new WebGLRenderTarget(gl, w, h);
@@ -243,10 +240,8 @@ describe("RenderTargetPool", () => {
 			glPool.destroy();
 		});
 
-		it("should resize target when dimensions change", () => {
-			if (sharedRenderer === undefined) {
-				return;
-			}
+		it("should resize target when dimensions change", (ctx) => {
+			requireWebGL(ctx, sharedRenderer);
 			const gl = sharedRenderer.gl;
 			const glPool = new RenderTargetPool((w, h) => {
 				return new WebGLRenderTarget(gl, w, h);

--- a/packages/melonjs/tests/renderable.spec.js
+++ b/packages/melonjs/tests/renderable.spec.js
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	Application,
 	boot,
@@ -369,10 +369,16 @@ describe("Renderable", () => {
 			renderable.addPostEffect({ enabled: true });
 			renderable.addPostEffect({ enabled: true });
 
-			// on Canvas renderer, beginPostEffect returns false (no-op)
-			// but the code path should be exercised without error
+			// On the Canvas renderer beginPostEffect returns false (no-op), so the
+			// only thing observable here is that it was REACHED. The test is named
+			// for that, so assert it: previously the body just called preDraw and
+			// postDraw and asserted nothing, passing whether or not the effect
+			// path ran at all.
+			const beginSpy = vi.spyOn(renderer, "beginPostEffect");
 			renderable.preDraw(renderer);
 			renderable.postDraw(renderer);
+			expect(beginSpy).toHaveBeenCalled();
+			beginSpy.mockRestore();
 		});
 
 		it("clearPostEffects should remove all and destroy", () => {

--- a/packages/melonjs/tests/renderer_save_restore.spec.js
+++ b/packages/melonjs/tests/renderer_save_restore.spec.js
@@ -1,5 +1,10 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Application, boot, video } from "../src/index.js";
+import {
+	getWebGLRenderer,
+	releaseWebGLRenderer,
+	requireWebGL,
+} from "./helpers/webgl-context.js";
 
 /**
  * Tests for renderer save/restore through the public API.
@@ -32,15 +37,6 @@ describe("Renderer save/restore", () => {
 		renderer.setGlobalAlpha(1.0);
 		renderer.setBlendMode("normal");
 		renderer.clearTint();
-	});
-
-	afterAll(async () => {
-		const app = new Application(800, 600, {
-			parent: "screen",
-			scale: "auto",
-			renderer: video.CANVAS,
-		});
-		await app.init();
 	});
 
 	// ---- Color ----
@@ -212,52 +208,65 @@ describe("Renderer save/restore", () => {
 	// save/restore natively; currentScissor is just a dedup cache there.
 	// These tests only apply to WebGL where we manage scissor state ourselves.
 
-	it("should preserve scissor state across save/restore (WebGL only)", () => {
-		if (renderer.type !== "WebGL") {
-			return;
-		}
+	describe("scissor state (WebGL)", () => {
+		// These two used to live in the outer describe behind
+		// `if (renderer.type !== "WebGL") return;`. That describe only ever
+		// builds a CANVAS renderer, so the guard was always true and both tests
+		// returned immediately — reported as passing, never once executed. They
+		// now get a real WebGL renderer, and skip VISIBLY when there is none.
+		let glRenderer;
 
-		renderer.clipRect(50, 60, 200, 150);
-		const scissorBefore = Array.from(renderer.currentScissor);
+		beforeAll(async () => {
+			glRenderer = await getWebGLRenderer();
+		});
 
-		renderer.save();
-		renderer.clipRect(10, 20, 100, 80);
-		expect(renderer.currentScissor[0]).toBe(10);
-		expect(renderer.currentScissor[1]).toBe(20);
-		renderer.restore();
+		afterAll(() => {
+			releaseWebGLRenderer();
+		});
 
-		expect(renderer.currentScissor[0]).toBe(scissorBefore[0]);
-		expect(renderer.currentScissor[1]).toBe(scissorBefore[1]);
-		expect(renderer.currentScissor[2]).toBe(scissorBefore[2]);
-		expect(renderer.currentScissor[3]).toBe(scissorBefore[3]);
-	});
+		it("preserves scissor state across save/restore", (ctx) => {
+			requireWebGL(ctx, glRenderer);
 
-	it("should preserve scissor through nested save/restore (WebGL only)", () => {
-		if (renderer.type !== "WebGL") {
-			return;
-		}
+			glRenderer.clipRect(50, 60, 200, 150);
+			const scissorBefore = Array.from(glRenderer.currentScissor);
 
-		renderer.clipRect(10, 20, 300, 250);
-		const scissor0 = Array.from(renderer.currentScissor);
+			glRenderer.save();
+			glRenderer.clipRect(10, 20, 100, 80);
+			expect(glRenderer.currentScissor[0]).toBe(10);
+			expect(glRenderer.currentScissor[1]).toBe(20);
+			glRenderer.restore();
 
-		renderer.save();
-		renderer.clipRect(50, 60, 100, 80);
-		const scissor1 = Array.from(renderer.currentScissor);
+			expect(glRenderer.currentScissor[0]).toBe(scissorBefore[0]);
+			expect(glRenderer.currentScissor[1]).toBe(scissorBefore[1]);
+			expect(glRenderer.currentScissor[2]).toBe(scissorBefore[2]);
+			expect(glRenderer.currentScissor[3]).toBe(scissorBefore[3]);
+		});
 
-		renderer.save();
-		renderer.clipRect(70, 80, 50, 40);
+		it("preserves scissor through nested save/restore", (ctx) => {
+			requireWebGL(ctx, glRenderer);
 
-		renderer.restore();
-		expect(renderer.currentScissor[0]).toBe(scissor1[0]);
-		expect(renderer.currentScissor[1]).toBe(scissor1[1]);
-		expect(renderer.currentScissor[2]).toBe(scissor1[2]);
-		expect(renderer.currentScissor[3]).toBe(scissor1[3]);
+			glRenderer.clipRect(10, 20, 300, 250);
+			const scissor0 = Array.from(glRenderer.currentScissor);
 
-		renderer.restore();
-		expect(renderer.currentScissor[0]).toBe(scissor0[0]);
-		expect(renderer.currentScissor[1]).toBe(scissor0[1]);
-		expect(renderer.currentScissor[2]).toBe(scissor0[2]);
-		expect(renderer.currentScissor[3]).toBe(scissor0[3]);
+			glRenderer.save();
+			glRenderer.clipRect(50, 60, 100, 80);
+			const scissor1 = Array.from(glRenderer.currentScissor);
+
+			glRenderer.save();
+			glRenderer.clipRect(70, 80, 50, 40);
+
+			glRenderer.restore();
+			expect(glRenderer.currentScissor[0]).toBe(scissor1[0]);
+			expect(glRenderer.currentScissor[1]).toBe(scissor1[1]);
+			expect(glRenderer.currentScissor[2]).toBe(scissor1[2]);
+			expect(glRenderer.currentScissor[3]).toBe(scissor1[3]);
+
+			glRenderer.restore();
+			expect(glRenderer.currentScissor[0]).toBe(scissor0[0]);
+			expect(glRenderer.currentScissor[1]).toBe(scissor0[1]);
+			expect(glRenderer.currentScissor[2]).toBe(scissor0[2]);
+			expect(glRenderer.currentScissor[3]).toBe(scissor0[3]);
+		});
 	});
 
 	// ---- Color alpha channel ----

--- a/packages/melonjs/tests/text_bucket.spec.js
+++ b/packages/melonjs/tests/text_bucket.spec.js
@@ -21,7 +21,9 @@ describe("Text — 32px canvas buckets", () => {
 	let renderer;
 
 	beforeAll(async () => {
-		renderer = await getWebGLRenderer(320, 240);
+		// default 128x128: this suite issues no renderer draws at all (Text bakes
+		// into its own offscreen canvases) and never reads the dimensions
+		renderer = await getWebGLRenderer();
 	});
 
 	afterAll(() => {

--- a/packages/melonjs/tests/texturecache-batcher-reset.spec.js
+++ b/packages/melonjs/tests/texturecache-batcher-reset.spec.js
@@ -46,7 +46,12 @@ describe("GPU texture cache reset (cross-batcher binding-tracker regression)", (
 	let quadBatcher;
 
 	beforeAll(async () => {
-		renderer = await getWebGLRenderer(800, 600);
+		// The default 128x128 canvas, deliberately: this suite issues ZERO draw
+		// calls and never reads the canvas dimensions. It inspects `renderer.cache`,
+		// the batcher registry and `currentBatcher`. Asking for 800x600 allocated a
+		// 480 000-pixel framebuffer for nothing, which on CI's software rasterizer
+		// is real time and memory, in the hook that was timing out.
+		renderer = await getWebGLRenderer();
 	});
 
 	afterAll(() => {

--- a/packages/melonjs/tests/video-upload-gating.spec.js
+++ b/packages/melonjs/tests/video-upload-gating.spec.js
@@ -38,7 +38,10 @@ describe("Video texture upload gating (WebGL)", () => {
 	beforeAll(async () => {
 		boot();
 		try {
-			renderer = await getWebGLRenderer(800, 600);
+			// default 128x128: every draw here is a 32x32 quad and the canvas
+			// dimensions are never referenced, so 800x600 allocated a 480 000-pixel
+			// software framebuffer for nothing
+			renderer = await getWebGLRenderer();
 			webglReady = renderer instanceof WebGLRenderer;
 		} catch {
 			// CI runners without GL acceleration can't construct a WebGL

--- a/packages/melonjs/tests/webgl_required_check.spec.js
+++ b/packages/melonjs/tests/webgl_required_check.spec.js
@@ -26,20 +26,46 @@ import * as video from "../src/video/video.js";
  *   Application doesn't need to import the concrete `Camera3d` class.
  */
 describe("Application: WebGL requirements fail loudly (#1479)", () => {
+	/** every Application a test builds, torn down in afterEach */
+	const built = [];
+
+	/**
+	 * Construct an Application and register it for teardown.
+	 * @param {object} settings - Application settings
+	 * @returns {Application} the tracked instance
+	 */
+	const make = (settings) => {
+		const app = new Application(64, 64, settings);
+		built.push(app);
+		return app;
+	};
+
 	beforeAll(async () => {
 		await boot();
 	});
 
-	afterEach(async () => {
-		// Reset the video subsystem so each test starts in a clean state.
-		try {
-			const app = new Application(64, 64, {
-				parent: "screen",
-				renderer: video.CANVAS,
-			});
-			await app.init();
-		} catch {
-			// best-effort reset
+	afterEach(() => {
+		// Tear down every Application a test built.
+		//
+		// This used to "reset the video subsystem" by constructing YET ANOTHER
+		// Application per test and leaving it live, so a file with 8 tests ended
+		// up holding ~18 applications, each with its own canvas and (for the
+		// WebGL ones) its own GL context, none of them released. Spec files are
+		// page-isolated so it could not leak into other files, but it was real
+		// pressure inside this one, on a CI runner whose GL is a software
+		// rasterizer.
+		//
+		// Since 20.0 `destroy()` is the honest reset: it releases the GL context
+		// through WEBGL_lose_context and unregisters the renderer's event
+		// handlers. A destroyed Application is terminal, which is fine here
+		// because every test constructs its own.
+		for (const app of built.splice(0)) {
+			try {
+				app.destroy();
+			} catch {
+				// a test may have left it half-built on purpose (the throwing
+				// and rejecting paths below); nothing to release in that case
+			}
 		}
 	});
 
@@ -51,7 +77,7 @@ describe("Application: WebGL requirements fail loudly (#1479)", () => {
 			// regardless, the Application succeeds → skip; the throw
 			// path is exercised wherever WebGL genuinely fails.
 			try {
-				const app = new Application(64, 64, {
+				const app = make({
 					parent: "screen",
 					renderer: video.WEBGL,
 					failIfMajorPerformanceCaveat: true,
@@ -71,7 +97,7 @@ describe("Application: WebGL requirements fail loudly (#1479)", () => {
 			// disagree — pre-20.0 the gate probed WebGL 1 while construction
 			// preferred WebGL 2.
 			if (device.isWebGLSupported()) {
-				const app = new Application(64, 64, {
+				const app = make({
 					parent: "screen",
 					renderer: video.WEBGL,
 					consoleHeader: false,
@@ -83,7 +109,7 @@ describe("Application: WebGL requirements fail loudly (#1479)", () => {
 					globalThis.WebGL2RenderingContext,
 				);
 			} else {
-				const app = new Application(64, 64, {
+				const app = make({
 					parent: "screen",
 					renderer: video.WEBGL,
 					consoleHeader: false,
@@ -97,7 +123,7 @@ describe("Application: WebGL requirements fail loudly (#1479)", () => {
 		it("renderer: video.AUTO falls back to Canvas silently (preserved behaviour)", async () => {
 			// AUTO is the documented fallback path. The same conditions
 			// that make `video.WEBGL` throw must NOT cause AUTO to reject.
-			const app = new Application(64, 64, {
+			const app = make({
 				parent: "screen",
 				renderer: video.AUTO,
 				failIfMajorPerformanceCaveat: true,
@@ -133,7 +159,7 @@ describe("Application: WebGL requirements fail loudly (#1479)", () => {
 
 		it("warns when cameraClass is Camera3d but renderer is Canvas", async () => {
 			warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			const app = new Application(64, 64, {
+			const app = make({
 				parent: "screen",
 				renderer: video.CANVAS,
 				cameraClass: Camera3d,
@@ -146,7 +172,7 @@ describe("Application: WebGL requirements fail loudly (#1479)", () => {
 
 		it("warn message points the user at video.WEBGL", async () => {
 			warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			const app = new Application(64, 64, {
+			const app = make({
 				parent: "screen",
 				renderer: video.CANVAS,
 				cameraClass: Camera3d,
@@ -158,7 +184,7 @@ describe("Application: WebGL requirements fail loudly (#1479)", () => {
 		it("subclass of Camera3d (inheriting defaultSortOn='depth') also warns on Canvas", async () => {
 			class MyCamera3d extends Camera3d {}
 			warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			const app = new Application(64, 64, {
+			const app = make({
 				parent: "screen",
 				renderer: video.CANVAS,
 				cameraClass: MyCamera3d,
@@ -172,7 +198,7 @@ describe("Application: WebGL requirements fail loudly (#1479)", () => {
 				static defaultSortOn = "z";
 			}
 			warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			const app = new Application(64, 64, {
+			const app = make({
 				parent: "screen",
 				renderer: video.CANVAS,
 				cameraClass: MyCam2d,
@@ -183,7 +209,7 @@ describe("Application: WebGL requirements fail loudly (#1479)", () => {
 
 		it("no cameraClass setting + Canvas renderer is silent (legacy default)", async () => {
 			warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			const app = new Application(64, 64, {
+			const app = make({
 				parent: "screen",
 				renderer: video.CANVAS,
 			});

--- a/packages/melonjs/tests/webgl_save_restore_bench.spec.js
+++ b/packages/melonjs/tests/webgl_save_restore_bench.spec.js
@@ -27,10 +27,12 @@ describe("WebGL save/restore benchmark", () => {
 		app?.destroy();
 	});
 
-	it("benchmark: 1000 sprites × 60 frames save/restore cycle", () => {
+	it("benchmark: 1000 sprites × 60 frames save/restore cycle", (ctx) => {
 		const isWebGL = renderer instanceof WebGLRenderer;
 		if (!isWebGL) {
-			console.log("[BENCH] Skipped — Canvas renderer (WebGL not available)");
+			// a console.log and a bare return reports as a PASS, so a benchmark
+			// that never ran looks identical to one that did
+			ctx.skip("Canvas renderer — WebGL benchmark not applicable");
 			return;
 		}
 

--- a/packages/melonjs/vitest.config.ts
+++ b/packages/melonjs/vitest.config.ts
@@ -45,6 +45,22 @@ export default defineConfig(() =>
 			// hook, not a hanging one. (`video.init` no longer exists; a context
 			// comes from `new Application(...)` + `await app.init()`.)
 			hookTimeout: 90000,
+			// CI is a 4-core runner with no GPU, so every browser page rasterizes
+			// through SwiftShader on the same cores vitest schedules files on. At the
+			// default worker count (roughly one per core) four pages compete for four
+			// cores while also driving software GL, and a `beforeAll` whose only job
+			// is to create a context can sit past the timeout above.
+			//
+			// The cost is contention, not the specs. Measured in isolation, the two
+			// that time out in CI are among the FASTEST in the suite
+			// (texturecache-batcher-reset 0.9s, renderTargetPool 1.2s), while
+			// webgl_pipeline_adversarial takes 7s and passes in the same run. File
+			// ordering is deterministic, which is why it is reproducibly those two:
+			// they are the ones that land in the congested window.
+			//
+			// Halving the workers on CI trades a little wall-clock for hooks that
+			// finish. Local runs (more cores, a real GPU) keep the default.
+			maxWorkers: process.env.CI ? 2 : undefined,
 			browser: {
 				enabled: true,
 				provider: playwright(),

--- a/packages/melonjs/vitest.config.ts
+++ b/packages/melonjs/vitest.config.ts
@@ -46,10 +46,10 @@ export default defineConfig(() =>
 			// comes from `new Application(...)` + `await app.init()`.)
 			hookTimeout: 90000,
 			// CI is a 4-core runner with no GPU, so every browser page rasterizes
-			// through SwiftShader on the same cores vitest schedules files on. At the
-			// default worker count (roughly one per core) four pages compete for four
-			// cores while also driving software GL, and a `beforeAll` whose only job
-			// is to create a context can sit past the timeout above.
+			// through SwiftShader on the same cores vitest schedules files on. The
+			// default is `min(12, availableParallelism - 1)`, i.e. 3 pages there, each
+			// also driving software GL, and a `beforeAll` whose only job is to create
+			// a context can sit past the timeout above.
 			//
 			// The cost is contention, not the specs. Measured in isolation, the two
 			// that time out in CI are among the FASTEST in the suite
@@ -58,8 +58,8 @@ export default defineConfig(() =>
 			// ordering is deterministic, which is why it is reproducibly those two:
 			// they are the ones that land in the congested window.
 			//
-			// Halving the workers on CI trades a little wall-clock for hooks that
-			// finish. Local runs (more cores, a real GPU) keep the default.
+			// Dropping 3 -> 2 on CI trades a little wall-clock for hooks that finish.
+			// Local runs (more cores, a real GPU) keep the default.
 			maxWorkers: process.env.CI ? 2 : undefined,
 			browser: {
 				enabled: true,

--- a/packages/melonjs/vitest.config.ts
+++ b/packages/melonjs/vitest.config.ts
@@ -60,7 +60,10 @@ export default defineConfig(() =>
 			//
 			// Dropping 3 -> 2 on CI trades a little wall-clock for hooks that finish.
 			// Local runs (more cores, a real GPU) keep the default.
-			maxWorkers: process.env.CI ? 2 : undefined,
+			// spread rather than `maxWorkers: CI ? 2 : undefined` — the config type
+			// is built with `exactOptionalPropertyTypes`, so an explicit `undefined`
+			// is a type error where an absent key is fine
+			...(process.env.CI ? { maxWorkers: 2 } : {}),
 			browser: {
 				enabled: true,
 				provider: playwright(),


### PR DESCRIPTION
Started as "why do two specs time out in CI", ended up also fixing two tests that had never run and one real engine bug.

## The CI flake

`renderTargetPool.spec.js` and `texturecache-batcher-reset.spec.js` intermittently failed with `Hook timed out in 90000ms` inside `getWebGLRenderer`. Same signature on [master, 2026-08-07](https://github.com/melonjs/melonJS/actions/runs/31175682155) and on the 20.0.0 release PR.

**It is not the specs.** In isolation they are among the fastest in the suite (0.86s and 1.23s), while `webgl_pipeline_adversarial` takes 7s and passes in the same run. Also ruled out: canvas size (six other specs use 800x600 and pass), position in the run (16th and 26th of 47), and a hung promise (`boot()` is synchronous, `WebGLRenderer.init` resolves immediately).

It is CPU contention. CI is a 4-core runner with no GPU, so every page rasterizes through SwiftShader on the cores vitest schedules files on. The failing run: 128.72s import + 358.37s test time against 237s wall. Vitest orders files deterministically, which is why the same two land in the congested window every time.

Fixes: cap CI at 2 workers (default there is 3, not 4 — `min(12, availableParallelism - 1)`), and stop three specs allocating framebuffers they never draw into.

| spec | was | now | why |
| --- | --- | --- | --- |
| `texturecache-batcher-reset` | 800x600 | 128x128 | **zero** draw calls, never reads the dimensions |
| `video-upload-gating` | 800x600 | 128x128 | every draw is a 32x32 quad |
| `text_bucket` | 320x240 | 128x128 | no renderer draws at all |

Benchmarks keep their canvas (published numbers). `clipRect`, `depth_adversarial` and `webgl_pipeline_adversarial` genuinely use their dimensions.

## Two tests that had never executed once

`renderer_save_restore.spec.js` guarded its two scissor tests with `if (renderer.type !== "WebGL") return;` — but that describe only ever builds a **Canvas** renderer, so the condition was always true. Both returned immediately and counted green from the day they were written. They now run against a real WebGL renderer and pass, so the engine was correct throughout; only the tests were dead.

## The silent-skip pattern, suite-wide

A bare `return` when a renderer is missing reports as a **PASS**. Converted everywhere it appeared:

| spec | count |
| --- | --- |
| `renderTarget` | 9 (the sibling of the file above, same guard in every test) |
| `renderer_save_restore` | 2 (the dead pair) |
| `renderTargetPool` | 3 |
| `audio` | 3 |
| `clipRect` | 3 |
| `drawmesh_bench`, `webgl_save_restore_bench` | 1 each |

A benchmark that silently passes is the worst case: it looks identical whether it ran or not. Left alone: `webgl_pipeline_adversarial`'s guard is in a `beforeEach`, and hooks cannot skip.

## Engine fix: camera effects threw on a second destroy()

`camera.spec.js` had two tests named "should release pooled resources on destroy" whose whole body was a bare `effect.destroy()` under a `// should not throw` comment. Writing the assertion the name promised turned them red:

```
Error: Instance is already in pool.
```

Neither `FadeEffect.destroy()` nor `MaskEffect.destroy()` guarded its pooled `tween`, `color` or mask shape before releasing, so a second call re-released the same instances. Reachable normally, since `removePostEffect()` destroys the effect it removes:

```js
effect.destroy();
camera.removePostEffect(effect);   // throws, from inside the pool
```

Both now guard and clear, matching the `Body.destroy()` fix shipped in 20.0.0. Opens a `20.0.1 - _unreleased_` CHANGELOG section.

Also fixed: `renderable.spec.js` "multiple effects should trigger beginPostEffect" asserted nothing at all; now spies on `beginPostEffect`.

## Audit negatives, on record

- 26 `it()` blocks have no direct `expect()`, but 23 delegate to assertion helpers that do assert (verified each). Only three were genuinely vacuous.
- No `it.skip` / `it.todo` / `describe.skip` anywhere.
- No other stale renderer-type guards; engine code uses `type.includes("WebGL")` / `startsWith("WebGL")`, which still match `"WebGL2"`.
- Spec file isolation confirmed empirically with a two-file probe, so none of the leaks crossed files.

## Gates

251 files / 6063 tests under `CI=1`, tsc clean, eslint 0 errors, biome clean.

**Caveat worth keeping:** an intermittent failure cannot be proven fixed by green runs. The worker cap and the framebuffer reduction both reduce the pressure, but this needs a few weeks of runs before it is genuinely closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVjYzf76AEU3wJk766JAQi