### PR TITLE
docs: correct how the skills installer places files

### DIFF
--- a/DOC_README.md
+++ b/DOC_README.md
@@ -161,8 +161,9 @@ npx skills add https://github.com/melonjs/melonJS/tree/master/packages/melonjs/s
 It installs one copy of each skill under `.agents/skills/<skill-name>`, then
 symlinks that copy into every assistant's own directory, so
 `.claude/skills/melonjs` points back at `.agents/skills/melonjs` and there is
-nothing to place by hand. The installer reports coverage of 77 agents. It
-installs from `master`; swap that for a release tag in the URL to pin.
+nothing to place by hand. It reports the assistants it covers as it runs (77 of
+them at the time of writing). It installs from `master`; swap that for a release
+tag in the URL to pin.
 
 They are plain Markdown — readable by any agent, or by you.
 

--- a/DOC_README.md
+++ b/DOC_README.md
@@ -158,9 +158,11 @@ Install them into whatever assistant you use, with one command:
 npx skills add https://github.com/melonjs/melonJS/tree/master/packages/melonjs/skills
 ```
 
-That writes each agent's own convention — `.claude/skills/`, `.agents/skills/`,
-`.windsurf/skills/` and around seventy others — so there is nothing to place by
-hand. It installs from `master`; swap that for a release tag in the URL to pin.
+It installs one copy of each skill under `.agents/skills/<skill-name>`, then
+symlinks that copy into every assistant's own directory, so
+`.claude/skills/melonjs` points back at `.agents/skills/melonjs` and there is
+nothing to place by hand. The installer reports coverage of 77 agents. It
+installs from `master`; swap that for a release tag in the URL to pin.
 
 They are plain Markdown — readable by any agent, or by you.
 

--- a/README.md
+++ b/README.md
@@ -341,10 +341,11 @@ Install them into whatever assistant you use, with one command :
 npx skills add https://github.com/melonjs/melonJS/tree/master/packages/melonjs/skills
 ```
 
-It detects the assistants in your project and writes each one's own convention
-— `.claude/skills/`, `.agents/skills/`, `.windsurf/skills/` and around seventy
-others — so there is nothing to place by hand. Add `-a claude-code -a cursor`
-to target specific ones.
+It detects the assistants in your project, installs the skills once into
+`.agents/skills/` — the shared location it reports as covering 77 agents — and
+symlinks them into each assistant's own directory, so `.claude/skills/melonjs`
+points back at the one copy and there is nothing to place by hand. Add
+`-a claude-code -a cursor` to target specific ones.
 
 The set includes an `AGENTS.md` for anything following that convention (Codex,
 Cursor, Gemini CLI); GitHub Copilot reads the same content from

--- a/README.md
+++ b/README.md
@@ -341,11 +341,12 @@ Install them into whatever assistant you use, with one command :
 npx skills add https://github.com/melonjs/melonJS/tree/master/packages/melonjs/skills
 ```
 
-It detects the assistants in your project, installs the skills once into
-`.agents/skills/` — the shared location it reports as covering 77 agents — and
-symlinks them into each assistant's own directory, so `.claude/skills/melonjs`
-points back at the one copy and there is nothing to place by hand. Add
-`-a claude-code -a cursor` to target specific ones.
+It detects the assistants in your project and installs one copy of each skill
+under `.agents/skills/<skill-name>`, then symlinks that copy into every
+assistant's own directory, so `.claude/skills/melonjs` points back at
+`.agents/skills/melonjs` and there is nothing to place by hand. The installer
+reports coverage of 77 agents. Add `-a claude-code -a cursor` to target
+specific ones.
 
 The set includes an `AGENTS.md` for anything following that convention (Codex,
 Cursor, Gemini CLI); GitHub Copilot reads the same content from

--- a/README.md
+++ b/README.md
@@ -344,9 +344,9 @@ npx skills add https://github.com/melonjs/melonJS/tree/master/packages/melonjs/s
 It detects the assistants in your project and installs one copy of each skill
 under `.agents/skills/<skill-name>`, then symlinks that copy into every
 assistant's own directory, so `.claude/skills/melonjs` points back at
-`.agents/skills/melonjs` and there is nothing to place by hand. The installer
-reports coverage of 77 agents. Add `-a claude-code -a cursor` to target
-specific ones.
+`.agents/skills/melonjs` and there is nothing to place by hand. It reports the
+assistants it covers as it runs (77 of them at the time of writing). Add
+`-a claude-code -a cursor` to target specific ones.
 
 The set includes an `AGENTS.md` for anything following that convention (Codex,
 Cursor, Gemini CLI); GitHub Copilot reads the same content from


### PR DESCRIPTION
## Description

The description of `npx skills add` did not match what the installer actually does.

It said the tool "writes each one's own convention" and listed `.claude/skills/`, `.agents/skills/` and `.windsurf/skills/` as peer destinations, with "around seventy others".

Running it against a project with Claude Code present shows a different shape. The installer creates **one directory per skill** under `.agents/skills/` — 23 of them, `melonjs`, `melonjs-physics`, `melonjs-tilemaps` and so on — and each detected assistant's directory gets a symlink back to that copy. `.claude/skills/melonjs` is a symlink to `../../.agents/skills/melonjs`, not a second copy. The tool also prints its own coverage figure, "77 agents", so the passage uses that rather than "around seventy".

`DOC_README.md` carried the same passage, so it is corrected in step (raised in review) and the two files no longer contradict each other.

Documentation only, no code touched.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the existing code style (`pnpm lint` passes) — the pre-commit hook globs `*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}`, so Markdown is out of scope
- [x] I have tested my changes locally (`pnpm test` passes) — verified by running the installer twice and inspecting the resulting tree; no tests cover README prose
- [ ] I have added tests that cover my changes (if applicable)
- [x] The build succeeds (`pnpm build`) — unaffected, Markdown only

## Related issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8aCt5SwH5D5Bi7qKXi2X8