### PR TITLE
chore(release): 20.1.1

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [20.1.1] (melonJS 2) - _unreleased_
+## [20.1.1] (melonJS 2) - _2026-08-25_
 
 ### Fixed
 - **A font whose filename contained a space failed to preload.** The `fontface` parser wrapped a bare path as `url(<path>)` with no quotes, and an unquoted CSS `url()` token may not contain whitespace, so `data/fnt/Super Bouncer.ttf` produced a descriptor the browser refuses to parse: `font.load()` rejected with a `SyntaxError` before any request was made, surfacing as `Failed loading resource`. The descriptor is now quoted, which also covers parentheses and commas. Only `fontface` was affected: every other asset type hands its path to the browser, which percent-encodes it and issues a real request. The parser also no longer writes its wrapped value back onto the caller's asset descriptor, which is routinely a module-level manifest reused across scenes


### PR DESCRIPTION
Dates the `20.1.1` section for release. Changelog text only — no code.

**`melonjs` 20.1.1** is the only package in this release. `@melonjs/planck-adapter` 1.3.0 and `@melonjs/matter-adapter` 1.2.0 shipped with 20.1.0 and are untouched by this line.

Seven fixes, no API change, no new features. Five of them are one bug class — an engine loop handing control to user code and then resuming into state that code was free to tear down. Two came from downstream reports; the other five from looking for siblings of the first.

| fix | source |
| --- | --- |
| animation callback destroying its own sprite | reported |
| the `{next, onComplete}` chain wrapper re-entering the engine | review |
| collision handler removing an object mid-step (4 sites) | review |
| `GLTFModel` posing a torn-down hierarchy | review |
| `updateTimers()` splicing the array it iterates | review |
| `Container.update()` updating a child twice | review |
| fontface path containing a space | reported |

Plus `Renderable.parentApp` honouring its documented `undefined` contract.

After merge: tag `20.1.1`, then dispatch `publish.yml` for `melonjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVjYzf76AEU3wJk766JAQi