### PR TITLE
docs(readme): replace the dead bundlephobia badges, and correct the size claim

### DIFF
--- a/DOC_README.md
+++ b/DOC_README.md
@@ -3,12 +3,12 @@
 </p>
 
 <p align="center">
-  <em>A lightweight, plugin-free HTML5 game engine</em>
+  <em>A modern, plugin-free HTML5 game engine</em>
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/melonjs"><img src="https://img.shields.io/npm/v/melonjs.svg" alt="npm"></a>
-  <a href="https://github.com/nicedoc/bundlephobia/blob/master/LICENSE"><img src="https://img.shields.io/bundlephobia/min/melonjs" alt="size"></a>
+  <a href="https://bundlejs.com/?q=melonjs"><img src="https://img.shields.io/bundlejs/size/melonjs?label=minzip" alt="size"></a>
   <a href="https://discord.gg/aur7JMk"><img src="https://img.shields.io/discord/608636676461428758?color=7289da&label=discord" alt="discord"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,18 @@ melonJS 2
 [![Build Status](https://github.com/melonjs/melonJS/actions/workflows/main.yml/badge.svg)](https://github.com/melonjs/melonJS/actions/workflows/main.yml)
 [![NPM Package](https://img.shields.io/npm/v/melonjs)](https://www.npmjs.com/package/melonjs)
 [![NPM Downloads](https://img.shields.io/npm/dm/melonjs)](https://www.npmjs.com/package/melonjs)
-[![Build Size](https://badgen.net/bundlephobia/minzip/melonjs)](https://bundlephobia.com/result?p=melonjs)
-[![Tree-shaking](https://badgen.net/bundlephobia/tree-shaking/melonjs)](https://bundlephobia.com/result?p=melonjs)
+[![Build Size](https://img.shields.io/bundlejs/size/melonjs?label=minzip)](https://bundlejs.com/?q=melonjs)
 [![jsDelivr](https://data.jsdelivr.com/v1/package/npm/melonjs/badge?style=rounded)](https://www.jsdelivr.com/package/npm/melonjs)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 [![Discord](https://img.shields.io/discord/608636676461428758?color=7289da&label=discord)](https://discord.gg/aur7JMk)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 
-A modern & lightweight HTML5 game engine
+A modern & fully featured HTML5 game engine
 -------------------------------------------------------------------------------
 ![melonJS](https://melonjs.org/img/alex4-github.png)
 
-[melonJS](https://melonjs.org/) is an open-source 2.5D game engine designed for indie developers — perspective and orthogonal cameras, GPU-accelerated tilemap rendering, post-processing effects, custom shaders, 3D mesh support, polygon-accurate physics, modern Tiled workflows, and high performance. Runs on WebGPU, WebGL 2 or Canvas2D with automatic fallback, tree-shakeable so you only pay for what you use, and the entire engine fits in ~150 KB minzipped of vanilla JS/TS with no toolchain lock-in. Built with ES6 classes and bundled with [esbuild](https://esbuild.github.io).
+[melonJS](https://melonjs.org/) is an open-source 2.5D game engine designed for indie developers — perspective and orthogonal cameras, GPU-accelerated tilemap rendering, post-processing effects, custom shaders, 3D mesh support, polygon-accurate physics, modern Tiled workflows, and high performance. Runs on WebGPU, WebGL 2 or Canvas2D with automatic fallback. The whole engine is ~250 KB minzipped of vanilla JS/TS, with no dependencies and no toolchain lock-in. Built with ES6 classes and bundled with [esbuild](https://esbuild.github.io).
 
 [melonJS](https://melonjs.org/) is licensed under the [MIT License](LICENSE.md) and actively maintained by the team at AltByte in Singapore.
 


### PR DESCRIPTION
Both bundlephobia badges rendered as `bundlephobia 429`. badgen's endpoint is
rate limited by an upstream service that is effectively unmaintained, and
shields' equivalent returns "rate limited by upstream service" too. They looked
like a duplicated badge because both failed to the same error text, though one
was meant to report minzip size and the other tree-shaking. Replaced with a
working bundlejs size badge; there is no tree-shaking equivalent.

`DOC_README.md` carried the same dead badge, with its link pointing at an
unrelated repository's LICENSE file.

### The size claim was stale

With a badge reporting a real number again, the neighbouring prose was wrong. It
claimed ~150 KB minzipped, written at 19.7.1 in June, before WebGPU, 3D meshes,
the glTF loader and the blend mode shaders landed. Measured at 20.2.0: **246 kB**
gzip locally via esbuild, **254 kB** via bundlejs. Quoted as ~250 KB, the
resolution the two instruments agree at.

### And "lightweight" rested on tree-shaking, which does not hold up

Measured against the shipped `build/index.js` — the single 2.1 MB file a
consumer's bundler actually sees, since the other entries under `build/` are
`.d.ts` only:

| imported | gzip |
| --- | --- |
| `Vector2d` alone | **184 kB** |
| `Application` | 230 kB |
| the platformer example's real 31 symbols | 234 kB |
| the whole barrel | 246 kB |

There is a 184 kB floor: importing a single vector class pulls three quarters of
the engine, and a real game saves about 5% rather than a large fraction.
`sideEffects` is declared correctly (`./src/polyfill/**`), so this is not a
missing hint — everything transitively reaches the renderers.

So the tree-shaking sentence is removed rather than left as an aspiration, the
engine is described as full-featured, and the size speaks for itself. The 184 kB
floor is a real finding but a separate concern from this README wording, and is
not addressed here.