### PR TITLE
test(bench): stop drawmesh_bench wedging the shared GPU process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,11 @@ jobs:
   test:
     needs: lint
     runs-on: ubuntu-latest
+    strategy:
+      # a shard failing should not cancel the other — we want to see both
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     container:
       # must match the workspace's playwright version (root devDependencies)
       image: mcr.microsoft.com/playwright:v1.62.1-noble
@@ -71,7 +76,14 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm i
-      - run: pnpm test
+      # Sharded because the browser accumulates across a run: the page died
+      # reproducibly around file ~125 of 263 regardless of WHICH files, naming
+      # whichever spec was executing ("Browser connection was closed while
+      # running tests"). A count-based failure is accumulation, not a bad spec
+      # — and neither raising /dev/shm nor cutting per-test contexts moved it.
+      # Each shard gets its own container and browser, halving what any one
+      # instance has to survive.
+      - run: pnpm test -- --shard=${{ matrix.shard }}/2
       - run: pnpm -F @melonjs/matter-adapter test
       - run: pnpm -F @melonjs/planck-adapter test
       - run: pnpm -F @melonjs/debug-plugin test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,13 +77,19 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm i
       # Sharded because the browser accumulates across a run: the page died
-      # reproducibly around file ~125 of 263 regardless of WHICH files, naming
+      # reproducibly at file 125 of 263 regardless of WHICH files, naming
       # whichever spec was executing ("Browser connection was closed while
       # running tests"). A count-based failure is accumulation, not a bad spec
-      # — and neither raising /dev/shm nor cutting per-test contexts moved it.
-      # Each shard gets its own container and browser, halving what any one
-      # instance has to survive.
-      - run: pnpm test -- --shard=${{ matrix.shard }}/2
+      # — every named victim passes alone in under a second — and neither
+      # raising /dev/shm nor cutting per-test contexts moved it. Each shard
+      # gets its own container and browser, halving what one instance has to
+      # survive.
+      #
+      # Invoked directly rather than through `pnpm test -- --shard=...`: that
+      # form silently does not reach vitest (both shards ran all 263 files and
+      # failed identically), so the build and the run are separate steps here.
+      - run: pnpm turbo build
+      - run: pnpm exec vitest run --config packages/melonjs/vitest.config.ts --shard=${{ matrix.shard }}/2
       - run: pnpm -F @melonjs/matter-adapter test
       - run: pnpm -F @melonjs/planck-adapter test
       - run: pnpm -F @melonjs/debug-plugin test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,22 +45,9 @@ jobs:
   test:
     needs: lint
     runs-on: ubuntu-latest
-    strategy:
-      # a shard failing should not cancel the other — we want to see both
-      fail-fast: false
-      matrix:
-        shard: [1, 2]
     container:
       # must match the workspace's playwright version (root devDependencies)
       image: mcr.microsoft.com/playwright:v1.62.1-noble
-      # Docker gives a container 64MB of /dev/shm, and Chromium uses it for
-      # shared memory between its processes. Software-rasterized WebGL across
-      # two pages exhausts that partway through a 263-file run, and the
-      # renderer dies with "Browser connection was closed while running tests.
-      # Was the page closed unexpectedly?" — naming whichever spec happened to
-      # be running, which is why the victim was different every time and never
-      # reproduced locally.
-      options: --shm-size=2gb
     steps:
       - uses: actions/checkout@v5
       - name: Setup node
@@ -76,20 +63,7 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm i
-      # Sharded because the browser accumulates across a run: the page died
-      # reproducibly at file 125 of 263 regardless of WHICH files, naming
-      # whichever spec was executing ("Browser connection was closed while
-      # running tests"). A count-based failure is accumulation, not a bad spec
-      # — every named victim passes alone in under a second — and neither
-      # raising /dev/shm nor cutting per-test contexts moved it. Each shard
-      # gets its own container and browser, halving what one instance has to
-      # survive.
-      #
-      # Invoked directly rather than through `pnpm test -- --shard=...`: that
-      # form silently does not reach vitest (both shards ran all 263 files and
-      # failed identically), so the build and the run are separate steps here.
-      - run: pnpm turbo build
-      - run: pnpm exec vitest run --config packages/melonjs/vitest.config.ts --shard=${{ matrix.shard }}/2
+      - run: pnpm test
       - run: pnpm -F @melonjs/matter-adapter test
       - run: pnpm -F @melonjs/planck-adapter test
       - run: pnpm -F @melonjs/debug-plugin test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,14 @@ jobs:
     container:
       # must match the workspace's playwright version (root devDependencies)
       image: mcr.microsoft.com/playwright:v1.62.1-noble
+      # Docker gives a container 64MB of /dev/shm, and Chromium uses it for
+      # shared memory between its processes. Software-rasterized WebGL across
+      # two pages exhausts that partway through a 263-file run, and the
+      # renderer dies with "Browser connection was closed while running tests.
+      # Was the page closed unexpectedly?" — naming whichever spec happened to
+      # be running, which is why the victim was different every time and never
+      # reproduced locally.
+      options: --shm-size=2gb
     steps:
       - uses: actions/checkout@v5
       - name: Setup node

--- a/packages/melonjs/tests/drawmesh_bench.spec.js
+++ b/packages/melonjs/tests/drawmesh_bench.spec.js
@@ -190,10 +190,29 @@ describe("drawMesh benchmark (baseline for #1468)", () => {
 				draw();
 			}
 		}
-		// gl.finish forces the driver to flush all queued GL work — without
-		// it, drawElements latency hides under the rAF cadence and the
-		// numbers look better than they really are.
-		renderer.gl.finish();
+		// A real barrier. `gl.finish()` was here, and it does NOT wait under
+		// ANGLE/SwiftShader — verified: a thousand draws queue in 0.3ms and
+		// `finish()` returns in 0.3ms, while the rasterization is still to
+		// come. So the timings it produced were fiction, AND the work escaped
+		// the test: it drained afterwards in Chromium's single shared GPU
+		// process, wedging every page for minutes. On CI that stall is
+		// visible as ~190 seconds of silence in the middle of a passing run,
+		// and it is what killed the browser in the failing ones — the spec
+		// named in "Browser connection was closed" was always this file's
+		// neighbour in execution order, never this file.
+		//
+		// A 1x1 readPixels genuinely blocks until the pipeline drains, so the
+		// cost lands inside the measurement where it belongs.
+		const drain = new Uint8Array(4);
+		renderer.gl.readPixels(
+			0,
+			0,
+			1,
+			1,
+			renderer.gl.RGBA,
+			renderer.gl.UNSIGNED_BYTE,
+			drain,
+		);
 		const elapsed = performance.now() - start;
 		renderer.gl.drawElements = origDE;
 
@@ -220,6 +239,16 @@ describe("drawMesh benchmark (baseline for #1468)", () => {
 		// like one that did. Decide it once, visibly, up front.
 		if (!(renderer instanceof WebGLRenderer)) {
 			ctx.skip("Canvas renderer — drawMesh benchmark not applicable");
+			return;
+		}
+		// Skipped on CI, visibly rather than by quietly measuring nothing.
+		// The runner is a GPU-less container rasterizing through SwiftShader's
+		// Subzero JIT on four shared vCPUs, so these figures describe that
+		// environment and not the engine. The work is also heavy enough to
+		// starve the shared GPU process for minutes, which is what made the
+		// suite flaky. Run it locally to compare against #1507's numbers.
+		if (import.meta.env.VITE_CI !== "") {
+			ctx.skip("CI — a software-rasterized benchmark measures the runner");
 			return;
 		}
 		// Frame counts chosen so total drawMesh calls stays in the same

--- a/packages/melonjs/tests/emitter.spec.js
+++ b/packages/melonjs/tests/emitter.spec.js
@@ -1,4 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import {
 	Application,
 	boot,
@@ -12,7 +21,11 @@ describe("ParticleEmitter", () => {
 	let emitter;
 
 	let app;
-	beforeEach(async () => {
+	beforeAll(async () => {
+		// One Application per FILE, not per test: each `init()` opens a real
+		// browser rendering context, and CI runs on a GPU-less container where
+		// those are scarce and slow enough that a hook creating one can miss
+		// its timeout. The emitter is still fresh per test below.
 		boot();
 		app = new Application(800, 600, {
 			parent: "screen",
@@ -20,6 +33,9 @@ describe("ParticleEmitter", () => {
 			renderer: video.CANVAS,
 		});
 		await app.init();
+	});
+
+	beforeEach(() => {
 		emitter = new ParticleEmitter(100, 100, {
 			width: 16,
 			height: 16,
@@ -28,8 +44,13 @@ describe("ParticleEmitter", () => {
 	});
 
 	afterEach(() => {
-		// release the WebGL context this describe owns — browsers cap
-		// live contexts, and a leak surfaces as UNRELATED specs failing
+		app.world.reset();
+		app.world.pos.set(0, 0, 0);
+		app.world.broadphase.clear();
+	});
+
+	afterAll(() => {
+		// browsers cap live contexts — a leak surfaces as UNRELATED specs failing
 		app?.destroy();
 	});
 

--- a/packages/melonjs/tests/particle-bounds.spec.js
+++ b/packages/melonjs/tests/particle-bounds.spec.js
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import {
 	Application,
 	boot,
@@ -25,7 +33,7 @@ import {
 describe("particle bounds", () => {
 	let app;
 
-	beforeEach(async () => {
+	beforeAll(async () => {
 		boot();
 		app = new Application(800, 600, {
 			parent: "screen",
@@ -36,6 +44,19 @@ describe("particle bounds", () => {
 	});
 
 	afterEach(() => {
+		// One Application per FILE, not per test: each `init()` opens a real
+		// browser rendering context, and CI runs on a GPU-less container where
+		// those are scarce and slow. Reset the scene between tests instead —
+		// the same trade `input.spec.js` makes.
+		app.world.reset();
+		app.world.pos.set(0, 0, 0);
+		app.world.broadphase.clear();
+		app.viewport.moveTo(0, 0);
+		app.viewport.setBounds(0, 0, app.viewport.width, app.viewport.height);
+	});
+
+	afterAll(() => {
+		// browsers cap live contexts — a leak surfaces as UNRELATED specs failing
 		app?.destroy();
 	});
 

--- a/packages/melonjs/tests/particle-reference-space.spec.js
+++ b/packages/melonjs/tests/particle-reference-space.spec.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
 	Application,
 	boot,
@@ -27,7 +27,7 @@ import {
 describe("particle referenceSpace", () => {
 	let app;
 
-	beforeEach(async () => {
+	beforeAll(async () => {
 		boot();
 		app = new Application(800, 600, {
 			parent: "screen",
@@ -45,6 +45,18 @@ describe("particle referenceSpace", () => {
 	});
 
 	afterEach(() => {
+		// One Application per FILE, not per test: each `init()` opens a real
+		// browser rendering context, and CI runs on a GPU-less container where
+		// those are scarce and slow. Reset the scene between tests instead —
+		// the same trade `input.spec.js` makes.
+		app.world.reset();
+		app.world.pos.set(0, 0, 0);
+		app.world.broadphase.clear();
+		app.viewport.moveTo(0, 0);
+		app.viewport.setBounds(0, 0, app.viewport.width, app.viewport.height);
+	});
+
+	afterAll(() => {
 		// browsers cap live contexts — a leak surfaces as UNRELATED specs failing
 		app?.destroy();
 	});

--- a/packages/melonjs/tests/renderable-transform.spec.js
+++ b/packages/melonjs/tests/renderable-transform.spec.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
 	Application,
 	boot,
@@ -22,7 +22,7 @@ import {
 describe("renderable transforms", () => {
 	let app;
 
-	beforeEach(async () => {
+	beforeAll(async () => {
 		boot();
 		app = new Application(800, 600, {
 			parent: "screen",
@@ -36,6 +36,19 @@ describe("renderable transforms", () => {
 	});
 
 	afterEach(() => {
+		// One Application per FILE, not per test: each `init()` opens a real
+		// browser rendering context, and CI runs on a GPU-less container where
+		// those are scarce and slow. Reset the scene between tests instead —
+		// the same trade `input.spec.js` makes.
+		app.world.reset();
+		app.world.pos.set(0, 0, 0);
+		app.world.broadphase.clear();
+		app.viewport.moveTo(0, 0);
+		app.viewport.setBounds(0, 0, app.viewport.width, app.viewport.height);
+	});
+
+	afterAll(() => {
+		// browsers cap live contexts — a leak surfaces as UNRELATED specs failing
 		app?.destroy();
 	});
 


### PR DESCRIPTION
## The cause

`gl.finish()` **does not wait** under ANGLE/SwiftShader. Verified directly: a thousand draws queue in 0.3 ms and `finish()` returns in 0.3 ms with the rasterization still ahead of it.

So the barrier `drawmesh_bench.spec.js` relied on did nothing — which made its numbers fiction, but worse, let the work **escape the test**. It drained afterwards in Chromium's single shared GPU process and starved every page for minutes.

That stall is in **every passing CI run**: ~190 s of silence in the middle, then `drawmesh_bench ✓` reporting "355ms". Passing runs take six minutes because they survive it. Failing runs die at it after ~2m20.

## Why the symptoms made no sense

The **"stable count of ~125 files"** is just how many finish before the bench detonates. Vitest orders files by size, and ranking today's specs puts `drawmesh_bench` at **131** — every spec ever named in a failure is its immediate neighbour:

| rank | spec | named in a failure |
| ---: | --- | :---: |
| 124 | `glcore-audit` | ✓ |
| 126 | `fillpolygon_mutation` | ✓ |
| 127 | `trigger` | ✓ |
| 129 | `shadereffect-program-cache` | ✓ |
| 130 | `sprite3d_webgl` | ✓ |
| **131** | **`drawmesh_bench`** | never — it had already "passed" |

It also explains the rest: `glcore-audit`'s 90 s `beforeAll` timeout is the same cause (a context-creating hook on the other worker starving behind the backlog), it never reproduced locally because a real GPU absorbs the flood, and it only began failing on 08-27 because the wedge has existed since #1507 but the browser survived it until GitHub's runner fleet moved images.

## The fix

**A real barrier.** A 1×1 `readPixels` genuinely blocks until the pipeline drains, so the cost lands inside the measurement. The case that reported 60 ms locally now reports **11.9 s** — which is what it always was.

**Skipped on CI**, visibly, through the `VITE_CI` define that exists for exactly this. A software-rasterized benchmark on four shared vCPUs measures the runner, not the engine.

## Reverted from this branch

Two earlier commits here were wrong and are undone:

- **`--shm-size=2gb`** — no-op. Verified applied in the `docker create` line; the run died identically. Modern Chromium uses memfd, not `/dev/shm`.
- **sharding** — not protection. The bench lands in one shard and still wedges it.

The workflow is now byte-identical to master again.

## Kept

The first commit — one browser context per spec file instead of per test, **88 → 4** — stays as hygiene, explicitly *not* as the fix. It made no difference to the crash.

## Result

Local suite 6354 passed / 10 skipped, and **26.6 s where it was 39 s**.

Credit: root cause found by an adversarial investigation after three wrong guesses of mine. One honest caveat it flagged — the exact fatal event (OOM-kill vs GPU-process crash) was not captured, because the container image could not be pulled locally. The trigger and location are proven; only the final kill mechanism is inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Aa37KGXZcnVrbn1yG4j1N