### PR TITLE
test(bench): correct what the mesh benchmark claims gl.finish() does

### DIFF
--- a/packages/melonjs/tests/drawmesh_bench.spec.js
+++ b/packages/melonjs/tests/drawmesh_bench.spec.js
@@ -190,9 +190,18 @@ describe("drawMesh benchmark (baseline for #1468)", () => {
 				draw();
 			}
 		}
-		// gl.finish forces the driver to flush all queued GL work — without
-		// it, drawElements latency hides under the rAF cadence and the
-		// numbers look better than they really are.
+		// NOTE: `gl.finish()` does NOT synchronise in this environment, so
+		// what follows is CPU-side submission cost, not end-to-end frame time.
+		// Verified by A/B: 4000 alpha-blended 512x512 quads — over a gigapixel
+		// of overdraw — measure 0.7ms with the call and 0.7ms without, which
+		// is not a rate any GPU achieves. Headless Chromium simply does not
+		// wait.
+		//
+		// That is the right measure for what this benchmark compares: the
+		// retained-mesh path wins by not re-uploading vertices and not
+		// re-transforming them on the CPU, and both are counted here. It just
+		// must not be read as a frame-time figure, and adding this call back
+		// does not make it one.
 		renderer.gl.finish();
 		const elapsed = performance.now() - start;
 		renderer.gl.drawElements = origDE;


### PR DESCRIPTION
The mesh benchmark's comment asserts something measurably false:

```js
// gl.finish forces the driver to flush all queued GL work — without
// it, drawElements latency hides under the rAF cadence and the
// numbers look better than they really are.
renderer.gl.finish();
```

It does not, in the environment this benchmark runs in.

## Evidence

A/B on identical workloads, alpha-blended fill, median of 15 frames:

| `gl.finish()` | quads | megapixels | median |
| --- | ---: | ---: | ---: |
| no | 2 000 × 64² | 8.2 | 0.4 ms |
| **yes** | 2 000 × 64² | 8.2 | **0.4 ms** |
| no | 2 000 × 256² | 131 | 0.3 ms |
| **yes** | 2 000 × 256² | 131 | **0.3 ms** |
| no | 4 000 × 512² | 1 049 | 0.7 ms |
| **yes** | 4 000 × 512² | 1 049 | **0.7 ms** |

Over a **gigapixel of overdraw in a single frame at 0.7 ms** — about 1.4 TPix/s — with and without the call identical. Headless Chromium does not wait. A separate fill sweep across a 600× range of shaded pixels likewise stayed flat at 2.9 ms.

## What changes

Only the comment. The call stays (harmless, and it may synchronise in other environments), but it now says what the numbers actually are: **CPU-side submission cost**.

That remains the right measure for what this benchmark compares — the retained-mesh path wins by not re-uploading vertices and not re-transforming them on the CPU, and both are counted here. It just must not be read as end-to-end frame time, and adding the call back does not make it one.

## Scope

Every other `gl.finish()` in the suite sits immediately before `gl.readPixels()`, which synchronises on its own — redundant but correct, so they are untouched.

This came out of trying to establish whether the GPU is the bottleneck for particle rendering ([#1404](https://github.com/melonjs/melonJS/issues/1404)). It is not answerable with this instrument; doing it properly needs `EXT_disjoint_timer_query_webgl2` and real hardware rather than a headless proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Aa37KGXZcnVrbn1yG4j1N