### PR TITLE
strip-internal: widen the fast gate, and call the sibling script through pnpm

### DIFF
--- a/packages/melonjs/package.json
+++ b/packages/melonjs/package.json
@@ -77,7 +77,7 @@
 		"build": "pnpm lint && tsx scripts/build.js && pnpm types",
 		"dist": "pnpm clean && pnpm lint && pnpm vitest run && pnpm build && pnpm doc && cp ../../README.md .",
 		"dist:publish": "pnpm clean && pnpm lint && pnpm build && pnpm doc && cp ../../README.md .",
-		"doc": "tsx scripts/check-doc-readme.ts && npm run doc:css && typedoc && tsx scripts/generate-llms-txt.ts",
+		"doc": "tsx scripts/check-doc-readme.ts && pnpm doc:css && typedoc && tsx scripts/generate-llms-txt.ts",
 		"doc:watch": "typedoc --watch --skipErrorChecking --preserveWatchOutput --logLevel Error",
 		"serve": "serve docs",
 		"prepublishOnly": "pnpm dist:publish",

--- a/packages/melonjs/scripts/strip-internal.ts
+++ b/packages/melonjs/scripts/strip-internal.ts
@@ -32,8 +32,16 @@ function isInternal(node: ts.Node): boolean {
 		.some((tag) => tag.tagName.getText() === "internal");
 }
 
-/** cheap pre-filter for the underscore rule below */
-const UNDERSCORE_HINT = /^\s*(readonly\s+)?_[A-Za-z0-9_]+\s*[?:(<]/m;
+/**
+ * Cheap pre-filter for the underscore rule below.
+ *
+ * It has to admit every modifier a member can carry, or a file whose only
+ * underscore members are written `private _foo` is skipped outright and they
+ * survive into the published types — a silent hole, since the file simply is
+ * not parsed. Erring wide costs one AST walk on a file with nothing to strip.
+ */
+const UNDERSCORE_HINT =
+	/^\s*(?:private |protected |public |static |declare |readonly |abstract |override |get |set )*_[A-Za-z0-9_]+\s*[?:(<]/m;
 
 /**
  * A class member whose name starts with `_`.


### PR DESCRIPTION
Two follow-ups from Copilot's review of #1639.

### The fast gate could skip a whole file

`UNDERSCORE_HINT` decides whether a `.d.ts` is worth parsing at all. It only matched an underscore member written bare or behind `readonly`:

```ts
/^\s*(readonly\s+)?_[A-Za-z0-9_]+\s*[?:(<]/m
```

A file whose underscore members all carry a modifier — `private _secret`, `protected _hidden()`, `static _shared` — fails that test and is skipped **outright**, so those members survive into the published types. The failure mode is silent: the file is never parsed, rather than parsed and passed over.

**Nothing leaks today.** No emitted declaration currently puts those modifiers on an underscore member, so the hole is latent. It opens the moment someone writes one in TypeScript source — which is exactly the kind of thing that gets noticed months later.

Verified in both directions against a probe declaration carrying only modified members and no `@internal`:

| | old pattern | new pattern |
| --- | --- | --- |
| parses the file | **no** — skipped entirely | yes |

Erring wide costs one AST walk on a file with nothing to strip.

### `doc` shelled out to npm

Every other script in the package uses pnpm (`pnpm lint`, `pnpm types`, `pnpm clean`); `doc` called `npm run doc:css`. Inconsistent, and npm can resolve differently in a workspace install.

### Verified

- 741 declarations stripped, unchanged
- 0 internals in the reference, 0 in the published types
- 6633 tests, lint and types clean, 156 doc warnings