### PR TITLE
ci: retry once when vitest loses its browser page

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,44 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm i
-      - run: pnpm test
+      # Vitest 4.1.11 runs each worker as one long-lived orchestrator page and
+      # dispatches every spec file over a single websocket. Its ws close handler
+      # destroys the session and rejects the pending `createTesters`, so if that
+      # socket drops the whole run dies — the in-page client does try to
+      # reconnect, but the session is already gone. Underneath, the browser
+      # intermittently severs a renderer's network-service channels: every
+      # websocket for that page dies at once, the server sees a graceful 1001
+      # while the page sees 1006, and no process crashes.
+      #
+      # Measured at 4 deaths in 21 local runs, and it cost three attempts to
+      # land a PR that changed nothing but Markdown. Not our code: no test ever
+      # fails, and the spec it names is just whichever was in flight. Launching
+      # the full Chromium build fixes it locally (20 runs clean) but does
+      # nothing here (0 of 4), so this retries instead.
+      #
+      # The condition is deliberately narrow — the page must have been lost AND
+      # no test may have failed. A real failure prints "N failed" in the summary
+      # and exits without a retry.
+      - name: Test (retries once if vitest loses its browser page)
+        # the container has no default bash, so GitHub would run this under
+        # dash, which has no `pipefail` — and without it the exit status of
+        # `pnpm test` is masked by `tee`
+        shell: bash
+        run: |
+          set -o pipefail
+          for attempt in 1 2; do
+            if pnpm test 2>&1 | tee "test-$attempt.log"; then
+              exit 0
+            fi
+            if ! grep -q "Browser connection was closed" "test-$attempt.log" \
+              || grep -qE "Test Files.*[0-9]+ failed" "test-$attempt.log"; then
+              echo "::error::test failed for a real reason, not the known browser flake"
+              exit 1
+            fi
+            echo "::warning::vitest lost its browser page (upstream flake) — attempt $attempt"
+          done
+          echo "::error::vitest lost its browser page on both attempts"
+          exit 1
       - run: pnpm -F @melonjs/matter-adapter test
       - run: pnpm -F @melonjs/planck-adapter test
       - run: pnpm -F @melonjs/debug-plugin test

--- a/packages/melonjs/tests/texture.spec.js
+++ b/packages/melonjs/tests/texture.spec.js
@@ -6,6 +6,7 @@ import {
 	Sprite,
 	TextureAtlas,
 	video,
+	WebGLRenderer,
 } from "../src/index.js";
 import Renderer from "../src/video/renderer.js";
 
@@ -287,8 +288,18 @@ describe("Texture", () => {
 
 			if (compositor) {
 				expect(flushed).toBe(true);
-				expect(compositor.boundTextures.length).toEqual(0);
-				expect(compositor.currentTextureUnit).toEqual(-1);
+				// `boundTextures` / `currentTextureUnit` are WebGL texture-unit
+				// bookkeeping and exist on no WebGPU batcher, which binds per
+				// draw instead. The app is built with `video.AUTO`, so which
+				// backend answers depends on the machine — headless SwiftShader
+				// lands on WebGL, a real GPU on WebGPU. The cache assertions
+				// above are backend-agnostic and run either way; only these two
+				// are gated, and on the renderer rather than on the field being
+				// present, so a WebGL regression that drops them still fails.
+				if (app.renderer instanceof WebGLRenderer) {
+					expect(compositor.boundTextures.length).toEqual(0);
+					expect(compositor.currentTextureUnit).toEqual(-1);
+				}
 				// restore original
 				compositor.flush = originalFlush;
 			}


### PR DESCRIPTION
The browser suite aborts at a random point with:

```
Error: Failed to run the test <spec>.
Caused by: [vitest] Browser connection was closed while running tests.
Caused by: [birpc] rpc is closed, cannot call "createTesters"
 Test Files  <N> passed (263)
```

A different victim spec every time — six distinct ones observed — and **zero
failed tests** in every occurrence. Measured at 4 deaths in 21 local runs; on CI
it took three attempts to land a PR that changed nothing but Markdown.

### Cause

Vitest 4.1.11 runs each worker as one long-lived orchestrator page and dispatches
every spec over a single websocket. Its `ws.on("close")` handler destroys the
session and rejects the pending `createTesters`, so losing that socket kills the
whole run — the in-page client does attempt to reconnect, but the session is
already gone. That is why no test ever fails and the named spec is just whichever
was in flight.

Underneath, the browser intermittently severs a renderer's network-service
channels: every websocket belonging to that page dies within ~3 ms, the server
receives a graceful `1001` while the page sees `1006 wasClean=false`, and both
processes stay alive with healthy memory.

Ruled out by direct measurement:

| hypothesis | result |
| --- | --- |
| memory / OOM | 2.46 GB peak against 64 GB |
| CPU starvation | 5/5 clean under 14 competing hogs |
| browser crash | no crash event, no signal in stderr |
| page navigation / reload | zero in ~90 instrumented runs |
| worker concurrency | single worker was *worse*, 2/6 |
| `drawmesh_bench` (#1612) | skips in ~30 ms, no stall in any log |
| CI-specific | reproduces locally |

### Why a retry rather than a fix

Launching the full Chromium build instead of the headless shell fixes it
**locally** — 20 consecutive clean runs against a baseline that died 4 times in
21. It does nothing here: **0 of 4** CI attempts passed with it applied. So it
was dropped, and this retries instead.

The condition is deliberately narrow — the page must have been lost **and** no
test may have failed:

```
grep "Browser connection was closed"  &&  ! grep "Test Files.*N failed"
```

A genuine failure prints `N failed` in the summary and exits immediately with no
second attempt. Both branches were verified against real captured logs from this
investigation: the flake log retries, a `1 failed | 262 passed` log does not.

### texture.spec.js

A latent bug found on the way, independent of the retry. The app is built with
`video.AUTO` while the test asserts `boundTextures` and `currentTextureUnit` —
WebGL texture-unit bookkeeping that no WebGPU batcher keeps. It passes only
because the headless browser has no GPU and falls back to WebGL; on a machine
where WebGPU is available it fails. Now gated on the renderer rather than on the
fields being present, so a WebGL regression that drops them still fails rather
than silently skipping.

### Worth reporting upstream

Vitest destroying the session on the first socket close while its own client is
still retrying, and `@vitest/browser-playwright` silently ignoring an
instance-level `launch:` key (it only reads `launchOptions` from the
`playwright({...})` factory call — setting the channel on the instance looks
correct, does nothing, and quietly re-measures the default).