### PR TITLE
Examples: the 3D examples await their level load

### DIFF
--- a/packages/examples/src/examples/forest/ExampleForest.tsx
+++ b/packages/examples/src/examples/forest/ExampleForest.tsx
@@ -234,7 +234,7 @@ const createGame = async () => {
 
 	loader.preload(
 		[{ name: "forest", type: "glb", src: `${base}forest.glb` }],
-		() => {
+		async () => {
 			state.change(state.DEFAULT, true);
 			// one call — the instanced node becomes an InstancedMesh, the
 			// ground stays an ordinary Mesh, and the authored sun lights both
@@ -243,12 +243,16 @@ const createGame = async () => {
 			// read from the same instance buffer the trees draw from. The
 			// scene's ground plane is skipped automatically — it has no height
 			// to cast, and shadowing it with itself would smear the floor.
-			level.load("forest", {
+			// `async: true` hands back a promise that settles once the scene is
+			// actually in the world, so the setup below reads as ordinary
+			// sequential code rather than a callback
+			await level.load("forest", {
 				scale: SCALE,
 				castGroundShadow: true,
 				shadowGroundY: GROUND_Y,
-				onLoaded: setupScene,
+				async: true,
 			});
+			setupScene();
 		},
 	);
 

--- a/packages/examples/src/examples/gltf/ExampleGltf.tsx
+++ b/packages/examples/src/examples/gltf/ExampleGltf.tsx
@@ -318,7 +318,7 @@ const createGame = async () => {
 
 	loader.preload(
 		[{ name: "diorama", type: "glb", src: `${base}platformer-diorama.glb` }],
-		() => {
+		async () => {
 			state.change(state.DEFAULT, true);
 			// load the whole glTF scene into the world in one call — the glb
 			// auto-registered with the level director on preload, exactly like
@@ -329,11 +329,15 @@ const createGame = async () => {
 			// heights rather than on one floor. The scene's ground/platform
 			// meshes are skipped automatically: they have no height to cast
 			// from, and shadowing them with themselves would smear the terrain.
-			level.load("diorama", {
+			// `async: true` hands back a promise that settles once the scene is
+			// actually in the world, so the setup below reads as ordinary
+			// sequential code rather than a callback
+			await level.load("diorama", {
 				scale: SCALE,
 				castGroundShadow: true,
-				onLoaded: setupScene,
+				async: true,
 			});
+			setupScene();
 		},
 	);
 

--- a/packages/examples/src/examples/gltf/ExampleGltfCharacter.tsx
+++ b/packages/examples/src/examples/gltf/ExampleGltfCharacter.tsx
@@ -265,9 +265,13 @@ const createGame = async () => {
 		// the GLB references an external texture (Textures/texture-a.png),
 		// resolved relative to the asset URL by the loader — no repackaging.
 		[{ name: "character", type: "glb", src: `${base}character.glb` }],
-		() => {
+		async () => {
 			state.change(state.DEFAULT, true);
-			level.load("character", { scale: SCALE, onLoaded: setupScene });
+			// `async: true` hands back a promise that settles once the scene is
+			// actually in the world, so the setup below reads as ordinary
+			// sequential code rather than a callback
+			await level.load("character", { scale: SCALE, async: true });
+			setupScene();
 		},
 	);
 

--- a/packages/melonjs/src/level/level.js
+++ b/packages/melonjs/src/level/level.js
@@ -122,7 +122,7 @@ function levelIdAt(offset) {
  * @property {boolean} [rightHanded=true] - (glTF/GLB only) convert the right-handed (Y-up) source to the engine's Y-down via a rotation rather than a mirror
  * @property {boolean} [lights=true] - (glTF/GLB only) add the scene's authored `KHR_lights_punctual` lights (plus a soft ambient fill) as {@link Light3d} world children
  * @property {number} [lightIntensityScale] - (glTF/GLB only) multiply each light's authored physical intensity by this factor instead of normalizing it to 1
- * @property {boolean} [castGroundShadow=false] - (glTF/GLB only) give every mesh in the scene a ground shadow
+ * @property {boolean} [castGroundShadow] - (glTF/GLB only) give every mesh in the scene a ground shadow; omit to inherit the application's `castGroundShadow` setting (on by default)
  * @property {number} [shadowGroundY] - (glTF/GLB only) world Y the ground shadows land on
  */
 


### PR DESCRIPTION
The three 3D examples that go through the level director — **forest**, **glTF scene** and **glTF character** — now use the `async` option from #1647 instead of the `onLoaded` callback, so the setup that follows the load reads as ordinary sequential code:

```js
await level.load("character", { scale: SCALE, async: true });
setupScene();
```

The other `Camera3d` examples (`afterBurner`, `billboard`, `camera3d`, `materialTextures`, `nightcity`) build their scenes in code and never call `level.load`, so there was nothing to convert. The remaining non-async call sites are all 2D and were left alone.

`loader.preload` deliberately keeps its callback form. Awaiting it would delay returning the teardown function, and the forest example needs that cleanup to exist while its 3 MB glb is still loading.

### Also: a JSDoc default that shipped in the published types

`LevelLoadOptions.castGroundShadow` was documented as defaulting to `false`, but the option is tri-state — omitting it means "inherit the application setting", which is `true` in `defaultApplicationSettings`. The three sibling declarations (`Mesh`, `GLTFScene`, `GLTFModel`) already said "omit to inherit"; this was the odd one out.

The emitted type is unchanged (`castGroundShadow?: boolean` either way) — only the prose was wrong, in the direction that makes someone set the flag to `true` believing it is off.

### Verification

- `tsc` on the examples package: exit 0
- eslint 0 errors, biome clean
- full engine suite: 276 files, 6733 passed, exit 0
- all three examples rendered in a real browser with zero console errors, and screenshots compared against the pre-change build: forest and glTF scene byte-identical (182100 B, 91528 B), the character differing by 316 B — the animation at a slightly different frame

No CHANGELOG entry: examples do not go in the engine changelog, and the JSDoc correction is below the bar for something a reader would act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Aa37KGXZcnVrbn1yG4j1N