### PR TITLE
Release 20.4.0

### DIFF
--- a/packages/melonjs/CHANGELOG.md
+++ b/packages/melonjs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [20.4.0] (melonJS 2) - _unreleased_
+## [20.4.0] (melonJS 2) - _2026-09-09_
 
 ### Added
 - `level.load()`, `reload()`, `next()` and `previous()` take an `async` option: set it and the call hands back a promise that settles once the level is actually in the world, instead of the boolean it has always returned. `options.onLoaded` still fires either way, so the two forms mix freely, and omitting the flag changes nothing — the existing signatures are preserved as TypeScript overloads, so `const ok: boolean = level.load("map1")` still compiles. Running out of levels still reports `false` rather than rejecting, and an unknown level id throws synchronously in both forms: that is a typo, not a load failure, and it should not need `await` to surface ([#1646](https://github.com/melonjs/melonJS/issues/1646))


### PR DESCRIPTION
Stamps the release date on the changelog. `packages/melonjs/package.json` is already at `20.4.0`, so this is the only change the release itself needs.

## What 20.4.0 contains

**Added** — an `async` option on `level.load()` / `reload()` / `next()` / `previous()` (#1646); soft transparency for the 3D tier (#1516); distance fog (#1622) with height falloff (#1633); per-vertex mesh colours (#1624); generated normals for `lit` meshes built without them; the API reference's own visual identity plus a Copy-page control.

**Performance** — the light block's `getUniformBlockIndex` memoized per program on WebGL (about 50% less engine CPU per frame), and the 1×1 filler texture no longer re-created every frame on WebGPU (about 17%).

**Fixed** — 14 entries, including specular highlights under a scaled ancestor (#1636), specular and alpha-map cutouts on whichever tier drew second, ground shadows lost to a batcher switch, `floating` children ordered by screen position, alpha-cutout meshes vanishing when faded, `alpha = 0` painting opaque black, `Color.toUint32()` returning negative values, four ways a preloaded sound could hang the loading screen, and engine internals leaking into the published types and reference (#1637).

## Verification

Full `pnpm dist` — clean, lint (**0 errors**, 174 pre-existing warnings), **276 test files / 6742 passing / 9 skipped**, build, types, and docs: `check-doc-readme` passed, typedoc reported **0 errors**, and `llms.txt` regenerated across 445 pages.

## After merge

1. tag `20.4.0` (no `v` prefix) and push it
2. dispatch `publish.yml` with `package=melonjs` — `pnpm publish-melonjs` (tag push alone does not trigger it)

`scripts/release.ts` creates the GitHub release and titles it `v20.4.0` itself. Docs redeploy from the push to master via `docs.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Aa37KGXZcnVrbn1yG4j1N